### PR TITLE
Lombok issue 591: Lombok 1.12.2 has some regressions with NetBeans

### DIFF
--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -149,7 +149,7 @@ public class JavacHandlerUtil {
 			if (source == null) generatedNodes.remove(node);
 			else generatedNodes.put(node, new WeakReference<JCTree>(source));
 		}
-		if (source != null && !inNetbeansEditor(context)) node.pos = source.pos;
+		if (source != null && (!inNetbeansEditor(context) || (node instanceof JCVariableDecl && (((JCVariableDecl) node).mods.flags & Flags.PARAMETER) != 0))) node.pos = source.pos;
 		return node;
 	}
 	


### PR DESCRIPTION
Currently Lombok won't set positions to (javac) trees while running inside NetBeans editor. In general, this seems reasonable (as the NB editor needs a way to distinguish trees that are actually in the source code from those generated by Lombok, e.g. during refactoring). But for method parameters this does not work, as javac's Flow depends on the positions. This patch sets positions for method parameters, which should allow the Flow to work.

I hope this could keep (NB) refactoring working as long as the newly generated methods don't have a position and Lombok does not add parameters to methods that actually exist in the source code.

I only did some very light testing with @Data - I don't use Lombok, so I don't have a real-world test case to perform.

Bug link:
http://code.google.com/p/projectlombok/issues/detail?id=591
