### PR TITLE
Resource not closed corrrectly

### DIFF
--- a/src/core/lombok/core/debug/AssertionLogger.java
+++ b/src/core/lombok/core/debug/AssertionLogger.java
@@ -68,10 +68,8 @@ public class AssertionLogger {
 	private static synchronized void logToFile(String msg) {
 		if (msg == null) return;
 		
-		try {
-			OutputStream out = new FileOutputStream(LOG_PATH, true);
+		try(OutputStream out = new FileOutputStream(LOG_PATH, true)) {
 			out.write(msg.getBytes("UTF-8"));
-			out.close();
 		} catch (Exception e) {
 			throw new RuntimeException("assertion logging can't write to log file", e);
 		}

--- a/test/ecj/SimpleTest.java
+++ b/test/ecj/SimpleTest.java
@@ -1,7 +1,7 @@
 @lombok.Data
 public class SimpleTest {
 	private final String test;
-	private final int foo;
+	private final int f;
 	
 	public String bar() {
 		int val = getFoo() + 5;


### PR DESCRIPTION
The resource would not be closed in case `out.write()` threw an Exception. Changing implementation to try-with-resources.
Issue: https://github.com/projectlombok/lombok/issues/2871
Reference: https://www.oracle.com/technical-resources/articles/java/trywithresources.html