### PR TITLE
[fixes #2768] Making the Builder constructor's visibility configurable. 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Roland Praml <pram@gmx.de>
 Rostislav Krasny <45571812+rosti-il@users.noreply.github.com>
 Samuel Pereira <samuel.p.araujo@gmail.com>
 Sander Koning <askoning@gmail.com>
+Sebestyen Bartha <sebestyen.bartha@gmail.com>
 Szymon Pacanowski <spacanowski@gmail.com>
 Taiki Sugawara <buzz.taiki@gmail.com>
 Takuya Murakami <tmurakam@tmurakam.org>

--- a/src/core/lombok/Builder.java
+++ b/src/core/lombok/Builder.java
@@ -153,6 +153,14 @@ public @interface Builder {
 	 * @return The builder class will be generated with this access modifier.
 	 */
 	AccessLevel access() default lombok.AccessLevel.PUBLIC;
+	
+	/**
+	 * Sets the access level of the generated builder's parameterless constructor. By default the generated constructor's access level is {@code package}
+	 * Note: This does nothing if you write your own builder constructor (we won't change its access level).
+	 * 
+	 * @return The builder's constructor will be generated with this access modifier.
+	 */
+	AccessLevel constructorAccess() default lombok.AccessLevel.PACKAGE;
 
 	/**
 	 * Prefix to prepend to 'set' methods in the generated builder class.  By default, generated methods do not include a prefix.


### PR DESCRIPTION
This makes the Builder constructor's visibility configurable. Also fixes #2768, however, I just stumbled upon that bug while trying to fix our own problem. 
The problem we had in our project is that we need to use Jackson and configure it so that it doesn't override access modifiers (set MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS to false) because in our runtime environment (embedded) there is a SecurityManager which doesn't allow that and we have no control over that. In this configuration Jackson cannot work unless the Builder's constructor is public. Making this configurable while keeping the default visibility PACKAGE, existing code is unaffected, but we can add the parameter to our Builder annotations which is more elegant than having to explicitly write the Builder classes.