### PR TITLE
Proposed fix for issue 263

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleConstructor.java
+++ b/src/core/lombok/eclipse/handlers/HandleConstructor.java
@@ -249,6 +249,7 @@ public class HandleConstructor {
 			SingleNameReference assignmentNameRef = new SingleNameReference(field.name, p);
 			setGeneratedBy(assignmentNameRef, source);
 			Assignment assignment = new Assignment(thisX, assignmentNameRef, (int)p);
+			assignment.sourceStart = (int)(p >> 32); assignment.sourceEnd = assignment.statementEnd = (int)(p >> 32);
 			setGeneratedBy(assignment, source);
 			assigns.add(assignment);
 			long fieldPos = (((long)field.sourceStart) << 32) | field.sourceEnd;

--- a/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
@@ -391,7 +391,7 @@ public class HandleEqualsAndHashCode extends EclipseAnnotationHandler<EqualsAndH
 				resultRef = new SingleNameReference(RESULT, p);
 				setGeneratedBy(resultRef, source);
 				Assignment assignment = new Assignment(resultRef, addItem, pE);
-				assignment.sourceStart = pS; assignment.sourceEnd = pE;
+				assignment.sourceStart = pS; assignment.sourceEnd = assignment.statementEnd = pE;
 				setGeneratedBy(assignment, source);
 				statements.add(assignment);
 			}

--- a/src/core/lombok/eclipse/handlers/HandleSetter.java
+++ b/src/core/lombok/eclipse/handlers/HandleSetter.java
@@ -198,7 +198,7 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 		NameReference fieldNameRef = new SingleNameReference(field.name, p);
 		setGeneratedBy(fieldNameRef, source);
 		Assignment assignment = new Assignment(fieldRef, fieldNameRef, (int)p);
-		assignment.sourceStart = pS; assignment.sourceEnd = pE;
+		assignment.sourceStart = pS; assignment.sourceEnd = assignment.statementEnd = pE;
 		setGeneratedBy(assignment, source);
 		method.bodyStart = method.declarationSourceStart = method.sourceStart = source.sourceStart;
 		method.bodyEnd = method.declarationSourceEnd = method.sourceEnd = source.sourceEnd;

--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -84,6 +84,7 @@ public class EclipsePatcher extends Agent {
 			patchCatchReparse(sm);
 			patchIdentifierEndReparse(sm);
 			patchRetrieveEllipsisStartPosition(sm);
+			patchRetrieveRightBraceOrSemiColonPosition(sm);
 			patchSetGeneratedFlag(sm);
 			patchDomAstReparseIssues(sm);
 			patchHideGeneratedNodes(sm);
@@ -98,7 +99,7 @@ public class EclipsePatcher extends Agent {
 		
 		if (reloadExistingClasses) sm.reloadClasses(instrumentation);
 	}
-	
+
 	private static void patchDomAstReparseIssues(ScriptManager sm) {
 		sm.addScript(ScriptBuilder.replaceMethodCall()
 				.target(new MethodTarget("org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer", "visit"))
@@ -193,6 +194,14 @@ public class EclipsePatcher extends Agent {
 				.transplant().request(StackRequest.RETURN_VALUE, StackRequest.PARAM2).build());
 	}
 	
+	private static void patchRetrieveRightBraceOrSemiColonPosition(ScriptManager sm) {
+		sm.addScript(ScriptBuilder.wrapReturnValue()
+				.target(new MethodTarget("org.eclipse.jdt.core.dom.ASTConverter", "retrieveRightBraceOrSemiColonPosition"))
+				.target(new MethodTarget("org.eclipse.jdt.core.dom.ASTConverter", "retrieveRightBrace"))
+				.wrapMethod(new Hook("lombok.eclipse.agent.PatchFixes", "fixRetrieveRightBraceOrSemiColonPosition", "int", "int", "int"))
+				.transplant().request(StackRequest.RETURN_VALUE, StackRequest.PARAM2).build());
+	}
+
 	private static void patchSetGeneratedFlag(ScriptManager sm) {
 		sm.addScript(ScriptBuilder.addField()
 				.targetClass("org.eclipse.jdt.internal.compiler.ast.ASTNode")

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchFixes.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchFixes.java
@@ -52,6 +52,10 @@ public class PatchFixes {
 	public static int fixRetrieveEllipsisStartPosition(int original, int end) {
 		return original == -1 ? end : original;
 	}
+
+	public static int fixRetrieveRightBraceOrSemiColonPosition(int original, int end) {
+		return original == -1 ? end : original;
+	}
 	
 	public static final int ALREADY_PROCESSED_FLAG = 0x800000;	//Bit 24
 	


### PR DESCRIPTION
patched retrieveRightBraceOrSemiColonPosition && retrieveRightBrace so method bodies are converted instead of skipped

Set Assignment.statementEnd to prevent invalid sourceRange in Statement convert
