### PR TITLE
Fix "Use modifier 'final' where possible" cleanup

### DIFF
--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -419,6 +419,7 @@ final class PatchFixesHider {
 			
 			String className = visitor.getClass().getName();
 			if (!(className.startsWith("org.eclipse.jdt.internal.corext.fix") || className.startsWith("org.eclipse.jdt.internal.ui.fix"))) return false;
+			if (className.equals("org.eclipse.jdt.internal.corext.fix.VariableDeclarationFixCore$WrittenNamesFinder")) return false;
 			
 			boolean result = false;
 			try {


### PR DESCRIPTION
This PR fixes #2926

The "Use modifier 'final' where possible" cleanup have to find the generated setter to properly detect that there is something that can modify the varaible. I also checked the other cleanups and it seems like this one is the only one that needs this exception.