### PR TITLE
Use simple name constructor in inner classes

### DIFF
--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -921,6 +921,16 @@ public class EclipseHandlerUtil {
 		return result;
 	}
 	
+	public static TypeReference cloneSelfTypeForConstructor(EclipseNode context, ASTNode source) {
+		TypeReference result = cloneSelfType(context, source);
+		if (result instanceof ParameterizedQualifiedTypeReference) {
+			ParameterizedQualifiedTypeReference parameterizedQualifiedTypeReference = (ParameterizedQualifiedTypeReference) result;
+			result = new QualifiedTypeReference(parameterizedQualifiedTypeReference.tokens, parameterizedQualifiedTypeReference.sourcePositions);
+		}
+		if (result != null && source != null) setGeneratedBy(result, source);
+		return result;
+	}
+	
 	public static TypeReference generateParameterizedTypeReference(EclipseNode type, TypeReference[] typeParams, long p) {
 		TypeDeclaration td = (TypeDeclaration) type.get();
 		char[][] tn = getQualifiedInnerName(type.up(), td.name);

--- a/src/core/lombok/eclipse/handlers/HandleWith.java
+++ b/src/core/lombok/eclipse/handlers/HandleWith.java
@@ -268,7 +268,7 @@ public class HandleWith extends EclipseAnnotationHandler<With> {
 			
 			AllocationExpression constructorCall = new AllocationExpression();
 			constructorCall.arguments = args.toArray(new Expression[0]);
-			constructorCall.type = cloneSelfType(fieldNode, source);
+			constructorCall.type = cloneSelfTypeForConstructor(fieldNode, source);
 			
 			Expression identityCheck = new EqualExpression(
 					createFieldAccessor(fieldNode, FieldAccess.ALWAYS_FIELD, source),

--- a/src/core/lombok/eclipse/handlers/HandleWithBy.java
+++ b/src/core/lombok/eclipse/handlers/HandleWithBy.java
@@ -357,7 +357,7 @@ public class HandleWithBy extends EclipseAnnotationHandler<WithBy> {
 			
 			AllocationExpression constructorCall = new AllocationExpression();
 			constructorCall.arguments = args.toArray(new Expression[0]);
-			constructorCall.type = cloneSelfType(fieldNode, source);
+			constructorCall.type = cloneSelfTypeForConstructor(fieldNode, source);
 			
 			Statement returnStatement = new ReturnStatement(constructorCall, pS, pE);
 			method.bodyStart = method.declarationSourceStart = method.sourceStart = source.sourceStart;

--- a/test/transform/resource/after-delombok/WithInnerClass.java
+++ b/test/transform/resource/after-delombok/WithInnerClass.java
@@ -4,11 +4,16 @@ public class WithInnerClass<Z> {
 		final String x;
 
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public Inner(final String x) {
 			this.x = x;
 		}
 
+		/**
+		 * @return a clone of this object, except with this updated property (returns {@code this} if an identical value is passed).
+		 */
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public WithInnerClass<Z>.Inner<Y> withX(final String x) {
 			return this.x == x ? this : new WithInnerClass<Z>.Inner<Y>(x);
 		}

--- a/test/transform/resource/after-delombok/WithInnerClass.java
+++ b/test/transform/resource/after-delombok/WithInnerClass.java
@@ -1,0 +1,16 @@
+public class WithInnerClass<Z> {
+
+	class Inner<Y> {
+		final String x;
+
+		@java.lang.SuppressWarnings("all")
+		public Inner(final String x) {
+			this.x = x;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public WithInnerClass<Z>.Inner<Y> withX(final String x) {
+			return this.x == x ? this : new WithInnerClass<Z>.Inner<Y>(x);
+		}
+	}
+}

--- a/test/transform/resource/after-delombok/WithInnerClassSameName.java
+++ b/test/transform/resource/after-delombok/WithInnerClassSameName.java
@@ -10,11 +10,16 @@ class WithInnerClassSameName<Z> {
 		final String x;
 
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public Inner(final String x) {
 			this.x = x;
 		}
 
+		/**
+		 * @return a clone of this object, except with this updated property (returns {@code this} if an identical value is passed).
+		 */
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public WithInnerClassSameName<Z>.Inner<Y> withX(final String x) {
 			return this.x == x ? this : new WithInnerClassSameName<Z>.Inner<Y>(x);
 		}

--- a/test/transform/resource/after-delombok/WithInnerClassSameName.java
+++ b/test/transform/resource/after-delombok/WithInnerClassSameName.java
@@ -1,0 +1,22 @@
+interface A {
+
+	class Inner<X> {
+	}
+}
+
+class WithInnerClassSameName<Z> {
+
+	class Inner<Y> implements A {
+		final String x;
+
+		@java.lang.SuppressWarnings("all")
+		public Inner(final String x) {
+			this.x = x;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public WithInnerClassSameName<Z>.Inner<Y> withX(final String x) {
+			return this.x == x ? this : new WithInnerClassSameName<Z>.Inner<Y>(x);
+		}
+	}
+}

--- a/test/transform/resource/after-delombok/WithNestedClass.java
+++ b/test/transform/resource/after-delombok/WithNestedClass.java
@@ -1,0 +1,16 @@
+public class WithNestedClass<Z> {
+
+	static class Inner<Z> {
+		final String x;
+
+		@java.lang.SuppressWarnings("all")
+		public Inner(final String x) {
+			this.x = x;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public WithNestedClass.Inner<Z> withX(final String x) {
+			return this.x == x ? this : new WithNestedClass.Inner<Z>(x);
+		}
+	}
+}

--- a/test/transform/resource/after-delombok/WithNestedClass.java
+++ b/test/transform/resource/after-delombok/WithNestedClass.java
@@ -4,11 +4,16 @@ public class WithNestedClass<Z> {
 		final String x;
 
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public Inner(final String x) {
 			this.x = x;
 		}
 
+		/**
+		 * @return a clone of this object, except with this updated property (returns {@code this} if an identical value is passed).
+		 */
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public WithNestedClass.Inner<Z> withX(final String x) {
 			return this.x == x ? this : new WithNestedClass.Inner<Z>(x);
 		}

--- a/test/transform/resource/after-ecj/WithInnerClass.java
+++ b/test/transform/resource/after-ecj/WithInnerClass.java
@@ -1,10 +1,13 @@
 public class WithInnerClass<Z> {
   @lombok.RequiredArgsConstructor class Inner<Y> {
     final @lombok.With String x;
-    public @java.lang.SuppressWarnings("all") WithInnerClass<Z>.Inner<Y> withX(final String x) {
+    /**
+     * @return a clone of this object, except with this updated property (returns {@code this} if an identical value is passed).
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated WithInnerClass<Z>.Inner<Y> withX(final String x) {
       return ((this.x == x) ? this : new WithInnerClass.Inner(x));
     }
-    public @java.lang.SuppressWarnings("all") Inner(final String x) {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated Inner(final String x) {
       super();
       this.x = x;
     }

--- a/test/transform/resource/after-ecj/WithInnerClass.java
+++ b/test/transform/resource/after-ecj/WithInnerClass.java
@@ -1,0 +1,15 @@
+public class WithInnerClass<Z> {
+  @lombok.RequiredArgsConstructor class Inner<Y> {
+    final @lombok.With String x;
+    public @java.lang.SuppressWarnings("all") WithInnerClass<Z>.Inner<Y> withX(final String x) {
+      return ((this.x == x) ? this : new WithInnerClass.Inner(x));
+    }
+    public @java.lang.SuppressWarnings("all") Inner(final String x) {
+      super();
+      this.x = x;
+    }
+  }
+  public WithInnerClass() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/WithInnerClassSameName.java
+++ b/test/transform/resource/after-ecj/WithInnerClassSameName.java
@@ -9,10 +9,13 @@ interface A {
 class WithInnerClassSameName<Z> {
   @lombok.RequiredArgsConstructor class Inner<Y> implements A {
     final @lombok.With String x;
-    public @java.lang.SuppressWarnings("all") WithInnerClassSameName<Z>.Inner<Y> withX(final String x) {
+    /**
+     * @return a clone of this object, except with this updated property (returns {@code this} if an identical value is passed).
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated WithInnerClassSameName<Z>.Inner<Y> withX(final String x) {
       return ((this.x == x) ? this : new WithInnerClassSameName.Inner(x));
     }
-    public @java.lang.SuppressWarnings("all") Inner(final String x) {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated Inner(final String x) {
       super();
       this.x = x;
     }

--- a/test/transform/resource/after-ecj/WithInnerClassSameName.java
+++ b/test/transform/resource/after-ecj/WithInnerClassSameName.java
@@ -1,0 +1,23 @@
+
+interface A {
+  class Inner<X> {
+    Inner() {
+      super();
+    }
+  }
+}
+class WithInnerClassSameName<Z> {
+  @lombok.RequiredArgsConstructor class Inner<Y> implements A {
+    final @lombok.With String x;
+    public @java.lang.SuppressWarnings("all") WithInnerClassSameName<Z>.Inner<Y> withX(final String x) {
+      return ((this.x == x) ? this : new WithInnerClassSameName.Inner(x));
+    }
+    public @java.lang.SuppressWarnings("all") Inner(final String x) {
+      super();
+      this.x = x;
+    }
+  }
+  WithInnerClassSameName() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/WithNestedClass.java
+++ b/test/transform/resource/after-ecj/WithNestedClass.java
@@ -1,10 +1,13 @@
 public class WithNestedClass<Z> {
   static @lombok.RequiredArgsConstructor class Inner<Z> {
     final @lombok.With String x;
-    public @java.lang.SuppressWarnings("all") WithNestedClass.Inner<Z> withX(final String x) {
+    /**
+     * @return a clone of this object, except with this updated property (returns {@code this} if an identical value is passed).
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated WithNestedClass.Inner<Z> withX(final String x) {
       return ((this.x == x) ? this : new WithNestedClass.Inner(x));
     }
-    public @java.lang.SuppressWarnings("all") Inner(final String x) {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated Inner(final String x) {
       super();
       this.x = x;
     }

--- a/test/transform/resource/after-ecj/WithNestedClass.java
+++ b/test/transform/resource/after-ecj/WithNestedClass.java
@@ -1,0 +1,15 @@
+public class WithNestedClass<Z> {
+  static @lombok.RequiredArgsConstructor class Inner<Z> {
+    final @lombok.With String x;
+    public @java.lang.SuppressWarnings("all") WithNestedClass.Inner<Z> withX(final String x) {
+      return ((this.x == x) ? this : new WithNestedClass.Inner(x));
+    }
+    public @java.lang.SuppressWarnings("all") Inner(final String x) {
+      super();
+      this.x = x;
+    }
+  }
+  public WithNestedClass() {
+    super();
+  }
+}

--- a/test/transform/resource/before/WithInnerClass.java
+++ b/test/transform/resource/before/WithInnerClass.java
@@ -1,0 +1,7 @@
+public class WithInnerClass<Z> {
+	@lombok.RequiredArgsConstructor
+	class Inner<Y> {
+		@lombok.With final String x;
+	}
+}
+

--- a/test/transform/resource/before/WithInnerClassSameName.java
+++ b/test/transform/resource/before/WithInnerClassSameName.java
@@ -1,0 +1,10 @@
+interface A {
+    class Inner<X> {}
+}
+
+class WithInnerClassSameName<Z> {
+	@lombok.RequiredArgsConstructor
+	class Inner<Y> implements A {
+		@lombok.With final String x;
+	}
+}

--- a/test/transform/resource/before/WithNestedClass.java
+++ b/test/transform/resource/before/WithNestedClass.java
@@ -1,0 +1,7 @@
+public class WithNestedClass<Z> {
+	@lombok.RequiredArgsConstructor
+	static class Inner<Z> {
+		@lombok.With final String x;
+	}
+}
+


### PR DESCRIPTION
This PR fixes #2571.

Using `@With` in inner classes generates a constructor using the name of the outer and the inner class. `ecj` does not like that if there also is a generic. To solve this lombok now generates constructor class using raw types: `new Outer<T>.Inner<U>()` -> `new Outer.Inner()`.