### PR TITLE
Move 'val' -> 'final var' code to patch method

### DIFF
--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -2052,11 +2052,7 @@ public class EclipseHandlerUtil {
 		}
 		
 		int pS = source.sourceStart, pE = source.sourceEnd;
-		long p = (long)pS << 32 | pE;
-		long[] poss = new long[annotationTypeFqn.length];
-		Arrays.fill(poss, p);
-		QualifiedTypeReference qualifiedType = new QualifiedTypeReference(annotationTypeFqn, poss);
-		setGeneratedBy(qualifiedType, source);
+		TypeReference qualifiedType = generateQualifiedTypeRef(source, annotationTypeFqn);
 		Annotation ann;
 		if (args != null && args.length == 1 && args[0] instanceof Expression) {
 			SingleMemberAnnotation sma = new SingleMemberAnnotation(qualifiedType, pS);

--- a/src/core/lombok/eclipse/handlers/HandleVal.java
+++ b/src/core/lombok/eclipse/handlers/HandleVal.java
@@ -22,14 +22,13 @@
 package lombok.eclipse.handlers;
 
 import static lombok.core.handlers.HandlerUtil.handleFlagUsage;
-import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
+import static lombok.eclipse.handlers.EclipseHandlerUtil.typeMatches;
 
 import lombok.ConfigurationKeys;
 import lombok.val;
 import lombok.var;
 import lombok.core.HandlerPriority;
 import lombok.eclipse.DeferUntilPostDiet;
-import lombok.eclipse.Eclipse;
 import lombok.eclipse.EclipseASTAdapter;
 import lombok.eclipse.EclipseASTVisitor;
 import lombok.eclipse.EclipseNode;
@@ -41,13 +40,10 @@ import org.eclipse.jdt.internal.compiler.ast.ForStatement;
 import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 import org.eclipse.jdt.internal.compiler.ast.LocalDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.NullLiteral;
-import org.eclipse.jdt.internal.compiler.ast.SingleTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 
 /*
- * Java 1-9: This class just handles 3 basic error cases. The real meat of eclipse 'val' support is in {@code PatchVal} and {@code PatchValEclipse}.
- * Java 10+: Lombok uses the native 'var' support and transforms 'val' to 'final var'.
+ * This class just handles 3 basic error cases. The real meat of eclipse 'val' support is in {@code PatchVal} and {@code PatchValEclipse}
  */
 @Provides(EclipseASTVisitor.class)
 @DeferUntilPostDiet
@@ -99,17 +95,6 @@ public class HandleVal extends EclipseASTAdapter {
 		
 		if(isVar && local.initialization instanceof NullLiteral) {
 			localNode.addError("variable initializer is 'null'");
-			return;
-		}
-		
-		// For Java >= 10 we use native support
-		if (localNode.getSourceVersion() >= 10) {
-			if (isVal) {
-				TypeReference originalType = local.type;
-				local.type = new SingleTypeReference("var".toCharArray(), Eclipse.pos(local.type));
-				local.modifiers |= ClassFileConstants.AccFinal;
-				local.annotations = addAnnotation(local.type, local.annotations, originalType.getTypeName());
-			}
 			return;
 		}
 	}

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchVal.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchVal.java
@@ -59,8 +59,8 @@ import org.eclipse.jdt.internal.compiler.problem.AbortCompilation;
 import java.lang.reflect.Field;
 
 import static lombok.Lombok.sneakyThrow;
-import static lombok.eclipse.Eclipse.poss;
-import static lombok.eclipse.handlers.EclipseHandlerUtil.makeType;
+import static lombok.eclipse.Eclipse.*;
+import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
 import static org.eclipse.jdt.core.compiler.CategorizedProblem.CAT_TYPE;
 
 public class PatchVal {
@@ -204,8 +204,6 @@ public class PatchVal {
 		boolean var = isVar(local, scope);
 		if (!(val || var)) return false;
 		
-		if (hasNativeVarSupport(scope)) return false;
-		
 		if (val) {
 			StackTraceElement[] st = new Throwable().getStackTrace();
 			for (int i = 0; i < st.length - 2 && i < 10; i++) {
@@ -238,6 +236,13 @@ public class PatchVal {
 		}
 		
 		TypeReference replacement = null;
+		
+		// Java 10+: Lombok uses the native 'var' support and transforms 'val' to 'final var'.
+		if (hasNativeVarSupport(scope) && val) {
+			replacement = new SingleTypeReference("var".toCharArray(), pos(local.type));
+			local.initialization = init;
+			init = null;
+		}
 		
 		if (init != null) {
 			if (init.getClass().getName().equals("org.eclipse.jdt.internal.compiler.ast.LambdaExpression")) {

--- a/test/transform/resource/before/ValAnonymousSubclassSelfReference.java
+++ b/test/transform/resource/before/ValAnonymousSubclassSelfReference.java
@@ -1,3 +1,4 @@
+// version :9
 // issue 2420: to trigger the problem 2 var/val, at least one normal variable and a anonymous self reference is required
 import java.util.Map;
 import java.util.HashMap;


### PR DESCRIPTION
This PR fixes #2972

The original bug was fixed by generating a `SingleTypeReference` instead of a `QualifiedTypeReference`. After that I noticed that the code completion is broken for `val`. This could be fixed by reusing the original patch code and move the new stuff to the patch part.