### PR TITLE
Fix for renaming class using Alt+Shift+R (Issue 286 variant)

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
@@ -478,7 +478,8 @@ public class HandleEqualsAndHashCode extends EclipseAnnotationHandler<EqualsAndH
 			setGeneratedBy(oRef, source);
 			
 			TypeReference typeReference = createTypeReference(type, p);
-			
+			setGeneratedBy(typeReference, source);
+
 			InstanceOfExpression instanceOf = new InstanceOfExpression(oRef, typeReference);
 			instanceOf.sourceStart = pS; instanceOf.sourceEnd = pE;
 			setGeneratedBy(instanceOf, source);
@@ -705,7 +706,6 @@ public class HandleEqualsAndHashCode extends EclipseAnnotationHandler<EqualsAndH
 		setGeneratedBy(otherRef, source);
 		
 		TypeReference typeReference = createTypeReference(type, p);
-		
 		setGeneratedBy(typeReference, source);
 		
 		InstanceOfExpression instanceOf = new InstanceOfExpression(otherRef, typeReference);


### PR DESCRIPTION
Added missing setGeneratedBy on TypeReference (prevented a rename of class with @Data/@EqualsAndHashCode on it using Alt+Shift+R)
