### PR TITLE
Skip records for field defaults via config

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleFieldDefaults.java
+++ b/src/core/lombok/eclipse/handlers/HandleFieldDefaults.java
@@ -160,6 +160,8 @@ public class HandleFieldDefaults extends EclipseASTAdapter {
 		boolean defaultToFinal = makeFinalIsExplicit ? false : Boolean.TRUE.equals(typeNode.getAst().readConfiguration(ConfigurationKeys.FIELD_DEFAULTS_FINAL_EVERYWHERE));
 		
 		if (!defaultToPrivate && !defaultToFinal && fieldDefaults == null) return;
+		// Do not apply field defaults to records if set using the the config system
+		if (fieldDefaults == null && !isClassOrEnum(typeNode)) return;
 		AccessLevel fdAccessLevel = (fieldDefaults != null && levelIsExplicit) ? fd.level() : defaultToPrivate ? AccessLevel.PRIVATE : null;
 		boolean fdToFinal = (fieldDefaults != null && makeFinalIsExplicit) ? fd.makeFinal() : defaultToFinal;
 		

--- a/src/core/lombok/javac/handlers/HandleFieldDefaults.java
+++ b/src/core/lombok/javac/handlers/HandleFieldDefaults.java
@@ -140,6 +140,8 @@ public class HandleFieldDefaults extends JavacASTAdapter {
 		boolean defaultToFinal = makeFinalIsExplicit ? false : Boolean.TRUE.equals(typeNode.getAst().readConfiguration(ConfigurationKeys.FIELD_DEFAULTS_FINAL_EVERYWHERE));
 		
 		if (!defaultToPrivate && !defaultToFinal && fieldDefaults == null) return;
+		// Do not apply field defaults to records if set using the the config system
+		if (fieldDefaults == null && !isClassOrEnum(typeNode)) return;
 		AccessLevel fdAccessLevel = (fieldDefaults != null && levelIsExplicit) ? fd.level() : defaultToPrivate ? AccessLevel.PRIVATE : null;
 		boolean fdToFinal = (fieldDefaults != null && makeFinalIsExplicit) ? fd.makeFinal() : defaultToFinal;
 		

--- a/test/transform/resource/after-delombok/FieldDefaultsViaConfigOnRecord.java
+++ b/test/transform/resource/after-delombok/FieldDefaultsViaConfigOnRecord.java
@@ -1,0 +1,3 @@
+// version 14:
+public record FieldDefaultsViaConfigOnRecord(String a, String b) {
+}

--- a/test/transform/resource/after-ecj/FieldDefaultsViaConfigOnRecord.java
+++ b/test/transform/resource/after-ecj/FieldDefaultsViaConfigOnRecord.java
@@ -1,0 +1,10 @@
+// version 14:
+public record FieldDefaultsViaConfigOnRecord(String a, String b) {
+/* Implicit */  private final String a;
+/* Implicit */  private final String b;
+  public FieldDefaultsViaConfigOnRecord(String a, String b) {
+    super();
+    .a = a;
+    .b = b;
+  }
+}

--- a/test/transform/resource/before/FieldDefaultsViaConfigOnRecord.java
+++ b/test/transform/resource/before/FieldDefaultsViaConfigOnRecord.java
@@ -1,0 +1,7 @@
+// version 14:
+//CONF: lombok.fieldDefaults.defaultFinal = true
+//CONF: lombok.fieldDefaults.defaultPrivate = true
+//unchanged
+
+public record FieldDefaultsViaConfigOnRecord(String a, String b) {
+}


### PR DESCRIPTION
This PR fixes #2995

Lombok now skips the type if there is no annotation and it is not a class or enum.