### PR TITLE
Make @Builder work with both Default and throwing constructor

### DIFF
--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -489,7 +489,12 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 		
 		{
 			MemberExistsResult methodExists = methodExists(job.buildMethodName, job.builderType, -1);
-			if (methodExists == MemberExistsResult.EXISTS_BY_LOMBOK) methodExists = methodExists(job.buildMethodName, job.builderType, 0);
+			if (methodExists == MemberExistsResult.EXISTS_BY_LOMBOK) {
+				if (!buildMethodThrownExceptions.isEmpty()) {
+					addThrowsTypes(job.builderType, job.buildMethodName, buildMethodThrownExceptions, 0);
+				}
+				methodExists = methodExists(job.buildMethodName, job.builderType, 0);
+			}
 			if (methodExists == MemberExistsResult.NOT_EXISTS) {
 				JCMethodDecl md = generateBuildMethod(job, nameOfBuilderMethod, buildMethodReturnType, buildMethodThrownExceptions, addCleaning);
 				if (md != null) {

--- a/test/transform/resource/after-delombok/BuilderWithDefaultAndConstructorThrows.java
+++ b/test/transform/resource/after-delombok/BuilderWithDefaultAndConstructorThrows.java
@@ -1,0 +1,55 @@
+import java.io.IOException;
+
+public class BuilderWithDefaultAndConstructorThrows {
+	private final int value;
+
+	public BuilderWithDefaultAndConstructorThrows(int value) throws IOException {
+		if (value > 100) {
+			throw new IOException("value too large");
+		}
+		this.value = value;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	private static int $default$value() {
+		return 10;
+	}
+
+
+	@java.lang.SuppressWarnings("all")
+	public static class BuilderWithDefaultAndConstructorThrowsBuilder {
+		@java.lang.SuppressWarnings("all")
+		private boolean value$set;
+		@java.lang.SuppressWarnings("all")
+		private int value$value;
+		@java.lang.SuppressWarnings("all")
+		private int value;
+		@java.lang.SuppressWarnings("all")
+		BuilderWithDefaultAndConstructorThrowsBuilder() {
+		}
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithDefaultAndConstructorThrows.BuilderWithDefaultAndConstructorThrowsBuilder value(final int value) {
+			this.value$value = value;
+			value$set = true;
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderWithDefaultAndConstructorThrows build() throws IOException {
+			int value$value = this.value$value;
+			if (!this.value$set) value$value = BuilderWithDefaultAndConstructorThrows.$default$value();
+			return new BuilderWithDefaultAndConstructorThrows(value$value);
+		}
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "BuilderWithDefaultAndConstructorThrows.BuilderWithDefaultAndConstructorThrowsBuilder(value$value=" + this.value$value + ")";
+		}
+	}
+	@java.lang.SuppressWarnings("all")
+	public static BuilderWithDefaultAndConstructorThrows.BuilderWithDefaultAndConstructorThrowsBuilder builder() {
+		return new BuilderWithDefaultAndConstructorThrows.BuilderWithDefaultAndConstructorThrowsBuilder();
+	}
+}

--- a/test/transform/resource/after-ecj/BuilderWithDefaultAndConstructorThrows.java
+++ b/test/transform/resource/after-ecj/BuilderWithDefaultAndConstructorThrows.java
@@ -1,0 +1,40 @@
+import lombok.Builder;
+import java.io.IOException;
+public @Builder class BuilderWithDefaultAndConstructorThrows {
+  public static @java.lang.SuppressWarnings("all") class BuilderWithDefaultAndConstructorThrowsBuilder {
+    private @java.lang.SuppressWarnings("all") int value;
+    private @java.lang.SuppressWarnings("all") int value$value;
+    private @java.lang.SuppressWarnings("all") boolean value$set;
+    @java.lang.SuppressWarnings("all") BuilderWithDefaultAndConstructorThrowsBuilder() {
+      super();
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") BuilderWithDefaultAndConstructorThrows.BuilderWithDefaultAndConstructorThrowsBuilder value(final int value) {
+      this.value = value;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderWithDefaultAndConstructorThrows build() throws IOException {
+      return new BuilderWithDefaultAndConstructorThrows(this.value);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (("BuilderWithDefaultAndConstructorThrows.BuilderWithDefaultAndConstructorThrowsBuilder(value=" + this.value) + ")");
+    }
+  }
+  private final @Builder.Default int value;
+  public @Builder BuilderWithDefaultAndConstructorThrows(int value) throws IOException {
+    super();
+    if ((value > 100))
+        {
+          throw new IOException("value too large");
+        }
+    this.value = value;
+  }
+  public static @java.lang.SuppressWarnings("all") BuilderWithDefaultAndConstructorThrows.BuilderWithDefaultAndConstructorThrowsBuilder builder() {
+    return new BuilderWithDefaultAndConstructorThrows.BuilderWithDefaultAndConstructorThrowsBuilder();
+  }
+  private static @java.lang.SuppressWarnings("all") int $default$value() {
+    return 10;
+  }
+}

--- a/test/transform/resource/before/BuilderWithDefaultAndConstructorThrows.java
+++ b/test/transform/resource/before/BuilderWithDefaultAndConstructorThrows.java
@@ -1,0 +1,16 @@
+import lombok.Builder;
+import java.io.IOException;
+
+@Builder
+public class BuilderWithDefaultAndConstructorThrows {
+	@Builder.Default
+	private final int value = 10;
+
+	@Builder
+	public BuilderWithDefaultAndConstructorThrows(int value) throws IOException {
+		if (value > 100) {
+			throw new IOException("value too large");
+		}
+		this.value = value;
+	}
+}


### PR DESCRIPTION
Currently, if the constructor throws a checked exception then `@Builder` must be on the constructor in order for the checked exception to propagate to the throws clause of the `builder()` method. However, `@Builder.Default` requires that the `@Builder` annotation be set on the class. It is possible to annotate both the class and the constructor, but then the constructor one gets skipped. This means it is currently impossible to use `@Builder.Default` simultaneously with a throwing constructor (except perhaps by manually implementing the `builder()` method), as demonstrated by the tests added in commit d905be5.

This attempts to fix that. If you set `@Builder` on both the class and the constructor, the constructor's checked exceptions will now be added to the `builder()` method initially generated by the class annotation. I have also verified that this works in the real-world context where I encountered the issue.