### PR TITLE
#2596 Builder's setter prefix configurable from lombok.config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ DaveLaw <project.lombok@apconsult.de>
 Dave Brosius <dbrosius@mebigfatguy.com>
 Dawid Rusin <dawidrusin90@gmail.com>
 Denis Stepanov <denis.stepanov@gmail.com>
+Dmitry Ivanov <sadv12@gmail.com>
 Emil Lundberg <emil@yubico.com>
 Enrique da Costa Cambio <enrique.dacostacambio@gmail.com>
 Jacob Middag <jacob@gaddim.nl>

--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -301,6 +301,13 @@ public class ConfigurationKeys {
 	public static final ConfigurationKey<String> BUILDER_CLASS_NAME = new ConfigurationKey<String>("lombok.builder.className", "Default name of the generated builder class. A * is replaced with the name of the relevant type (default = *Builder).") {};
 	
 	/**
+	 * lombok configuration: {@code lombok.builder.setterPrefix} = &lt;String: prefix&gt;.
+	 *
+	 * For any usage of the {@code @Builder} annotation without an explicit {@code setterPrefix} parameter, this prefix is used.
+	 */
+	public static final ConfigurationKey<String> BUILDER_SETTER_PREFIX = new ConfigurationKey<String>("lombok.builder.setterPrefix", "The prefix to prepend to generated @Builder setter method names") {};
+	
+	/**
 	 * lombok configuration: {@code lombok.builder.flagUsage} = {@code WARNING} | {@code ERROR}.
 	 * 
 	 * If set, <em>any</em> usage of {@code @Builder} results in a warning / error.

--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -863,4 +863,15 @@ public class HandlerUtil {
 		}
 		return null;
 	}
+	
+	public static String getBuilderSetterPrefix(LombokNode<?, ?, ?> node, String setterPrefix) {
+		if (setterPrefix != null && !setterPrefix.isEmpty()) {
+			return setterPrefix;
+		}
+		
+		String configurationPrefix = node.getAst().readConfiguration(ConfigurationKeys.BUILDER_SETTER_PREFIX);
+		if (configurationPrefix != null && !configurationPrefix.isEmpty()) return configurationPrefix;
+		
+		return setterPrefix;
+	}
 }

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -320,7 +320,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 				bfd.builderFieldName = bfd.name;
 				bfd.annotations = copyAnnotations(fd, findCopyableAnnotations(fieldNode));
 				bfd.type = fd.type;
-				bfd.singularData = getSingularData(fieldNode, ast, annInstance.setterPrefix());
+				bfd.singularData = getSingularData(fieldNode, ast, getBuilderSetterPrefix(annotationNode, annInstance.setterPrefix()));
 				bfd.originalFieldNode = fieldNode;
 				
 				if (bfd.singularData != null && isDefault != null) {
@@ -483,7 +483,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 				bfd.builderFieldName = bfd.name;
 				bfd.annotations = copyAnnotations(arg, copyableAnnotations);
 				bfd.type = arg.type;
-				bfd.singularData = getSingularData(param, ast, annInstance.setterPrefix());
+				bfd.singularData = getSingularData(param, ast, getBuilderSetterPrefix(annotationNode, annInstance.setterPrefix()));
 				bfd.originalFieldNode = param;
 				addObtainVia(bfd, param);
 				job.builderFields.add(bfd);
@@ -552,7 +552,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		}
 		
 		for (BuilderFieldData bfd : job.builderFields) {
-			makePrefixedSetterMethodsForBuilder(job, bfd, annInstance.setterPrefix());
+			makePrefixedSetterMethodsForBuilder(job, bfd, getBuilderSetterPrefix(annotationNode, annInstance.setterPrefix()));
 		}
 		
 		{
@@ -599,7 +599,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 					tps[i].name = typeArgsForToBuilder.get(i);
 				}
 			}
-			MethodDeclaration md = generateToBuilderMethod(job, tps, annInstance.setterPrefix());
+			MethodDeclaration md = generateToBuilderMethod(job, tps, getBuilderSetterPrefix(annotationNode, annInstance.setterPrefix()));
 			
 			if (md != null) injectMethod(job.parentType, md);
 		}

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -261,7 +261,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 				bfd.builderFieldName = bfd.name;
 				bfd.annotations = findCopyableAnnotations(fieldNode);
 				bfd.type = fd.vartype;
-				bfd.singularData = getSingularData(fieldNode, annInstance.setterPrefix());
+				bfd.singularData = getSingularData(fieldNode, getBuilderSetterPrefix(annotationNode, annInstance.setterPrefix()));
 				bfd.originalFieldNode = fieldNode;
 				
 				if (bfd.singularData != null && isDefault != null) {
@@ -422,7 +422,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 				bfd.rawName = raw.name;
 				bfd.annotations = findCopyableAnnotations(param);
 				bfd.type = raw.vartype;
-				bfd.singularData = getSingularData(param, annInstance.setterPrefix());
+				bfd.singularData = getSingularData(param, getBuilderSetterPrefix(annotationNode, annInstance.setterPrefix()));
 				bfd.originalFieldNode = param;
 				addObtainVia(bfd, param);
 				job.builderFields.add(bfd);
@@ -489,7 +489,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 		}
 		
 		for (BuilderFieldData bfd : job.builderFields) {
-			makePrefixedSetterMethodsForBuilder(job, bfd, annInstance.setterPrefix());
+			makePrefixedSetterMethodsForBuilder(job, bfd, getBuilderSetterPrefix(annotationNode, annInstance.setterPrefix()));
 		}
 		
 		{
@@ -540,7 +540,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 					}
 					tps = lb.toList();
 				}
-				JCMethodDecl md = generateToBuilderMethod(job, tps, annInstance.setterPrefix());
+				JCMethodDecl md = generateToBuilderMethod(job, tps, getBuilderSetterPrefix(annotationNode, annInstance.setterPrefix()));
 				if (md != null) {
 					recursiveSetGeneratedBy(md, annotationNode);
 					injectMethod(job.parentType, md);

--- a/test/transform/resource/after-delombok/BuilderSimpleWithSetterPrefixConfiguration.java
+++ b/test/transform/resource/after-delombok/BuilderSimpleWithSetterPrefixConfiguration.java
@@ -1,0 +1,37 @@
+import java.util.List;
+class BuilderSimpleWithSetterPrefix<T> {
+	private int unprefixed;
+	@java.lang.SuppressWarnings("all")
+	BuilderSimpleWithSetterPrefix(final int unprefixed) {
+		this.unprefixed = unprefixed;
+	}
+	@java.lang.SuppressWarnings("all")
+	protected static class BuilderSimpleWithSetterPrefixBuilder<T> {
+		@java.lang.SuppressWarnings("all")
+		private int unprefixed;
+		@java.lang.SuppressWarnings("all")
+		BuilderSimpleWithSetterPrefixBuilder() {
+		}
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public BuilderSimpleWithSetterPrefix.BuilderSimpleWithSetterPrefixBuilder<T> withUnprefixed(final int unprefixed) {
+			this.unprefixed = unprefixed;
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderSimpleWithSetterPrefix<T> build() {
+			return new BuilderSimpleWithSetterPrefix<T>(this.unprefixed);
+		}
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "BuilderSimpleWithSetterPrefix.BuilderSimpleWithSetterPrefixBuilder(unprefixed=" + this.unprefixed + ")";
+		}
+	}
+	@java.lang.SuppressWarnings("all")
+	protected static <T> BuilderSimpleWithSetterPrefix.BuilderSimpleWithSetterPrefixBuilder<T> builder() {
+		return new BuilderSimpleWithSetterPrefix.BuilderSimpleWithSetterPrefixBuilder<T>();
+	}
+}

--- a/test/transform/resource/after-ecj/BuilderSimpleWithSetterPrefixConfiguration.java
+++ b/test/transform/resource/after-ecj/BuilderSimpleWithSetterPrefixConfiguration.java
@@ -1,0 +1,30 @@
+import java.util.List;
+@lombok.Builder(access = lombok.AccessLevel.PROTECTED) class BuilderSimpleWithSetterPrefix<T> {
+  protected static @java.lang.SuppressWarnings("all") class BuilderSimpleWithSetterPrefixBuilder<T> {
+    private @java.lang.SuppressWarnings("all") int unprefixed;
+    @java.lang.SuppressWarnings("all") BuilderSimpleWithSetterPrefixBuilder() {
+      super();
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") BuilderSimpleWithSetterPrefix.BuilderSimpleWithSetterPrefixBuilder<T> withUnprefixed(final int unprefixed) {
+      this.unprefixed = unprefixed;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderSimpleWithSetterPrefix<T> build() {
+      return new BuilderSimpleWithSetterPrefix<T>(this.unprefixed);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (("BuilderSimpleWithSetterPrefix.BuilderSimpleWithSetterPrefixBuilder(unprefixed=" + this.unprefixed) + ")");
+    }
+  }
+  private int unprefixed;
+  @java.lang.SuppressWarnings("all") BuilderSimpleWithSetterPrefix(final int unprefixed) {
+    super();
+    this.unprefixed = unprefixed;
+  }
+  protected static @java.lang.SuppressWarnings("all") <T>BuilderSimpleWithSetterPrefix.BuilderSimpleWithSetterPrefixBuilder<T> builder() {
+    return new BuilderSimpleWithSetterPrefix.BuilderSimpleWithSetterPrefixBuilder<T>();
+  }
+}

--- a/test/transform/resource/before/BuilderSimpleWithSetterPrefixConfiguration.java
+++ b/test/transform/resource/before/BuilderSimpleWithSetterPrefixConfiguration.java
@@ -1,0 +1,8 @@
+//CONF: lombok.builder.setterPrefix = with
+
+import java.util.List;
+
+@lombok.Builder(access = lombok.AccessLevel.PROTECTED)
+class BuilderSimpleWithSetterPrefix<T> {
+	private int unprefixed;
+}

--- a/website/templates/features/Builder.html
+++ b/website/templates/features/Builder.html
@@ -188,6 +188,10 @@ public class JacksonExample {
 		</dt><dd>
 			Unless you explicitly pick the builder's class name with the <code>builderClassName</code> parameter, this name is chosen; any star in the name is replaced with the relevant return type.
 		</dd><dt>
+			<code>lombok.builder.setterPrefix</code> = [the prefix to prepend to generated <code>@Builder</code> setter method names] (default: not set)
+		</dt><dd>
+			Unless you explicitly pick the builder's setter prefix with the <code>setterPrefix</code> parameter, this prefix is chosen.
+		</dd><dt>
 			<code>lombok.builder.flagUsage</code> = [<code>warning</code> | <code>error</code>] (default: not set)
 		</dt><dd>
 			Lombok will flag any usage of <code>@Builder</code> as a warning or error if configured.


### PR DESCRIPTION
Added possibility to provide `@Builder` setterPrefix from the `lombok.config`, like requested in https://github.com/projectlombok/lombok/pull/2174#issuecomment-524099192