### PR TITLE
Cleanup internal argument cache

### DIFF
--- a/src/stubs/com/sun/tools/javac/comp/ArgumentAttr.java
+++ b/src/stubs/com/sun/tools/javac/comp/ArgumentAttr.java
@@ -1,0 +1,12 @@
+/*
+ * These are stub versions of various bits of javac-internal API (for various different versions of javac). Lombok is compiled against these.
+ */
+package com.sun.tools.javac.comp;
+
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.util.Context;
+
+// JDK9+
+public class ArgumentAttr extends JCTree.Visitor {
+	public static ArgumentAttr instance(Context context) { return null; }
+}


### PR DESCRIPTION
This PR fixes #2460, fixes #2462

In Java 9 the class `ArgumentAttr` was added to address some performance issues (https://github.com/openjdk/jdk/commit/981c6dc2989b66f3691090c9f81e23d2b0a00087). This class uses an internal cache that gets polluted by lomboks resoultion calls. I fixed that by storing the original cache value and restoring it after lomboks resolution calls.

I tested it using Java 8, 11 and 16, I also validated that the `javac` performance improvements are not affected by these changes.

For some reaseon the fixed bugs only occurs during normal compilation and not in test cases...