### PR TITLE
@Builder annotation in a class with defined constructor.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@ Adam Juraszek <juriad@gmail.com>
 Aleksandr Zhelezniak <lekan1992@gmail.com>
 Andre Brait <andrebrait@gmail.com>
 Bulgakov Alexander <buls@yandex.ru>
+Caio Cruz <acruz.caio@gmail.com>
 Caleb Brinkman <floralvikings@gmail.com>
 Christian Nüssgens <christian@nuessgens.com>
 Christian Schlichtherle <christian-schlichtherle@users.noreply.github.com>

--- a/src/core/lombok/eclipse/handlers/HandleConstructor.java
+++ b/src/core/lombok/eclipse/handlers/HandleConstructor.java
@@ -251,9 +251,10 @@ public class HandleConstructor {
 		if (skipIfConstructorExists != SkipIfConstructorExists.NO) {
 			for (EclipseNode child : typeNode.down()) {
 				if (child.getKind() == Kind.ANNOTATION) {
-					boolean skipGeneration = (annotationTypeMatches(NoArgsConstructor.class, child) ||
-						annotationTypeMatches(AllArgsConstructor.class, child) ||
-						annotationTypeMatches(RequiredArgsConstructor.class, child));
+					boolean skipGeneration = annotationTypeMatches(AllArgsConstructor.class, child) ||
+						(skipIfConstructorExists != SkipIfConstructorExists.I_AM_BUILDER
+							&& (annotationTypeMatches(RequiredArgsConstructor.class, child)
+								|| annotationTypeMatches(NoArgsConstructor.class, child)));
 					
 					if (!skipGeneration && skipIfConstructorExists == SkipIfConstructorExists.YES) {
 						skipGeneration = annotationTypeMatches(Builder.class, child);
@@ -277,7 +278,7 @@ public class HandleConstructor {
 		
 		if (noArgs && noArgsConstructorExists(typeNode)) return;
 		
-		if (!(skipIfConstructorExists != SkipIfConstructorExists.NO && constructorExists(typeNode) != MemberExistsResult.NOT_EXISTS)) {
+		if (!(skipIfConstructorExists != SkipIfConstructorExists.NO && constructorExists(typeNode, fieldsToParam) != MemberExistsResult.NOT_EXISTS)) {
 			ConstructorDeclaration constr = createConstructor(
 				staticConstrRequired ? AccessLevel.PRIVATE : level, typeNode, fieldsToParam, forceDefaults,
 				sourceNode, onConstructor);

--- a/src/core/lombok/javac/handlers/HandleConstructor.java
+++ b/src/core/lombok/javac/handlers/HandleConstructor.java
@@ -228,9 +228,10 @@ public class HandleConstructor {
 		if (skipIfConstructorExists != SkipIfConstructorExists.NO) {
 			for (JavacNode child : typeNode.down()) {
 				if (child.getKind() == Kind.ANNOTATION) {
-					boolean skipGeneration = annotationTypeMatches(NoArgsConstructor.class, child) ||
-						annotationTypeMatches(AllArgsConstructor.class, child) ||
-						annotationTypeMatches(RequiredArgsConstructor.class, child);
+					boolean skipGeneration = annotationTypeMatches(AllArgsConstructor.class, child) ||
+						(skipIfConstructorExists != SkipIfConstructorExists.I_AM_BUILDER
+							&& (annotationTypeMatches(RequiredArgsConstructor.class, child)
+								|| annotationTypeMatches(NoArgsConstructor.class, child)));
 					
 					if (!skipGeneration && skipIfConstructorExists == SkipIfConstructorExists.YES) {
 						skipGeneration = annotationTypeMatches(Builder.class, child);
@@ -262,7 +263,7 @@ public class HandleConstructor {
 		}
 		List<Type> argTypes_ = argTypes == null ? null : argTypes.toList();
 
-		if (!(skipIfConstructorExists != SkipIfConstructorExists.NO && constructorExists(typeNode) != MemberExistsResult.NOT_EXISTS)) {
+		if (!(skipIfConstructorExists != SkipIfConstructorExists.NO && constructorExists(typeNode, fields) != MemberExistsResult.NOT_EXISTS)) {
 			JCMethodDecl constr = createConstructor(staticConstrRequired ? AccessLevel.PRIVATE : level, onConstructor, typeNode, fields, allToDefault, source);
 			injectMethod(typeNode, constr, argTypes_, Javac.createVoidType(typeNode.getSymbolTable(), CTC_VOID));
 		}

--- a/test/transform/resource/after-delombok/BuilderWithNoArgsConstructor.java
+++ b/test/transform/resource/after-delombok/BuilderWithNoArgsConstructor.java
@@ -28,24 +28,36 @@ class BuilderWithNoArgsConstructor {
 		BuilderWithNoArgsConstructorBuilder() {
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder plower(final int plower) {
 			this.plower = plower;
 			return this;
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder pUpper(final Long pUpper) {
 			this.pUpper = pUpper;
 			return this;
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder _foo(final long _foo) {
 			this._foo = _foo;
 			return this;
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder __bar(final String __bar) {
 			this.__bar = __bar;

--- a/test/transform/resource/after-delombok/BuilderWithNoArgsConstructor.java
+++ b/test/transform/resource/after-delombok/BuilderWithNoArgsConstructor.java
@@ -1,0 +1,75 @@
+class BuilderWithNoArgsConstructor {
+	private int plower;
+	private Long pUpper;
+	private long _foo;
+	private String __bar;
+
+	@java.lang.SuppressWarnings("all")
+	BuilderWithNoArgsConstructor(final int plower, final Long pUpper, final long _foo, final String __bar) {
+		this.plower = plower;
+		this.pUpper = pUpper;
+		this._foo = _foo;
+		this.__bar = __bar;
+	}
+
+
+	@java.lang.SuppressWarnings("all")
+	public static class BuilderWithNoArgsConstructorBuilder {
+		@java.lang.SuppressWarnings("all")
+		private int plower;
+		@java.lang.SuppressWarnings("all")
+		private Long pUpper;
+		@java.lang.SuppressWarnings("all")
+		private long _foo;
+		@java.lang.SuppressWarnings("all")
+		private String __bar;
+
+		@java.lang.SuppressWarnings("all")
+		BuilderWithNoArgsConstructorBuilder() {
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder plower(final int plower) {
+			this.plower = plower;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder pUpper(final Long pUpper) {
+			this.pUpper = pUpper;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder _foo(final long _foo) {
+			this._foo = _foo;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder __bar(final String __bar) {
+			this.__bar = __bar;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithNoArgsConstructor build() {
+			return new BuilderWithNoArgsConstructor(this.plower, this.pUpper, this._foo, this.__bar);
+		}
+
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder(plower=" + this.plower + ", pUpper=" + this.pUpper + ", _foo=" + this._foo + ", __bar=" + this.__bar + ")";
+		}
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public static BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder builder() {
+		return new BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public BuilderWithNoArgsConstructor() {
+	}
+}

--- a/test/transform/resource/after-delombok/BuilderWithRequiredArgsConstructor.java
+++ b/test/transform/resource/after-delombok/BuilderWithRequiredArgsConstructor.java
@@ -1,0 +1,77 @@
+class BuilderWithRequiredArgsConstructor {
+	private int plower;
+	private Long pUpper;
+	private final long _foo;
+	private final String __bar;
+
+	@java.lang.SuppressWarnings("all")
+	BuilderWithRequiredArgsConstructor(final int plower, final Long pUpper, final long _foo, final String __bar) {
+		this.plower = plower;
+		this.pUpper = pUpper;
+		this._foo = _foo;
+		this.__bar = __bar;
+	}
+
+
+	@java.lang.SuppressWarnings("all")
+	public static class BuilderWithRequiredArgsConstructorBuilder {
+		@java.lang.SuppressWarnings("all")
+		private int plower;
+		@java.lang.SuppressWarnings("all")
+		private Long pUpper;
+		@java.lang.SuppressWarnings("all")
+		private long _foo;
+		@java.lang.SuppressWarnings("all")
+		private String __bar;
+
+		@java.lang.SuppressWarnings("all")
+		BuilderWithRequiredArgsConstructorBuilder() {
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder plower(final int plower) {
+			this.plower = plower;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder pUpper(final Long pUpper) {
+			this.pUpper = pUpper;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder _foo(final long _foo) {
+			this._foo = _foo;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder __bar(final String __bar) {
+			this.__bar = __bar;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithRequiredArgsConstructor build() {
+			return new BuilderWithRequiredArgsConstructor(this.plower, this.pUpper, this._foo, this.__bar);
+		}
+
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder(plower=" + this.plower + ", pUpper=" + this.pUpper + ", _foo=" + this._foo + ", __bar=" + this.__bar + ")";
+		}
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public static BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder builder() {
+		return new BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public BuilderWithRequiredArgsConstructor(final long _foo, final String __bar) {
+		this._foo = _foo;
+		this.__bar = __bar;
+	}
+}

--- a/test/transform/resource/after-delombok/BuilderWithRequiredArgsConstructor.java
+++ b/test/transform/resource/after-delombok/BuilderWithRequiredArgsConstructor.java
@@ -28,24 +28,36 @@ class BuilderWithRequiredArgsConstructor {
 		BuilderWithRequiredArgsConstructorBuilder() {
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder plower(final int plower) {
 			this.plower = plower;
 			return this;
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder pUpper(final Long pUpper) {
 			this.pUpper = pUpper;
 			return this;
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder _foo(final long _foo) {
 			this._foo = _foo;
 			return this;
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder __bar(final String __bar) {
 			this.__bar = __bar;

--- a/test/transform/resource/after-delombok/BuilderWithUserDefinedConstructor.java
+++ b/test/transform/resource/after-delombok/BuilderWithUserDefinedConstructor.java
@@ -33,24 +33,36 @@ class BuilderWithUserDefinedConstructor {
 		BuilderWithUserDefinedConstructorBuilder() {
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder plower(final int plower) {
 			this.plower = plower;
 			return this;
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder pUpper(final int pUpper) {
 			this.pUpper = pUpper;
 			return this;
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder _foo(final int _foo) {
 			this._foo = _foo;
 			return this;
 		}
 
+		/**
+		 * @return {@code this}.
+		 */
 		@java.lang.SuppressWarnings("all")
 		public BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder __bar(final int __bar) {
 			this.__bar = __bar;

--- a/test/transform/resource/after-delombok/BuilderWithUserDefinedConstructor.java
+++ b/test/transform/resource/after-delombok/BuilderWithUserDefinedConstructor.java
@@ -1,0 +1,76 @@
+class BuilderWithUserDefinedConstructor {
+	private int plower;
+	private int pUpper;
+	private int _foo;
+	private int __bar;
+
+	BuilderWithUserDefinedConstructor(int plower, int pUpper) {
+		this.plower = plower;
+		this.pUpper = pUpper;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	BuilderWithUserDefinedConstructor(final int plower, final int pUpper, final int _foo, final int __bar) {
+		this.plower = plower;
+		this.pUpper = pUpper;
+		this._foo = _foo;
+		this.__bar = __bar;
+	}
+
+
+	@java.lang.SuppressWarnings("all")
+	public static class BuilderWithUserDefinedConstructorBuilder {
+		@java.lang.SuppressWarnings("all")
+		private int plower;
+		@java.lang.SuppressWarnings("all")
+		private int pUpper;
+		@java.lang.SuppressWarnings("all")
+		private int _foo;
+		@java.lang.SuppressWarnings("all")
+		private int __bar;
+
+		@java.lang.SuppressWarnings("all")
+		BuilderWithUserDefinedConstructorBuilder() {
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder plower(final int plower) {
+			this.plower = plower;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder pUpper(final int pUpper) {
+			this.pUpper = pUpper;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder _foo(final int _foo) {
+			this._foo = _foo;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder __bar(final int __bar) {
+			this.__bar = __bar;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithUserDefinedConstructor build() {
+			return new BuilderWithUserDefinedConstructor(this.plower, this.pUpper, this._foo, this.__bar);
+		}
+
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder(plower=" + this.plower + ", pUpper=" + this.pUpper + ", _foo=" + this._foo + ", __bar=" + this.__bar + ")";
+		}
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public static BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder builder() {
+		return new BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder();
+	}
+}

--- a/test/transform/resource/after-delombok/BuilderWithUserDefinedConstructorVarArgs.java
+++ b/test/transform/resource/after-delombok/BuilderWithUserDefinedConstructorVarArgs.java
@@ -1,0 +1,78 @@
+class BuilderWithUserDefinedConstructorVarArgs {
+	private int plower;
+	private int pUpper;
+	private int _foo;
+	private int __bar;
+
+	BuilderWithUserDefinedConstructorVarArgs(int... args) {
+	}
+
+
+	@java.lang.SuppressWarnings("all")
+	public static class BuilderWithUserDefinedConstructorVarArgsBuilder {
+		@java.lang.SuppressWarnings("all")
+		private int plower;
+		@java.lang.SuppressWarnings("all")
+		private int pUpper;
+		@java.lang.SuppressWarnings("all")
+		private int _foo;
+		@java.lang.SuppressWarnings("all")
+		private int __bar;
+
+		@java.lang.SuppressWarnings("all")
+		BuilderWithUserDefinedConstructorVarArgsBuilder() {
+		}
+
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder plower(final int plower) {
+			this.plower = plower;
+			return this;
+		}
+
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder pUpper(final int pUpper) {
+			this.pUpper = pUpper;
+			return this;
+		}
+
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder _foo(final int _foo) {
+			this._foo = _foo;
+			return this;
+		}
+
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder __bar(final int __bar) {
+			this.__bar = __bar;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithUserDefinedConstructorVarArgs build() {
+			return new BuilderWithUserDefinedConstructorVarArgs(this.plower, this.pUpper, this._foo, this.__bar);
+		}
+
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder(plower=" + this.plower + ", pUpper=" + this.pUpper + ", _foo=" + this._foo + ", __bar=" + this.__bar + ")";
+		}
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public static BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder builder() {
+		return new BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder();
+	}
+}

--- a/test/transform/resource/after-ecj/BuilderWithGenericsDefinedConstructor.java
+++ b/test/transform/resource/after-ecj/BuilderWithGenericsDefinedConstructor.java
@@ -1,0 +1,29 @@
+import java.util.List;
+@lombok.Builder class BuilderWithGenericsDefinedConstructor<T extends Number, V extends T> {
+  public static @java.lang.SuppressWarnings("all") class BuilderWithGenericsDefinedConstructorBuilder<T extends Number, V extends T> {
+    private @java.lang.SuppressWarnings("all") V a;
+    @java.lang.SuppressWarnings("all") BuilderWithGenericsDefinedConstructorBuilder() {
+      super();
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") BuilderWithGenericsDefinedConstructor.BuilderWithGenericsDefinedConstructorBuilder<T, V> a(final V a) {
+      this.a = a;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithGenericsDefinedConstructor<T, V> build() {
+      return new BuilderWithGenericsDefinedConstructor<T, V>(this.a);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (("BuilderWithGenericsDefinedConstructor.BuilderWithGenericsDefinedConstructorBuilder(a=" + this.a) + ")");
+    }
+  }
+  private V a;
+  public BuilderWithGenericsDefinedConstructor(T b) {
+    super();
+  }
+  public static @java.lang.SuppressWarnings("all") <T extends Number, V extends T>BuilderWithGenericsDefinedConstructor.BuilderWithGenericsDefinedConstructorBuilder<T, V> builder() {
+    return new BuilderWithGenericsDefinedConstructor.BuilderWithGenericsDefinedConstructorBuilder<T, V>();
+  }
+}

--- a/test/transform/resource/after-ecj/BuilderWithNoArgsConstructor.java
+++ b/test/transform/resource/after-ecj/BuilderWithNoArgsConstructor.java
@@ -7,18 +7,30 @@
     @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructorBuilder() {
       super();
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder plower(final int plower) {
       this.plower = plower;
       return this;
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder pUpper(final Long pUpper) {
       this.pUpper = pUpper;
       return this;
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder _foo(final long _foo) {
       this._foo = _foo;
       return this;
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder __bar(final String __bar) {
       this.__bar = __bar;
       return this;

--- a/test/transform/resource/after-ecj/BuilderWithNoArgsConstructor.java
+++ b/test/transform/resource/after-ecj/BuilderWithNoArgsConstructor.java
@@ -1,0 +1,50 @@
+@lombok.NoArgsConstructor @lombok.Builder class BuilderWithNoArgsConstructor {
+  public static @java.lang.SuppressWarnings("all") class BuilderWithNoArgsConstructorBuilder {
+    private @java.lang.SuppressWarnings("all") int plower;
+    private @java.lang.SuppressWarnings("all") Long pUpper;
+    private @java.lang.SuppressWarnings("all") long _foo;
+    private @java.lang.SuppressWarnings("all") String __bar;
+    @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructorBuilder() {
+      super();
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder plower(final int plower) {
+      this.plower = plower;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder pUpper(final Long pUpper) {
+      this.pUpper = pUpper;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder _foo(final long _foo) {
+      this._foo = _foo;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder __bar(final String __bar) {
+      this.__bar = __bar;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor build() {
+      return new BuilderWithNoArgsConstructor(this.plower, this.pUpper, this._foo, this.__bar);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (((((((("BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder(plower=" + this.plower) + ", pUpper=") + this.pUpper) + ", _foo=") + this._foo) + ", __bar=") + this.__bar) + ")");
+    }
+  }
+  private int plower;
+  private Long pUpper;
+  private long _foo;
+  private String __bar;
+  @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor(final int plower, final Long pUpper, final long _foo, final String __bar) {
+    super();
+    this.plower = plower;
+    this.pUpper = pUpper;
+    this._foo = _foo;
+    this.__bar = __bar;
+  }
+  public static @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder builder() {
+    return new BuilderWithNoArgsConstructor.BuilderWithNoArgsConstructorBuilder();
+  }
+  public @java.lang.SuppressWarnings("all") BuilderWithNoArgsConstructor() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/BuilderWithRequiredArgsConstructor.java
+++ b/test/transform/resource/after-ecj/BuilderWithRequiredArgsConstructor.java
@@ -1,0 +1,52 @@
+@lombok.RequiredArgsConstructor @lombok.Builder class BuilderWithRequiredArgsConstructor {
+  public static @java.lang.SuppressWarnings("all") class BuilderWithRequiredArgsConstructorBuilder {
+    private @java.lang.SuppressWarnings("all") int plower;
+    private @java.lang.SuppressWarnings("all") Long pUpper;
+    private @java.lang.SuppressWarnings("all") long _foo;
+    private @java.lang.SuppressWarnings("all") String __bar;
+    @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructorBuilder() {
+      super();
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder plower(final int plower) {
+      this.plower = plower;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder pUpper(final Long pUpper) {
+      this.pUpper = pUpper;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder _foo(final long _foo) {
+      this._foo = _foo;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder __bar(final String __bar) {
+      this.__bar = __bar;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor build() {
+      return new BuilderWithRequiredArgsConstructor(this.plower, this.pUpper, this._foo, this.__bar);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (((((((("BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder(plower=" + this.plower) + ", pUpper=") + this.pUpper) + ", _foo=") + this._foo) + ", __bar=") + this.__bar) + ")");
+    }
+  }
+  private int plower;
+  private Long pUpper;
+  private final long _foo;
+  private final String __bar;
+  @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor(final int plower, final Long pUpper, final long _foo, final String __bar) {
+    super();
+    this.plower = plower;
+    this.pUpper = pUpper;
+    this._foo = _foo;
+    this.__bar = __bar;
+  }
+  public static @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder builder() {
+    return new BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder();
+  }
+  public @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor(final long _foo, final String __bar) {
+    super();
+    this._foo = _foo;
+    this.__bar = __bar;
+  }
+}

--- a/test/transform/resource/after-ecj/BuilderWithRequiredArgsConstructor.java
+++ b/test/transform/resource/after-ecj/BuilderWithRequiredArgsConstructor.java
@@ -7,18 +7,30 @@
     @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructorBuilder() {
       super();
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder plower(final int plower) {
       this.plower = plower;
       return this;
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder pUpper(final Long pUpper) {
       this.pUpper = pUpper;
       return this;
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder _foo(final long _foo) {
       this._foo = _foo;
       return this;
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithRequiredArgsConstructor.BuilderWithRequiredArgsConstructorBuilder __bar(final String __bar) {
       this.__bar = __bar;
       return this;

--- a/test/transform/resource/after-ecj/BuilderWithSuperObjectsDefinedConstructor.java
+++ b/test/transform/resource/after-ecj/BuilderWithSuperObjectsDefinedConstructor.java
@@ -1,0 +1,39 @@
+@lombok.Builder class BuilderWithSuperObjectsDefinedConstructor {
+  public static @java.lang.SuppressWarnings("all") class BuilderWithSuperObjectsDefinedConstructorBuilder {
+    private @java.lang.SuppressWarnings("all") String __bar;
+    private @java.lang.SuppressWarnings("all") Long pUpper;
+    @java.lang.SuppressWarnings("all") BuilderWithSuperObjectsDefinedConstructorBuilder() {
+      super();
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") BuilderWithSuperObjectsDefinedConstructor.BuilderWithSuperObjectsDefinedConstructorBuilder __bar(final String __bar) {
+      this.__bar = __bar;
+      return this;
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") BuilderWithSuperObjectsDefinedConstructor.BuilderWithSuperObjectsDefinedConstructorBuilder pUpper(final Long pUpper) {
+      this.pUpper = pUpper;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithSuperObjectsDefinedConstructor build() {
+      return new BuilderWithSuperObjectsDefinedConstructor(this.__bar, this.pUpper);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (((("BuilderWithSuperObjectsDefinedConstructor.BuilderWithSuperObjectsDefinedConstructorBuilder(__bar=" + this.__bar) + ", pUpper=") + this.pUpper) + ")");
+    }
+  }
+  private String __bar;
+  private Long pUpper;
+  public BuilderWithSuperObjectsDefinedConstructor(CharSequence a, Number b) {
+    super();
+    __bar = (String) a;
+    pUpper = (Long) b;
+  }
+  public static @java.lang.SuppressWarnings("all") BuilderWithSuperObjectsDefinedConstructor.BuilderWithSuperObjectsDefinedConstructorBuilder builder() {
+    return new BuilderWithSuperObjectsDefinedConstructor.BuilderWithSuperObjectsDefinedConstructorBuilder();
+  }
+}

--- a/test/transform/resource/after-ecj/BuilderWithUserDefinedConstructor.java
+++ b/test/transform/resource/after-ecj/BuilderWithUserDefinedConstructor.java
@@ -7,18 +7,30 @@
     @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructorBuilder() {
       super();
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder plower(final int plower) {
       this.plower = plower;
       return this;
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder pUpper(final int pUpper) {
       this.pUpper = pUpper;
       return this;
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder _foo(final int _foo) {
       this._foo = _foo;
       return this;
     }
+    /**
+     * @return {@code this}.
+     */
     public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder __bar(final int __bar) {
       this.__bar = __bar;
       return this;

--- a/test/transform/resource/after-ecj/BuilderWithUserDefinedConstructor.java
+++ b/test/transform/resource/after-ecj/BuilderWithUserDefinedConstructor.java
@@ -1,0 +1,52 @@
+@lombok.Builder class BuilderWithUserDefinedConstructor {
+  public static @java.lang.SuppressWarnings("all") class BuilderWithUserDefinedConstructorBuilder {
+    private @java.lang.SuppressWarnings("all") int plower;
+    private @java.lang.SuppressWarnings("all") int pUpper;
+    private @java.lang.SuppressWarnings("all") int _foo;
+    private @java.lang.SuppressWarnings("all") int __bar;
+    @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructorBuilder() {
+      super();
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder plower(final int plower) {
+      this.plower = plower;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder pUpper(final int pUpper) {
+      this.pUpper = pUpper;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder _foo(final int _foo) {
+      this._foo = _foo;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder __bar(final int __bar) {
+      this.__bar = __bar;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructor build() {
+      return new BuilderWithUserDefinedConstructor(this.plower, this.pUpper, this._foo, this.__bar);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (((((((("BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder(plower=" + this.plower) + ", pUpper=") + this.pUpper) + ", _foo=") + this._foo) + ", __bar=") + this.__bar) + ")");
+    }
+  }
+  private int plower;
+  private int pUpper;
+  private int _foo;
+  private int __bar;
+  BuilderWithUserDefinedConstructor(int plower, int pUpper) {
+    super();
+    this.plower = plower;
+    this.pUpper = pUpper;
+  }
+  @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructor(final int plower, final int pUpper, final int _foo, final int __bar) {
+    super();
+    this.plower = plower;
+    this.pUpper = pUpper;
+    this._foo = _foo;
+    this.__bar = __bar;
+  }
+  public static @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder builder() {
+    return new BuilderWithUserDefinedConstructor.BuilderWithUserDefinedConstructorBuilder();
+  }
+}

--- a/test/transform/resource/after-ecj/BuilderWithUserDefinedConstructorVarArgs.java
+++ b/test/transform/resource/after-ecj/BuilderWithUserDefinedConstructorVarArgs.java
@@ -1,0 +1,55 @@
+@lombok.Builder class BuilderWithUserDefinedConstructorVarArgs {
+  public static @java.lang.SuppressWarnings("all") class BuilderWithUserDefinedConstructorVarArgsBuilder {
+    private @java.lang.SuppressWarnings("all") int plower;
+    private @java.lang.SuppressWarnings("all") int pUpper;
+    private @java.lang.SuppressWarnings("all") int _foo;
+    private @java.lang.SuppressWarnings("all") int __bar;
+    @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructorVarArgsBuilder() {
+      super();
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder plower(final int plower) {
+      this.plower = plower;
+      return this;
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder pUpper(final int pUpper) {
+      this.pUpper = pUpper;
+      return this;
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder _foo(final int _foo) {
+      this._foo = _foo;
+      return this;
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder __bar(final int __bar) {
+      this.__bar = __bar;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructorVarArgs build() {
+      return new BuilderWithUserDefinedConstructorVarArgs(this.plower, this.pUpper, this._foo, this.__bar);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (((((((("BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder(plower=" + this.plower) + ", pUpper=") + this.pUpper) + ", _foo=") + this._foo) + ", __bar=") + this.__bar) + ")");
+    }
+  }
+  private int plower;
+  private int pUpper;
+  private int _foo;
+  private int __bar;
+  BuilderWithUserDefinedConstructorVarArgs(int... args) {
+    super();
+  }
+  public static @java.lang.SuppressWarnings("all") BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder builder() {
+    return new BuilderWithUserDefinedConstructorVarArgs.BuilderWithUserDefinedConstructorVarArgsBuilder();
+  }
+}

--- a/test/transform/resource/before/BuilderWithGenericsDefinedConstructor.java
+++ b/test/transform/resource/before/BuilderWithGenericsDefinedConstructor.java
@@ -1,0 +1,7 @@
+import java.util.List;
+@lombok.Builder
+class BuilderWithGenericsDefinedConstructor<T extends Number, V extends T> {
+	private V a;
+	
+	public BuilderWithGenericsDefinedConstructor(T b) {}
+}

--- a/test/transform/resource/before/BuilderWithNoArgsConstructor.java
+++ b/test/transform/resource/before/BuilderWithNoArgsConstructor.java
@@ -1,0 +1,8 @@
+@lombok.NoArgsConstructor
+@lombok.Builder
+class BuilderWithNoArgsConstructor {
+	private int plower;
+	private Long pUpper;
+	private long _foo;
+	private String __bar;
+}

--- a/test/transform/resource/before/BuilderWithRequiredArgsConstructor.java
+++ b/test/transform/resource/before/BuilderWithRequiredArgsConstructor.java
@@ -1,0 +1,8 @@
+@lombok.RequiredArgsConstructor
+@lombok.Builder
+class BuilderWithRequiredArgsConstructor {
+	private int plower;
+	private Long pUpper;
+	private final long _foo;
+	private final String __bar;
+}

--- a/test/transform/resource/before/BuilderWithSuperObjectsDefinedConstructor.java
+++ b/test/transform/resource/before/BuilderWithSuperObjectsDefinedConstructor.java
@@ -1,0 +1,10 @@
+@lombok.Builder
+class BuilderWithSuperObjectsDefinedConstructor {
+	private String __bar;
+	private Long pUpper;
+	
+	public BuilderWithSuperObjectsDefinedConstructor(CharSequence a, Number b) {
+		__bar = (String)a;
+		pUpper = (Long)b;
+	}
+}

--- a/test/transform/resource/before/BuilderWithUserDefinedConstructor.java
+++ b/test/transform/resource/before/BuilderWithUserDefinedConstructor.java
@@ -1,0 +1,14 @@
+@lombok.Builder
+class BuilderWithUserDefinedConstructor {
+	private int plower;
+	private int pUpper;
+	private int _foo;
+	private int __bar;
+	
+	
+	BuilderWithUserDefinedConstructor(int plower, int pUpper) {
+		this.plower = plower;
+		this.pUpper = pUpper;
+	}
+
+}

--- a/test/transform/resource/before/BuilderWithUserDefinedConstructorVarArgs.java
+++ b/test/transform/resource/before/BuilderWithUserDefinedConstructorVarArgs.java
@@ -1,0 +1,11 @@
+@lombok.Builder
+class BuilderWithUserDefinedConstructorVarArgs {
+	private int plower;
+	private int pUpper;
+	private int _foo;
+	private int __bar;
+	
+	
+	BuilderWithUserDefinedConstructorVarArgs(int...args) {}
+
+}


### PR DESCRIPTION
This change makes builder processor to find an all argument matching constructor before skip constructor generation.

So it opens the possibility of having a `@Builder` along with `@RequiredArgsConstructor` or `@NoArgsConstructor` annotations, as well as user defined constructor methods.