### PR TITLE
Proposed fix for issue 90

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -106,12 +106,17 @@ public class EclipsePatcher extends Agent {
 				.callToWrap(new Hook("org.eclipse.jdt.internal.core.util.CodeSnippetParsingUtil", "parseCompilationUnit", "org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration", "char[]", "java.util.Map", "boolean"))
 				.symbol("lombok.disable")
 				.build());
-	
-		sm.addScript(ScriptBuilder.setSymbolDuringMethodCall()
-				.target(new MethodTarget("org.eclipse.jdt.internal.corext.fix.CleanUpPostSaveListener", "createAst"))
-				.callToWrap(new Hook("org.eclipse.jdt.core.dom.ASTParser", "createAST", "org.eclipse.jdt.core.dom.ASTNode", "org.eclipse.core.runtime.IProgressMonitor"))
-				.symbol("lombok.disable")
-				.build());
+		
+		sm.addScript(ScriptBuilder.exitEarly()
+			.target(new MethodTarget("org.eclipse.jdt.internal.corext.fix.ControlStatementsFix$ControlStatementFinder", "visit", "boolean", "org.eclipse.jdt.core.dom.DoStatement"))
+			.target(new MethodTarget("org.eclipse.jdt.internal.corext.fix.ControlStatementsFix$ControlStatementFinder", "visit", "boolean", "org.eclipse.jdt.core.dom.EnhancedForStatement"))
+			.target(new MethodTarget("org.eclipse.jdt.internal.corext.fix.ControlStatementsFix$ControlStatementFinder", "visit", "boolean", "org.eclipse.jdt.core.dom.ForStatement"))
+			.target(new MethodTarget("org.eclipse.jdt.internal.corext.fix.ControlStatementsFix$ControlStatementFinder", "visit", "boolean", "org.eclipse.jdt.core.dom.IfStatement"))
+			.target(new MethodTarget("org.eclipse.jdt.internal.corext.fix.ControlStatementsFix$ControlStatementFinder", "visit", "boolean", "org.eclipse.jdt.core.dom.WhileStatement"))
+			.decisionMethod(new Hook("lombok.eclipse.agent.PatchFixes", "isGenerated", "boolean", "org.eclipse.jdt.core.dom.Statement"))
+			.request(StackRequest.PARAM1)
+			.valueMethod(new Hook("lombok.eclipse.agent.PatchFixes", "isGenerated", "boolean", "org.eclipse.jdt.core.dom.Statement"))
+			.build());
 	}
 	
 

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchFixes.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchFixes.java
@@ -41,6 +41,16 @@ import org.eclipse.jdt.internal.compiler.ast.Annotation;
 import org.eclipse.jdt.internal.core.dom.rewrite.TokenScanner;
 
 public class PatchFixes {
+	public static boolean isGenerated(org.eclipse.jdt.core.dom.Statement statement) {
+		boolean result = false;
+		try {
+			result =  ((Boolean)statement.getClass().getField("$isGenerated").get(statement)).booleanValue();
+		} catch (Exception e) {
+			// better to assume it isn't generated
+		}
+		return result;
+	}
+
 	public static int fixRetrieveStartingCatchPosition(int original, int start) {
 		return original == -1 ? start : original;
 	}


### PR DESCRIPTION
Lombok disabled during ast creation in DefaultCodeFormatter & CleanUpPostSaveListener

Tested using @Getter(lazy=true) @Setter(AccesLevel.Private) and @Cleanup and the save actions described in issue 90 active
