### PR TITLE
The installer creates proper "full paths" on Windows

### DIFF
--- a/src/installer/lombok/installer/IdeLocation.java
+++ b/src/installer/lombok/installer/IdeLocation.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
+import lombok.installer.eclipse.EclipseFinder;
 import lombok.patcher.inject.LiveInjector;
 
 /**
@@ -66,11 +67,12 @@ public abstract class IdeLocation {
 	}
 	
 	private static final String LEGAL_PATH_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_/";
+	private static final String LEGAL_PATH_CHARS_WINDOWS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_/:\\ ";
 	public static String escapePath(String path) {
 		StringBuilder out = new StringBuilder();
-		
+		String legalChars = IdeFinder.getOS() == EclipseFinder.OS.UNIX ? LEGAL_PATH_CHARS : LEGAL_PATH_CHARS_WINDOWS; 
 		for (char c : path.toCharArray()) {
-			if (LEGAL_PATH_CHARS.indexOf(c) == -1) out.append('\\');
+			if (legalChars.indexOf(c) == -1) out.append('\\');
 			out.append(c);
 		}
 		return out.toString();


### PR DESCRIPTION
See discussion on [Stackoverflow](http://stackoverflow.com/questions/3418865/cannot-make-project-lombok-work-on-eclipse-helios).
In short, the installer creates relative paths for lombok.jar in eclipse.ini. This doesn't work if you star eclipse with a different working path than the eclipse installation path. The solution is to start the installer with `-Dlombok.installer.fullpath`. The installer escapes backslash and colon on Windows, thereby creating wrong entries. The patch fixes this. 
