### PR TITLE
Resolve variables in switch expressions

### DIFF
--- a/src/utils/lombok/javac/TreeMirrorMaker.java
+++ b/src/utils/lombok/javac/TreeMirrorMaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2015 The Project Lombok Authors.
+ * Copyright (C) 2010-2021 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -56,14 +56,14 @@ public class TreeMirrorMaker extends TreeCopier<Void> {
 	
 	@Override public <T extends JCTree> T copy(T original) {
 		T copy = super.copy(original);
-		originalToCopy.put(original, copy);
+		putIfAbsent(originalToCopy, original, copy);
 		return copy;
 	}
 	
 	@Override public <T extends JCTree> T copy(T original, Void p) {
 		T copy = super.copy(original, p);
-		originalToCopy.put(original, copy);
-		return copy;
+		putIfAbsent(originalToCopy, original, copy);
+		return copy; 
 	}
 	
 	@Override public <T extends JCTree> List<T> copy(List<T> originals) {
@@ -71,7 +71,7 @@ public class TreeMirrorMaker extends TreeCopier<Void> {
 		if (originals != null) {
 			Iterator<T> it1 = originals.iterator();
 			Iterator<T> it2 = copies.iterator();
-			while (it1.hasNext()) originalToCopy.put(it1.next(), it2.next());
+			while (it1.hasNext()) putIfAbsent(originalToCopy, it1.next(), it2.next());
 		}
 		return copies;
 	}
@@ -81,7 +81,7 @@ public class TreeMirrorMaker extends TreeCopier<Void> {
 		if (originals != null) {
 			Iterator<T> it1 = originals.iterator();
 			Iterator<T> it2 = copies.iterator();
-			while (it1.hasNext()) originalToCopy.put(it1.next(), it2.next());
+			while (it1.hasNext()) putIfAbsent(originalToCopy, it1.next(), it2.next());
 		}
 		return copies;
 	}
@@ -119,5 +119,11 @@ public class TreeMirrorMaker extends TreeCopier<Void> {
 	// This and visitVariable is rather hacky but we're working around evident bugs or at least inconsistencies in javac.
 	@Override public JCTree visitLabeledStatement(LabeledStatementTree node, Void p) {
 		return node.getStatement().accept(this, p);
+	}
+	
+	private <K, V> void putIfAbsent(Map<K, V> map, K key, V value) {
+		if (!map.containsKey(key)) {
+			map.put(key, value);
+		}
 	}
 }

--- a/test/transform/resource/after-delombok/ValSwitchExpression.java
+++ b/test/transform/resource/after-delombok/ValSwitchExpression.java
@@ -1,0 +1,11 @@
+// version 14:
+public class ValSwitchExpression {
+	public void method(int arg) {
+		final int x = switch (arg) {
+			default -> {
+				final java.lang.String s = "string";
+				yield arg;
+			}
+		};
+	}
+}

--- a/test/transform/resource/after-ecj/ValSwitchExpression.java
+++ b/test/transform/resource/after-ecj/ValSwitchExpression.java
@@ -1,0 +1,16 @@
+// version 14:
+import lombok.val;
+public class ValSwitchExpression {
+  public ValSwitchExpression() {
+    super();
+  }
+  public void method(int arg) {
+    final @val int x =     switch (arg) {
+    default ->
+        {
+          final @val java.lang.String s = "string";
+          yield arg;
+        }
+    };
+  }
+}

--- a/test/transform/resource/before/ValSwitchExpression.java
+++ b/test/transform/resource/before/ValSwitchExpression.java
@@ -1,0 +1,13 @@
+// version 14:
+import lombok.val;
+
+public class ValSwitchExpression {
+	public void method(int arg) {
+		val x = switch (arg) {
+			default -> {
+				val s = "string";
+				yield arg;
+			}
+		};
+	}
+}


### PR DESCRIPTION
This PR fixes #2624.

In Java 14 and 15 the `TreeCopier` creates inconsistent copies by duplicating `JCCase#body` instead of using the one that is already part of `JCCase#stats`. This bug/problem was fixed in Java 16: https://github.com/openjdk/jdk/commit/b37228e11fc69128b8172968e6b1049bcb9cb994. 
Instead of overriding the `TreeCopier` code and using reflection to fix `JCCase#body` this PR simply discards multiple targets in the result map. As the right part of `JCCase` gets copied first this fixes the actual problem.