### PR TITLE
Proposed fix for Issue 138

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -89,6 +89,7 @@ public class EclipsePatcher extends Agent {
 			patchHideGeneratedNodes(sm);
 			patchPostCompileHookEclipse(sm);
 			patchFixSourceTypeConverter(sm);
+			patchListRewriteHandleGeneratedMethods(sm);
 		} else {
 			patchPostCompileHookEcj(sm);
 		}
@@ -99,6 +100,14 @@ public class EclipsePatcher extends Agent {
 		if (reloadExistingClasses) sm.reloadClasses(instrumentation);
 	}
 	
+	private static void patchListRewriteHandleGeneratedMethods(ScriptManager sm) {
+		sm.addScript(ScriptBuilder.replaceMethodCall()
+				.target(new MethodTarget("org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer$ListRewriter", "rewriteList"))
+				.methodToReplace(new Hook("org.eclipse.jdt.internal.core.dom.rewrite.RewriteEvent", "getChildren", "org.eclipse.jdt.internal.core.dom.rewrite.RewriteEvent[]"))
+				.replacementMethod(new Hook("lombok.eclipse.agent.PatchFixes", "listRewriteHandleGeneratedMethods", "org.eclipse.jdt.internal.core.dom.rewrite.RewriteEvent[]", "org.eclipse.jdt.internal.core.dom.rewrite.RewriteEvent"))
+				.build());
+	}
+
 	private static void patchDomAstReparseIssues(ScriptManager sm) {
 		sm.addScript(ScriptBuilder.replaceMethodCall()
 				.target(new MethodTarget("org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer", "visit"))


### PR DESCRIPTION
(and other "generate method"-refactorings that collide with lombok)

First commit is a necessary fix so MethodDeclaration and their SimpleName(s) get marked as generated (eclipse 3.7 M5 and higher)

Second commit is the actual fix.

The unit tests won't run in on my computer, so wasn't able to check for side effects that way

(closed former pull request, fixed SimpleNames of MethodDeclaration as well)
