### PR TITLE
#591, #627: Fix for refactoring when @Getter(lazy=true)

### DIFF
--- a/src/core/lombok/javac/handlers/HandleGetter.java
+++ b/src/core/lombok/javac/handlers/HandleGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2013 The Project Lombok Authors.
+ * Copyright (C) 2009-2014 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -225,7 +225,7 @@ public class HandleGetter extends JavacAnnotationHandler<Getter> {
 		
 		List<JCStatement> statements;
 		JCTree toClearOfMarkers = null;
-		if (lazy) {
+		if (lazy && !inNetbeansEditor(field)) {
 			toClearOfMarkers = fieldNode.init;
 			statements = createLazyGetterBody(treeMaker, field, source);
 		} else {


### PR DESCRIPTION
When if in NB Editor, after validating the field modifiers and required initialization, just make the regular getter available (the lazy stuff will be created when compiling).

The inNetbeansEditor test is made after all the validations are made to the annotated field, and generates a regular getter for validations, Naviagator and autocompletion.
