### PR TITLE
Also copy vartype.type in TreeMirrorMaker

### DIFF
--- a/src/utils/lombok/javac/TreeMirrorMaker.java
+++ b/src/utils/lombok/javac/TreeMirrorMaker.java
@@ -32,8 +32,10 @@ import lombok.javac.JavacTreeMaker.TypeTag;
 import com.sun.source.tree.LabeledStatementTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.tree.TreeCopier;
+import com.sun.tools.javac.tree.TreeScanner;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
 
@@ -110,7 +112,20 @@ public class TreeMirrorMaker extends TreeCopier<Void> {
 				copy.sym = null;
 				copy.type = null;
 			} else {
-				if (original.vartype != null) copy.vartype.type = original.vartype.type;
+				if (original.vartype != null) {
+					copy.vartype.type = original.vartype.type;
+					original.vartype.accept(new TreeScanner() {
+						@Override public void scan(JCTree tree) {
+							super.scan(tree);
+							originalToCopy.get(tree).type = tree.type;
+						}
+						
+						@Override public void visitSelect(JCFieldAccess tree) {
+							super.visitSelect(tree);
+							((JCFieldAccess) originalToCopy.get(tree)).sym = tree.sym;
+						}
+					});
+				}
 			}
 		}
 		

--- a/src/utils/lombok/javac/TreeMirrorMaker.java
+++ b/src/utils/lombok/javac/TreeMirrorMaker.java
@@ -109,6 +109,8 @@ public class TreeMirrorMaker extends TreeCopier<Void> {
 			if (wipeSymAndType) {
 				copy.sym = null;
 				copy.type = null;
+			} else {
+				if (original.vartype != null) copy.vartype.type = original.vartype.type;
 			}
 		}
 		

--- a/test/transform/resource/after-delombok/ValAnonymousSubclassSelfReference.java
+++ b/test/transform/resource/after-delombok/ValAnonymousSubclassSelfReference.java
@@ -1,5 +1,13 @@
+import java.util.Map;
+import java.util.HashMap;
+
 public class ValAnonymousSubclassSelfReference {
-	public void test() {
+	public <T> void test(T arg) {
+		T d = arg;
+		Integer[] e = new Integer[1];
+		int[] f = new int[0];
+		java.util.Map<java.lang.String, Integer> g = new HashMap<String, Integer>();
+		Integer h = 0;
 		int i = 0;
 		final int j = 1;
 		final int k = 2;

--- a/test/transform/resource/after-delombok/ValAnonymousSubclassSelfReference.java
+++ b/test/transform/resource/after-delombok/ValAnonymousSubclassSelfReference.java
@@ -1,0 +1,9 @@
+public class ValAnonymousSubclassSelfReference {
+	public void test() {
+		int i = 0;
+		final int j = 1;
+		final int k = 2;
+		new ValAnonymousSubclassSelfReference() {
+		};
+	}
+}

--- a/test/transform/resource/after-ecj/ValAnonymousSubclassSelfReference.java
+++ b/test/transform/resource/after-ecj/ValAnonymousSubclassSelfReference.java
@@ -1,0 +1,16 @@
+import lombok.val;
+public class ValAnonymousSubclassSelfReference {
+  public ValAnonymousSubclassSelfReference() {
+    super();
+  }
+  public void test() {
+    int i = 0;
+    final @val int j = 1;
+    final @val int k = 2;
+    new ValAnonymousSubclassSelfReference() {
+      x() {
+        super();
+      }
+    };
+  }
+}

--- a/test/transform/resource/after-ecj/ValAnonymousSubclassSelfReference.java
+++ b/test/transform/resource/after-ecj/ValAnonymousSubclassSelfReference.java
@@ -1,9 +1,16 @@
+import java.util.Map;
+import java.util.HashMap;
 import lombok.val;
 public class ValAnonymousSubclassSelfReference {
   public ValAnonymousSubclassSelfReference() {
     super();
   }
-  public void test() {
+  public <T>void test(T arg) {
+    T d = arg;
+    Integer[] e = new Integer[1];
+    int[] f = new int[0];
+    java.util.Map<java.lang.String, Integer> g = new HashMap<String, Integer>();
+    Integer h = 0;
     int i = 0;
     final @val int j = 1;
     final @val int k = 2;

--- a/test/transform/resource/before/ValAnonymousSubclassSelfReference.java
+++ b/test/transform/resource/before/ValAnonymousSubclassSelfReference.java
@@ -1,9 +1,18 @@
-// issue 2420: to trigger the problem 2 var/val, one normal variable and a anonymous self reference is required
+// issue 2420: to trigger the problem 2 var/val, at least one normal variable and a anonymous self reference is required
+import java.util.Map;
+import java.util.HashMap;
+
 import lombok.val;
 
 public class ValAnonymousSubclassSelfReference {
-	public void test() {
+	public <T> void test(T arg) {
+		T d = arg;
+		Integer[] e = new Integer[1];
+		int[] f = new int[0];
+		java.util.Map<java.lang.String, Integer> g = new HashMap<String, Integer>();
+		Integer h = 0;  
 		int i = 0;
+		
 		val j = 1;
 		val k = 2;
 

--- a/test/transform/resource/before/ValAnonymousSubclassSelfReference.java
+++ b/test/transform/resource/before/ValAnonymousSubclassSelfReference.java
@@ -1,0 +1,12 @@
+// issue 2420: to trigger the problem 2 var/val, one normal variable and a anonymous self reference is required
+import lombok.val;
+
+public class ValAnonymousSubclassSelfReference {
+	public void test() {
+		int i = 0;
+		val j = 1;
+		val k = 2;
+
+		new ValAnonymousSubclassSelfReference() { };
+	}
+}


### PR DESCRIPTION
This PR fixes #2420

The `TreeMirrorMaker` has some special code to copy symbols and types for variables in some cases. It seems like that it is also required to copy the `vartype` field if we copy the other stuff. It also works if the whole symbol/type copy block gets removed but that most likely reintroduce the original issue even if I was unable to reproduce it.

**Edit**
Added a visitor to also copy reference types