### PR TITLE
Fix for Issue 325

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/eclipse/handlers/HandleEqualsAndHashCode.java
@@ -222,14 +222,17 @@ public class HandleEqualsAndHashCode extends EclipseAnnotationHandler<EqualsAndH
 		}
 		
 		MethodDeclaration equalsMethod = createEquals(typeNode, nodesForEquality, callSuper, errorNode.get(), fieldAccess, needsCanEqual);
+		equalsMethod.traverse(new SetGeneratedByVisitor(errorNode.get()), ((TypeDeclaration)typeNode.get()).scope);
 		injectMethod(typeNode, equalsMethod);
 		
 		if (needsCanEqual) {
 			MethodDeclaration canEqualMethod = createCanEqual(typeNode, errorNode.get());
+			canEqualMethod.traverse(new SetGeneratedByVisitor(errorNode.get()), ((TypeDeclaration)typeNode.get()).scope);
 			injectMethod(typeNode, canEqualMethod);
 		}
 		
 		MethodDeclaration hashCodeMethod = createHashCode(typeNode, nodesForEquality, callSuper, errorNode.get(), fieldAccess);
+		hashCodeMethod.traverse(new SetGeneratedByVisitor(errorNode.get()), ((TypeDeclaration)typeNode.get()).scope);
 		injectMethod(typeNode, hashCodeMethod);
 	}
 	

--- a/src/core/lombok/eclipse/handlers/SetGeneratedByVisitor.java
+++ b/src/core/lombok/eclipse/handlers/SetGeneratedByVisitor.java
@@ -247,6 +247,13 @@ public final class SetGeneratedByVisitor extends ASTVisitor {
 		node.nameSourcePosition = recalcSourcePosition(node.nameSourcePosition);
 	}
 	
+	private void applyOffsetQualifiedNameReference(QualifiedNameReference node) {
+		applyOffsetExpression(node);
+		for (int i = 0; i < node.sourcePositions.length; i++) {
+			node.sourcePositions[i] = recalcSourcePosition(node.sourcePositions[i]);
+		}
+	}
+	
 	private void applyOffsetQualifiedTypeReference(QualifiedTypeReference node) {
 		applyOffsetExpression(node);
 		for (int i = 0; i < node.sourcePositions.length; i++) {
@@ -787,8 +794,8 @@ public final class SetGeneratedByVisitor extends ASTVisitor {
 	}
 	
 	@Override public boolean visit(QualifiedNameReference node, BlockScope scope) {
-		setGeneratedBy(node, source);
-		applyOffsetExpression(node);
+		setGeneratedBy(node, source);	
+		applyOffsetQualifiedNameReference(node);
 		return super.visit(node, scope);
 	}
 	

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchFixes.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchFixes.java
@@ -237,8 +237,8 @@ public class PatchFixes {
 	}
 	
 	public static int fixRetrieveRightBraceOrSemiColonPosition(int original, int end) {
-		return original;
-		// return original == -1 ? end : original;  // Need to fix: see issue 325.
+//		return original;
+		 return original == -1 ? end : original;  // Need to fix: see issue 325.
 	}
 	
 	public static final int ALREADY_PROCESSED_FLAG = 0x800000;  //Bit 24


### PR DESCRIPTION
1) Rollback of rollback fixRetrieveRightBraceOrSemiColonPosition
2) HandleEqualsAndHashCode now use SetGeneratedByVisitor to ensure "correct" sourcepositions
3) SetGeneratedByVisitor now sets QualifiedNameReference.sourcePositions

The problem in the example was located in EqualsAndHashCode when using a double field, since this results in the use of a QualifiedName in the generated Equals method. (java.lang.Double)

I tried several other usecases, but all seems to work on my system now.
