### PR TITLE
Issue 591:	Lombok 1.12.2 has some regressions with NetBeans

### DIFF
--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -142,7 +142,6 @@ public class JavacHandlerUtil {
 			if (source == null) generatedNodes.remove(node);
 			else generatedNodes.put(node, new WeakReference<JCTree>(source));
 		}
-		if (source != null) node.pos = source.pos;
 		return node;
 	}
 	


### PR DESCRIPTION
Found the line who caused the weird behavior on netbeans refactoring. Lombok now works on Netbeans < 7.4, but still throws an AssertionError while refactoring a lombok annotated class. This has to be investigated.

Caused: java.lang.AssertionError
    at com.sun.tools.javac.util.Assert.error(Assert.java:126)
    at com.sun.tools.javac.util.Assert.check(Assert.java:45)
    at com.sun.tools.javac.util.Bits.incl(Bits.java:205)
    at com.sun.tools.javac.comp.Flow$AssignAnalyzer.visitMethodDef(Flow.java:1739)
    at com.sun.tools.javac.tree.JCTree$JCMethodDecl.accept(JCTree.java:778)
    at com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
    at com.sun.tools.javac.comp.Flow$BaseAnalyzer.scan(Flow.java:402)
    at com.sun.tools.javac.comp.Flow$AssignAnalyzer.visitClassDef(Flow.java:1704)
    at com.sun.tools.javac.tree.JCTree$JCClassDecl.accept(JCTree.java:692)
    at com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
    at com.sun.tools.javac.comp.Flow$BaseAnalyzer.scan(Flow.java:402)
    at com.sun.tools.javac.comp.Flow$AssignAnalyzer.analyzeTree(Flow.java:2328)
    at com.sun.tools.javac.comp.Flow$AssignAnalyzer.analyzeTree(Flow.java:2309)
    at com.sun.tools.javac.comp.Flow.analyzeTree(Flow.java:215)
    at com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1362)
    at com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1326)
    at com.sun.tools.javac.api.JavacTaskImpl.analyze(JavacTaskImpl.java:469)
    at com.sun.tools.javac.api.JavacTaskImpl.analyze(JavacTaskImpl.java:448)
    at org.netbeans.modules.java.source.parsing.JavacParser.moveToPhase(JavacParser.java:664)
    at org.netbeans.modules.java.source.parsing.JavacParser.getResult(JavacParser.java:521)
    at org.netbeans.modules.java.source.parsing.JavacParser.getResult(JavacParser.java:174)
    at org.netbeans.modules.parsing.impl.TaskProcessor.callGetResult(TaskProcessor.java:615)
    at org.netbeans.modules.parsing.impl.SourceCache.getResult(SourceCache.java:247)
[catch] at org.netbeans.modules.parsing.impl.TaskProcessor$CompilationJob.run(TaskProcessor.java:727)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334)
    at java.util.concurrent.FutureTask.run(FutureTask.java:166)
    at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1432)
    at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2042)
