### PR TITLE
Add XXXArgsConstructor exceptions thrown declaration (#1921)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Christian Sterzl <christian.sterzl@gmail.com>
 DaveLaw <project.lombok@apconsult.de>
 Dave Brosius <dbrosius@mebigfatguy.com>
 Dawid Rusin <dawidrusin90@gmail.com>
+Demian Banakh <dembanakh01@gmail.com>
 Denis Stepanov <denis.stepanov@gmail.com>
 Emil Lundberg <emil@yubico.com>
 Enrique da Costa Cambio <enrique.dacostacambio@gmail.com>

--- a/src/core/lombok/AllArgsConstructor.java
+++ b/src/core/lombok/AllArgsConstructor.java
@@ -70,6 +70,13 @@ public @interface AllArgsConstructor {
 	AccessLevel access() default lombok.AccessLevel.PUBLIC;
 	
 	/**
+	 * Any throwable class listed here is appended to the generated constructor's {@code throws} clause.
+	 * 
+	 * @return The exception types that the generated constructor will declare to throw.
+	 */
+	Class<? extends Throwable>[] throwing() default {};
+	
+	/**
 	  * Placeholder annotation to enable the placement of annotations on the generated code.
 	  * 
 	  * @deprecated Don't use this annotation, ever - Read the documentation.

--- a/src/core/lombok/NoArgsConstructor.java
+++ b/src/core/lombok/NoArgsConstructor.java
@@ -80,6 +80,13 @@ public @interface NoArgsConstructor {
 	boolean force() default false;
 	
 	/**
+	 * Any throwable class listed here is appended to the generated constructor's {@code throws} clause.
+	 * 
+	 * @return The exception types that the generated constructor will declare to throw.
+	 */
+	Class<? extends Throwable>[] throwing() default {};
+	
+	/**
 	  * Placeholder annotation to enable the placement of annotations on the generated code.
 	  * @deprecated Don't use this annotation, ever - Read the documentation.
 	  */

--- a/src/core/lombok/RequiredArgsConstructor.java
+++ b/src/core/lombok/RequiredArgsConstructor.java
@@ -70,6 +70,13 @@ public @interface RequiredArgsConstructor {
 	AccessLevel access() default lombok.AccessLevel.PUBLIC;
 	
 	/**
+	 * Any throwable class listed here is appended to the generated constructor's {@code throws} clause.
+	 * 
+	 * @return The exception types that the generated constructor will declare to throw.
+	 */
+	Class<? extends Throwable>[] throwing() default {};
+	
+	/**
 	  * Placeholder annotation to enable the placement of annotations on the generated code.
 	  * @deprecated Don't use this annotation, ever - Read the documentation.
 	  */

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -542,7 +542,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		if (constructorExists(job.builderType) == MemberExistsResult.NOT_EXISTS) {
 			ConstructorDeclaration cd = HandleConstructor.createConstructor(
 				AccessLevel.PACKAGE, job.builderType, Collections.<EclipseNode>emptyList(), false,
-				annotationNode, Collections.<Annotation>emptyList());
+				annotationNode, Collections.<Annotation>emptyList(), Collections.<TypeReference>emptyList());
 			if (cd != null) injectMethod(job.builderType, cd);
 		}
 		

--- a/src/core/lombok/experimental/StandardException.java
+++ b/src/core/lombok/experimental/StandardException.java
@@ -41,7 +41,7 @@ import lombok.AccessLevel;
 @Retention(RetentionPolicy.SOURCE)
 public @interface StandardException {
 	/**
-	 * Sets the access level of the generated constuctors. By default, generated constructors are {@code public}.
+	 * Sets the access level of the generated constructors. By default, generated constructors are {@code public}.
 	 * Note: This does nothing if you write your own constructors (we won't change their access levels).
 	 * 
 	 * @return The constructors will be generated with this access modifier.

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -479,7 +479,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 		}
 		
 		if (constructorExists(job.builderType) == MemberExistsResult.NOT_EXISTS) {
-			JCMethodDecl cd = HandleConstructor.createConstructor(AccessLevel.PACKAGE, List.<JCAnnotation>nil(), job.builderType, List.<JavacNode>nil(), false, annotationNode);
+			JCMethodDecl cd = HandleConstructor.createConstructor(AccessLevel.PACKAGE, List.<JCAnnotation>nil(), List.<JCExpression>nil(), job.builderType, List.<JavacNode>nil(), false, annotationNode);
 			if (cd != null) injectMethod(job.builderType, cd);
 		}
 		

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -383,7 +383,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			}
 
 			// Create a simple constructor for the BuilderImpl class.
-			JCMethodDecl cd = HandleConstructor.createConstructor(AccessLevel.PRIVATE, List.<JCAnnotation>nil(), job.builderImplType, List.<JavacNode>nil(), false, annotationNode);
+			JCMethodDecl cd = HandleConstructor.createConstructor(AccessLevel.PRIVATE, List.<JCAnnotation>nil(), List.<JCExpression>nil(), job.builderImplType, List.<JavacNode>nil(), false, annotationNode);
 			if (cd != null) injectMethod(job.builderImplType, cd);
 			job.setBuilderToImpl();
 			

--- a/test/transform/resource/after-delombok/Constructors.java
+++ b/test/transform/resource/after-delombok/Constructors.java
@@ -100,3 +100,13 @@ class NoArgsConstructor2 {
 		this.s = null;
 	}
 }
+class NoArgsConstructorThrowingSimple {
+	@java.lang.SuppressWarnings("all")
+	public NoArgsConstructorThrowingSimple() throws Exception {
+	}
+}
+class NoArgsConstructorThrowingQualified {
+	@java.lang.SuppressWarnings("all")
+	public NoArgsConstructorThrowingQualified() throws java.lang.Exception {
+	}
+}

--- a/test/transform/resource/after-ecj/Constructors.java
+++ b/test/transform/resource/after-ecj/Constructors.java
@@ -96,3 +96,13 @@
     this.s = null;
   }
 }
+@lombok.NoArgsConstructor(throwing = {Exception.class} class NoArgsConstructorThrowingSimple {
+	public @java.lang.SuppressWarnings("all") NoArgsConstructorThrowingSimple() throws Exception {
+		super();
+	}
+}
+class NoArgsConstructorThrowingQualified {
+	public @java.lang.SuppressWarnings("all") NoArgsConstructorThrowingQualified() throws java.lang.Exception {
+		super();
+	}
+}

--- a/test/transform/resource/before/Constructors.java
+++ b/test/transform/resource/before/Constructors.java
@@ -42,3 +42,7 @@
 	final String s;
 	byte z;
 }
+@lombok.NoArgsConstructor(throwing = {Exception.class}) class NoArgsConstructorThrowingSimple {
+}
+@lombok.NoArgsConstructor(throwing = {java.lang.Exception.class}) class NoArgsConstructorThrowingQualified {
+}


### PR DESCRIPTION
Implements #1921:
Added throwing property to XXXArgsConstructor, to specify the exceptions to declare on the constructor.
For now, one must manually specify the list of exceptions. As far as I understand, inferring the exceptions from the base class constructor may be problematic due to the resolving happening after lombok. But I haven't looked into this inferring part yet.