### PR TITLE
[Issue 349] Test failed on some locale environment

### DIFF
--- a/test/core/src/lombok/RunTestsViaDelombok.java
+++ b/test/core/src/lombok/RunTestsViaDelombok.java
@@ -56,6 +56,12 @@ public class RunTestsViaDelombok extends AbstractRunTests {
 		delombok.addFile(file.getAbsoluteFile().getParentFile(), file.getName());
 		delombok.setSourcepath(file.getAbsoluteFile().getParent());
 		delombok.setWriter(result);
-		delombok.delombok();
+		Locale originalLocale = Locale.getDefault();
+		Locale.setDefault(Locale.ENGLISH);
+		try {
+			delombok.delombok();
+		} finally {
+			Locale.setDefault(originalLocale);
+		}
 	}
 }


### PR DESCRIPTION
This patch makes test to work on some locale environment (e.g. Japanese)
