### PR TITLE
Fix for Issue 187: Stop screwing up classpath via ASM inclusion

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -164,7 +164,9 @@ the common tasks and can be called on to run the main aspects of all the sub-scr
 	<target name="dist" description="Builds THE lombok.jar file which contains everything." depends="version, compile">
 		<mkdir dir="dist" />
 		<copy file="doc/changelog.markdown" tofile="build/changelog.txt" />
-		<jar destfile="dist/lombok-${lombok.version}.jar">
+		<taskdef name="jarjar" classname="com.tonicsystems.jarjar.JarJarTask" classpath="lib/build/jarjar.jar"/>
+		<jarjar destfile="dist/lombok-${lombok.version}.jar">
+			<rule pattern="org.objectweb.asm.**" result="lombokinternal.org.objectweb.asm.@1" />
 			<fileset dir="build/lombok">
 				<exclude name="com/sun/**"/>
 			</fileset>
@@ -177,7 +179,7 @@ the common tasks and can be called on to run the main aspects of all the sub-scr
 				<attribute name="Main-Class" value="lombok.core.Main" />
 				<attribute name="Lombok-Version" value="${lombok.version}" />
 			</manifest>
-		</jar>
+		</jarjar>
 		<copy file="dist/lombok-${lombok.version}.jar" tofile="dist/lombok.jar" />
 		<property name="lombok.dist.built" value="true" />
 	</target>

--- a/buildScripts/ivy-repo/tonicsystems.com-jarjar-1.1.xml
+++ b/buildScripts/ivy-repo/tonicsystems.com-jarjar-1.1.xml
@@ -1,0 +1,12 @@
+<ivy-module version="2.0">
+	<info organisation="tonicsystems.com" module="jarjar" revision="1.1" publication="20110421200000">
+		<license name="Apache License v2.0" url="http://www.apache.org/licenses/LICENSE-2.0" />
+		<description homepage="http://code.google.com/p/jarjar/" />
+	</info>
+	<configurations>
+		<conf name="build" />
+	</configurations>
+	<publications>
+    <artifact conf="build" url="http://jarjar.googlecode.com/files/jarjar-1.1.jar" />
+	</publications>
+</ivy-module>

--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -24,6 +24,7 @@
 		<dependency org="projectlombok.org" name="jsch-ant-fixed" rev="0.1.42" conf="build" />
 		<dependency org="projectlombok.org" name="markdownj" rev="1.02b4" conf="build" />
 		<dependency org="de.java2html" name="java2html" rev="5.0" conf="build->default" />
+		<dependency org="tonicsystems.com" name="jarjar" rev="1.1" conf="build" />
 		
 		<dependency org="projectlombok.org" name="javac" rev="1.6.0.18" conf="build->runtime; contrib->sources" />
 		<dependency org="org.eclipse.custom" name="ecj" rev="3.6.0" conf="build->default; contrib->sources" />


### PR DESCRIPTION
Uses jarjar to rename ASM without any Java source code changes in Lombok. 

I don't have any large Lombok-enabled projects that I could use for testing, but at least in simple test projects everything works fine after this change.
