### PR TITLE
Fix syntax highlighting for EqualsAndHashCode

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -199,6 +199,7 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 				.target(new MethodTarget("org.eclipse.jdt.internal.ui.search.OccurrencesFinder", "addUsage"))
 				.target(new MethodTarget("org.eclipse.jdt.internal.ui.search.OccurrencesFinder", "addWrite"))
 				.target(new MethodTarget("org.eclipse.jdt.internal.ui.javaeditor.SemanticHighlightingReconciler$PositionCollector", "visit", "boolean", "org.eclipse.jdt.core.dom.SimpleName"))
+				.target(new MethodTarget("org.eclipse.jdt.internal.ui.javaeditor.SemanticHighlightingReconciler$PositionCollector", "visitLiteral", "boolean", "org.eclipse.jdt.core.dom.Expression"))
 				.decisionMethod(new Hook("lombok.launch.PatchFixesHider$PatchFixes", "isGenerated", "boolean", "org.eclipse.jdt.core.dom.ASTNode"))
 				.valueMethod(new Hook("lombok.launch.PatchFixesHider$PatchFixes", "returnFalse", "boolean", "java.lang.Object"))
 				.request(StackRequest.PARAM1)


### PR DESCRIPTION
This might be related to #2509

**Without the fix:** 
`@EqualsAndHashCode` is blue 
![img1](https://user-images.githubusercontent.com/5850477/136157878-4dfe26ea-1d47-474c-85aa-cfabcd473c11.png)
After adding a new line half of the class looses its highlighting
![img2](https://user-images.githubusercontent.com/5850477/136157947-7d80f09b-89b6-4d6a-8193-06319308a4c7.png)

**After the fix:**
![img3](https://user-images.githubusercontent.com/5850477/136158161-41d76694-2b17-4f96-96c7-1081ef01c3d4.png)