### PR TITLE
Generate new type reference for val marker annotation

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/PatchVal.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchVal.java
@@ -359,7 +359,8 @@ public class PatchVal {
 			newAnn = new Annotation[1];
 		}
 		
-		newAnn[newAnn.length - 1] = new org.eclipse.jdt.internal.compiler.ast.MarkerAnnotation(originalRef, originalRef.sourceStart);
+		TypeReference qualifiedTypeRef = generateQualifiedTypeRef(originalRef, originalRef.getTypeName());
+		newAnn[newAnn.length - 1] = new org.eclipse.jdt.internal.compiler.ast.MarkerAnnotation(qualifiedTypeRef, qualifiedTypeRef.sourceStart);
 		
 		return newAnn;
 	}


### PR DESCRIPTION
This PR fixes #3000

Lombok now generates a new type reference for the `val` marker annotation.