### PR TITLE
Resolve var/val only once in eclipse

### DIFF
--- a/buildScripts/tests.ant.xml
+++ b/buildScripts/tests.ant.xml
@@ -152,13 +152,18 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 	
 	<macrodef name="test.eclipse-X">
 		<attribute name="version" />
+		<attribute name="compiler.compliance.level" default="latest" />
 		<sequential>
-			<echo>Running TestEclipse on eclipse-@{version} on JVM${ant.java.version}.</echo>
+			<condition property="compiler.compliance.level" value="-Dcompiler.compliance.level=@{compiler.compliance.level}" else="-Dnot=set">
+				<not><equals arg1="@{compiler.compliance.level}" arg2="latest" /></not>
+			</condition>
+			<echo>Running TestEclipse on eclipse-@{version} on JVM${ant.java.version} using. Compiler compliance level: @{compiler.compliance.level}</echo>
 			<junit haltonfailure="yes" fork="true" forkmode="once">
 				<formatter classname="lombok.ant.SimpleTestFormatter" usefile="false" unless="tests.quiet" />
 				<jvmarg value="-Xbootclasspath/a:${jdk8-rt.loc}" />
 				<jvmarg value="-Ddelombok.bootclasspath=${jdk8-rt.loc}" />
 				<jvmarg value="-javaagent:dist/lombok.jar" />
+				<jvmarg value="${compiler.compliance.level}" />
 				<classpath location="build/ant" />
 				<classpath refid="cp.test" />
 				<classpath refid="cp.stripe" />
@@ -175,9 +180,14 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 		<test.eclipse-X version="oxygen" />
 	</target>
 	
-	<target name="test.eclipse-202006" depends="test.formatter.compile, test.compile" description="runs the tests on your default VM, testing the 2020-03 release of eclipse">
+	<target name="test.eclipse-202006" depends="test.formatter.compile, test.compile" description="runs the tests on your default VM, testing the 2020-06 release of eclipse">
 		<fetchdep.eclipse version="202006" />
 		<test.eclipse-X version="202006" />
+	</target>
+	
+	<target name="test.eclipse-202006-jdk8" depends="test.formatter.compile, test.compile" description="runs the tests on your default VM, testing the 2020-06 release of eclipse with compiler compliance level 8">
+		<fetchdep.eclipse version="202006" />
+		<test.eclipse-X version="202006" compiler.compliance.level="8" />
 	</target>
 	
 	<macrodef name="test.ecj-X">
@@ -217,5 +227,5 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 	</target>
 	
 	<target name="test" depends="test.javacCurrent, test.eclipse-202006" description="runs the tests against the default JVM, javac, and eclipse" />
-	<target name="test.broad" depends="test.javac8, test.javac14, test.eclipse-oxygen, test.eclipse-202006" description="runs the tests against the default JVM, javac, and eclipse" />
+	<target name="test.broad" depends="test.javac8, test.javac14, test.eclipse-oxygen, test.eclipse-202006, test.eclipse-202006-jdk8" description="runs the tests against the default JVM, javac, and eclipse" />
 </project>

--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -764,6 +764,7 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 		
 		sm.addScript(ScriptBuilder.replaceMethodCall()
 				.target(new MethodTarget(LOCALDECLARATION_SIG, "resolve", "void", BLOCKSCOPE_SIG))
+				.target(new MethodTarget(LOCALDECLARATION_SIG, "resolve", "void", BLOCKSCOPE_SIG, "boolean"))
 				.methodToReplace(new Hook(EXPRESSION_SIG, "resolveType", TYPEBINDING_SIG, BLOCKSCOPE_SIG))
 				.requestExtra(StackRequest.THIS)
 				.replacementMethod(new Hook("lombok.launch.PatchFixesHider$Val", "skipResolveInitializerIfAlreadyCalled2", TYPEBINDING_SIG, EXPRESSION_SIG, BLOCKSCOPE_SIG, LOCALDECLARATION_SIG))

--- a/test/core/src/lombok/DirectoryRunner.java
+++ b/test/core/src/lombok/DirectoryRunner.java
@@ -55,7 +55,8 @@ public class DirectoryRunner extends Runner {
 		},
 		ECJ {
 			@Override public int getVersion() {
-				return Eclipse.getEcjCompilerVersion();
+				String javaVersionString = System.getProperty("compiler.compliance.level");
+				return javaVersionString != null ? Integer.parseInt(javaVersionString) : Eclipse.getEcjCompilerVersion();
 			}
 		};
 		

--- a/test/transform/resource/after-delombok/ValInvalidParameter.java
+++ b/test/transform/resource/after-delombok/ValInvalidParameter.java
@@ -1,0 +1,29 @@
+public class ValInvalidParameter {
+	public void val() {
+		final java.lang.Object a = a(new NonExistingClass());
+		final java.lang.Object b = a(a(new NonExistingClass()));
+		final java.lang.Object c = nonExisitingMethod(b(1));
+		final java.lang.Object d = nonExistingObject.nonExistingMethod();
+		final java.lang.Object e = b(1).nonExistingMethod();
+		final java.lang.Object f = 1 > 2 ? a(new NonExistingClass()) : a(new NonExistingClass());
+		final java.lang.Object g = b2(1);
+		final java.lang.Integer h = b2(a("a"), a(null));
+		final int i = a(a(null));
+	}
+
+	public int a(String param) {
+		return 0;
+	}
+
+	public int a(Integer param) {
+		return 0;
+	}
+
+	public Integer b(int i) {
+		return i;
+	}
+
+	public Integer b2(int i, int j) {
+		return i;
+	}
+}

--- a/test/transform/resource/after-ecj/ValErrors.java
+++ b/test/transform/resource/after-ecj/ValErrors.java
@@ -4,9 +4,9 @@ public class ValErrors {
     super();
   }
   public void unresolvableExpression() {
-    val c = d;
+    final @val java.lang.Object c = d;
   }
   public void arrayInitializer() {
-    val e = {"foo", "bar"};
+    final @val java.lang.Object e = {"foo", "bar"};
   }
 }

