### PR TITLE
Use newSourceEnd for sourceEnd calculation

### DIFF
--- a/src/core/lombok/eclipse/handlers/SetGeneratedByVisitor.java
+++ b/src/core/lombok/eclipse/handlers/SetGeneratedByVisitor.java
@@ -261,7 +261,7 @@ public final class SetGeneratedByVisitor extends ASTVisitor {
 //		start = newSourceStart;
 //		end = newSourceStart;
 //		return ((start<<32)+end); 
-		return ((long)newSourceStart << 32) | (newSourceStart & INT_TO_LONG_MASK);
+		return ((long)newSourceStart << 32) | (newSourceEnd & INT_TO_LONG_MASK);
 	}
 	
 	@Override public boolean visit(AllocationExpression node, BlockScope scope) {


### PR DESCRIPTION
made a copypaste mistake in SetGeneratedByVisitor.calculateSourcePosition(), which rspilker detected, but thought it might be by design... It wasn't ;)
