### PR TITLE
Keep record compact constructor parameters

### DIFF
--- a/src/core/lombok/javac/handlers/HandleNonNull.java
+++ b/src/core/lombok/javac/handlers/HandleNonNull.java
@@ -99,7 +99,6 @@ public class HandleNonNull extends JavacAnnotationHandler<NonNull> {
 			return recursiveSetGeneratedBy(constr, source);
 		} else {
 			existingCtr.mods = mods;
-			existingCtr.params = params.toList();
 			existingCtr.body = body;
 			existingCtr = recursiveSetGeneratedBy(existingCtr, source);
 			addSuppressWarningsAll(existingCtr.mods, typeNode, typeNode.getNodeFor(getGeneratedBy(existingCtr)), typeNode.getContext());

--- a/src/delombok/lombok/delombok/Delombok.java
+++ b/src/delombok/lombok/delombok/Delombok.java
@@ -43,9 +43,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -733,7 +733,7 @@ public class Delombok {
 		List<JCCompilationUnit> roots = new ArrayList<JCCompilationUnit>();
 		Map<JCCompilationUnit, File> baseMap = new IdentityHashMap<JCCompilationUnit, File>();
 		
-		Set<AbstractProcessor> processors = new HashSet<AbstractProcessor>();
+		Set<AbstractProcessor> processors = new LinkedHashSet<AbstractProcessor>();
 		processors.add(new lombok.javac.apt.LombokProcessor());
 		processors.addAll(additionalAnnotationProcessors);
 		

--- a/test/core/src/lombok/RunTestsViaDelombok.java
+++ b/test/core/src/lombok/RunTestsViaDelombok.java
@@ -42,7 +42,6 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 
 import com.sun.source.util.TreePath;
@@ -211,8 +210,8 @@ public class RunTestsViaDelombok extends AbstractRunTests {
 				}
 				
 				@Override public void visitVarDef(JCVariableDecl tree) {
-					// Skip non-field variables
-					if (!(parent instanceof JCClassDecl)) return;
+					// Skip local variables
+					if (!(parent instanceof JCClassDecl || parent instanceof JCMethodDecl)) return;
 					
 					validateSymbol(tree, tree.sym);
 					super.visitVarDef(tree);
@@ -222,8 +221,8 @@ public class RunTestsViaDelombok extends AbstractRunTests {
 					if (sym == null) {
 						fail("Missing symbol for " + tree);
 					}
-					// Skip top level classes
-					if (sym.owner.getKind() == ElementKind.PACKAGE) return;
+					// Only classes have enclosed elements, skip everything else
+					if (!sym.owner.getKind().isClass()) return;
 					
 					if (!sym.owner.getEnclosedElements().contains(sym)) {
 						fail(tree + " not added to parent");


### PR DESCRIPTION
This PR fixes #2907

We can simply keep the parameters of the constructor to also keep the symbols.
I also adjusted the automatic symbol check to catch problems like this one.