--- a/test/transform/resource/after-ecj/ValInvalidParameter.java
+++ b/test/transform/resource/after-ecj/ValInvalidParameter.java
@@ -1,0 +1,29 @@
+import lombok.val;
+public class ValInvalidParameter {
+  public ValInvalidParameter() {
+    super();
+  }
+  public void val() {
+    final @val java.lang.Object a = a(new NonExistingClass());
+    final @val java.lang.Object b = a(a(new NonExistingClass()));
+    final @val java.lang.Object c = nonExisitingMethod(b(1));
+    final @val java.lang.Object d = nonExistingObject.nonExistingMethod();
+    final @val java.lang.Object e = b(1).nonExistingMethod();
+    final @val java.lang.Object f = ((1 > 2) ? a(new NonExistingClass()) : a(new NonExistingClass()));
+    final @val java.lang.Object g = b2(1);
+    final @val java.lang.Object h = b2(a("a"), a(null));
+    final @val java.lang.Object i = a(a(null));
+  }
+  public int a(String param) {
+    return 0;
+  }
+  public int a(Integer param) {
+    return 0;
+  }
+  public Integer b(int i) {
+    return i;
+  }
+  public Integer b2(int i, int j) {
+    return i;
+  }
+}

--- a/test/transform/resource/before/ValInvalidParameter.java
+++ b/test/transform/resource/before/ValInvalidParameter.java
@@ -1,0 +1,32 @@
+//version :9
+import lombok.val;
+
+public class ValInvalidParameter {
+	public void val() {
+		val a = a(new NonExistingClass());
+		val b = a(a(new NonExistingClass()));
+		val c = nonExisitingMethod(b(1));
+		val d = nonExistingObject.nonExistingMethod();
+		val e = b(1).nonExistingMethod();
+		val f = 1 > 2 ? a(new NonExistingClass()) : a(new NonExistingClass());
+		val g = b2(1);
+		val h = b2(a("a"), a(null));
+		val i = a(a(null));
+	}
+	
+	public int a(String param) {
+		return 0;
+	}
+	
+	public int a(Integer param) {
+		return 0;
+	}
+	
+	public Integer b(int i) {
+		return i;
+	}
+	
+	public Integer b2(int i, int j) {
+		return i;
+	}
+}

--- a/test/transform/resource/messages-delombok/ValInvalidParameter.java.messages
+++ b/test/transform/resource/messages-delombok/ValInvalidParameter.java.messages
@@ -1,0 +1,1 @@
+12 Cannot use 'val' here because initializer expression does not have a representable type: Type cannot be resolved

--- a/test/transform/resource/messages-ecj/ValErrors.java.messages
+++ b/test/transform/resource/messages-ecj/ValErrors.java.messages
@@ -1,2 +1,4 @@
-6 d cannot be resolved to a variable
-10 'val' is not compatible with array initializer expressions. Use the full form (new int[] { ... } instead of just { ... })
+7 d cannot be resolved to a variable
+7 d cannot be resolved or is not a field
+11 'val' is not compatible with array initializer expressions. Use the full form (new int[] { ... } instead of just { ... })
+11 Type mismatch: cannot convert from String[] to Object

--- a/test/transform/resource/messages-ecj/ValInBasicFor.java.messages
+++ b/test/transform/resource/messages-ecj/ValInBasicFor.java.messages
@@ -1,2 +1,4 @@
-7 'val' is not allowed in old-style for loops
-7 Type mismatch: cannot convert from int to val
+8 'val' is not allowed in old-style for loops
+8 Type mismatch: cannot convert from int to val
+8 Type mismatch: cannot convert from String to val
+8 Type mismatch: cannot convert from double to val

--- a/test/transform/resource/messages-ecj/ValInvalidParameter.java.messages
+++ b/test/transform/resource/messages-ecj/ValInvalidParameter.java.messages
@@ -1,0 +1,9 @@
+5 NonExistingClass cannot be resolved to a type
+6 NonExistingClass cannot be resolved to a type
+7 The method nonExisitingMethod(Integer) is undefined for the type ValInvalidParameter
+8 nonExistingObject cannot be resolved
+9 The method nonExistingMethod() is undefined for the type Integer
+10 NonExistingClass cannot be resolved to a type
+11 The method b2(int, int) in the type ValInvalidParameter is not applicable for the arguments (int)
+12 The method a(String) is ambiguous for the type ValInvalidParameter
+13 The method a(String) is ambiguous for the type ValInvalidParameter

--- a/test/transform/resource/messages-idempotent/ValInvalidParameter.java.messages
+++ b/test/transform/resource/messages-idempotent/ValInvalidParameter.java.messages
@@ -1,0 +1,9 @@
+3 cannot find symbol
+4 cannot find symbol
+5 cannot find symbol
+6 cannot find symbol
+7 cannot find symbol
+8 cannot find symbol
+9 method b2 in class ValInvalidParameter cannot be applied to given types;
+10 reference to a is ambiguous
+11 reference to a is ambiguous


### PR DESCRIPTION
This PR fixes #2985

The actual problem was the changed method signature of `LocalDeclaration::resolve`. I also changed the ecj test system to set a lower java version than the maximum supported one. This is something that happens a lot in real world usage e.g. current eclipse but java 8 project and is required to test the < java 10 `val` code. I also updated the tests to no longer stop if an error occours to trigger the reported bug. This also revealed another bug related to conditional expressions (eclipse does not throw an AbortCompilation during normal compilation)