### PR TITLE
Add syntax highlighting and javadoc to language server (VSCode)

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -892,6 +892,14 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 				.requestExtra(StackRequest.PARAM1)
 				.build());
 		
+		/* This is a copy for the language server implementation that also supports markdown */
+		sm.addScript(ScriptBuilder.wrapMethodCall()
+				.target(new MethodTarget("org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess2", "getHTMLContent", "java.lang.String", "org.eclipse.jdt.core.IJavaElement", "boolean"))
+				.methodToWrap(new Hook("org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess2", "getHTMLContentFromSource", "java.lang.String", "org.eclipse.jdt.core.IJavaElement"))
+				.wrapMethod(new Hook("lombok.launch.PatchFixesHider$Javadoc", "getHTMLContentFromSource", "java.lang.String", "java.lang.String", "org.eclipse.jdt.core.IJavaElement"))
+				.requestExtra(StackRequest.PARAM1)
+				.build());
+		
 		/* This is an older version that uses IMember instead of IJavaElement */
 		sm.addScriptIfWitness(OSGI_TYPES, ScriptBuilder.wrapMethodCall()
 				.target(new MethodTarget("org.eclipse.jdt.internal.ui.text.javadoc.JavadocContentAccess2", "getHTMLContent", "java.lang.String", "org.eclipse.jdt.core.IMember", "boolean"))

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchJavadoc.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchJavadoc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 The Project Lombok Authors.
+ * Copyright (C) 2020-2021 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -103,8 +103,9 @@ public class PatchJavadoc {
 	private static class Reflection {
 		private static final Method javadoc2HTML;
 		private static final Method oldJavadoc2HTML;
+		private static final Method lsJavadoc2HTML;
 		static {
-			Method a = null, b = null;
+			Method a = null, b = null, c = null;
 			
 			try {
 				a = Permit.getMethod(JavadocContentAccess2.class, "javadoc2HTML", IMember.class, IJavaElement.class, String.class);
@@ -112,15 +113,26 @@ public class PatchJavadoc {
 			try {
 				b = Permit.getMethod(JavadocContentAccess2.class, "javadoc2HTML", IMember.class, String.class);
 			} catch (Throwable t) {}
+			try {
+				c = Permit.getMethod(Class.forName("org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess2"), "javadoc2HTML", IMember.class, IJavaElement.class, String.class);
+			} catch (Throwable t) {}
 			
 			javadoc2HTML = a;
 			oldJavadoc2HTML = b;
+			lsJavadoc2HTML = c;
 		}
 		
 		private static String javadoc2HTML(IMember member, IJavaElement element, String rawJavadoc) {
 			if (javadoc2HTML != null) {
 				try {
 					return (String) javadoc2HTML.invoke(null, member, element, rawJavadoc);
+				} catch (Throwable t) {
+					return null;
+				}
+			}
+			if (lsJavadoc2HTML != null) {
+				try {
+					return (String) lsJavadoc2HTML.invoke(null, member, element, rawJavadoc);
 				} catch (Throwable t) {
 					return null;
 				}

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -414,23 +414,14 @@ final class PatchFixesHider {
 			return result;
 		}
 		
-		public static boolean isRefactoringVisitorAndGenerated(org.eclipse.jdt.core.dom.ASTNode node, org.eclipse.jdt.core.dom.ASTVisitor visitor) {
+		public static boolean isBlockedVisitorAndGenerated(org.eclipse.jdt.core.dom.ASTNode node, org.eclipse.jdt.core.dom.ASTVisitor visitor) {
 			if (visitor == null) return false;
 			
 			String className = visitor.getClass().getName();
-			if (!(className.startsWith("org.eclipse.jdt.internal.corext.fix") || className.startsWith("org.eclipse.jdt.internal.ui.fix"))) return false;
+			if (!(className.startsWith("org.eclipse.jdt.internal.corext.fix") || className.startsWith("org.eclipse.jdt.internal.ui.fix") || className.startsWith("org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokensVisitor"))) return false;
 			if (className.equals("org.eclipse.jdt.internal.corext.fix.VariableDeclarationFixCore$WrittenNamesFinder")) return false;
 			
-			boolean result = false;
-			try {
-				result = ((Boolean)node.getClass().getField("$isGenerated").get(node)).booleanValue();
-				if (!result && node.getParent() != null && node.getParent() instanceof org.eclipse.jdt.core.dom.QualifiedName) {
-					result = isGenerated(node.getParent());
-				}
-			} catch (Exception e) {
-				// better to assume it isn't generated
-			}
-			return result;
+			return isGenerated(node);
 		}
 		
 		public static boolean isListRewriteOnGeneratedNode(org.eclipse.jdt.core.dom.rewrite.ListRewrite rewrite) {


### PR DESCRIPTION
This PR fixes #2950

For the syntax highlighting I added the language server `SemanticTokensVisitor` to hide generated lombok nodes. I also renamed the patch method because it now handles more things than only refactorings.

To fix the javadoc I added patches for the language server copy of `JavadocContentAccess2`, they modified it to also support markdown. I also had to add some reflection code to call `CompilationUnit::originalFromClone` because the language server implementation uses a working copy for compilation and the original compilation unit to resolve the comments.