### PR TITLE
fix copy-and-paste errors in page titles

### DIFF
--- a/website/features/NonNull.html
+++ b/website/features/NonNull.html
@@ -5,7 +5,7 @@
 	<link rel="stylesheet" type="text/css" href="features.css" />
 	<link rel="shortcut icon" href="../favicon.ico" type="image/x-icon" />
 	<meta name="description" content="Spice up your java" />
-	<title>val</title>
+	<title>@NonNull</title>
 </head><body><div id="pepper">
 	<div class="minimumHeight"></div>
 	<div class="meat">

--- a/website/features/Value.html
+++ b/website/features/Value.html
@@ -5,7 +5,7 @@
 	<link rel="stylesheet" type="text/css" href="features.css" />
 	<link rel="shortcut icon" href="../favicon.ico" type="image/x-icon" />
 	<meta name="description" content="Spice up your java" />
-	<title>@ExtensionMethod</title>
+	<title>@Value</title>
 </head><body><div id="pepper">
 	<div class="minimumHeight"></div>
 	<div class="meat">


### PR DESCRIPTION
Fix minor copy-and-paste typos in the `<title/>` elements.
