### PR TITLE
Added implementation for FxProperty

### DIFF
--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -678,6 +678,15 @@ public class ConfigurationKeys {
 	 */
 	public static final ConfigurationKey<FlagUsageType> JACKSONIZED_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.jacksonized.flagUsage", "Emit a warning or error if @Jacksonized is used.") {};
 	
+	// ----- FxProperty -----
+	
+	/**
+	 * lombok configuration: {@code lombok.fxproperty.flagUsage} = {@code WARNING} | {@code ERROR}.
+	 * 
+	 * If set, <em>any</em> usage of {@code @FxProperty} results in a warning / error.
+	 */
+	public static final ConfigurationKey<FlagUsageType> FXPROPERTY_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.fxproperty.flagUsage", "Emit a warning or error if @FxProperty is used.") {};
+	
 	// ----- Configuration System -----
 	
 	/**

--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -564,6 +564,18 @@ public class HandlerUtil {
 	}
 	
 	/**
+	 * Generates a property name from a given field name.
+	 * 
+	 * Strategy: Take the field name and append {@code "Property"} at the end.
+	 * 
+	 * @param fieldName the name of the field.
+	 * @return The property name for this field.
+	 */
+	public static String toPropertyName(CharSequence fieldName) {
+		return fieldName + "Property";
+	}
+	
+	/**
 	 * Generates a withBy name from a given field name.
 	 * 
 	 * Strategy: The same as the {@code toWithName} strategy, but then append {@code "By"} at the end.

--- a/src/core/lombok/eclipse/handlers/HandleFxProperty.java
+++ b/src/core/lombok/eclipse/handlers/HandleFxProperty.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (C) 2020-2021 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.eclipse.handlers;
+
+import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.eclipse.Eclipse.ECLIPSE_DO_NOT_TOUCH_FLAG;
+import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
+
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.eclipse.jdt.internal.compiler.ast.Annotation;
+import org.eclipse.jdt.internal.compiler.ast.Argument;
+import org.eclipse.jdt.internal.compiler.ast.Expression;
+import org.eclipse.jdt.internal.compiler.ast.FieldDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.MessageSend;
+import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.NameReference;
+import org.eclipse.jdt.internal.compiler.ast.ParameterizedQualifiedTypeReference;
+import org.eclipse.jdt.internal.compiler.ast.ReturnStatement;
+import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;
+import org.eclipse.jdt.internal.compiler.ast.Statement;
+import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.TypeReference;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
+
+import lombok.ConfigurationKeys;
+import lombok.core.AST.Kind;
+import lombok.core.AnnotationValues;
+import lombok.core.handlers.HandlerUtil.FieldAccess;
+import lombok.eclipse.Eclipse;
+import lombok.eclipse.EclipseAnnotationHandler;
+import lombok.eclipse.EclipseNode;
+import lombok.eclipse.handlers.EclipseHandlerUtil.MemberExistsResult;
+import lombok.extern.javafx.FxProperty;
+import lombok.spi.Provides;
+
+/**
+ * Handles the {@link FxProperty} annotation for eclipse.
+ */
+@Provides
+public class HandleFxProperty extends EclipseAnnotationHandler<FxProperty> {
+
+	@Override public void handle(AnnotationValues<FxProperty> annotation, Annotation ast, EclipseNode annotationNode) {
+		handleFlagUsage(annotationNode, ConfigurationKeys.FXPROPERTY_FLAG_USAGE, "@FxProperty");
+		
+		Collection<EclipseNode> fields = annotationNode.upFromAnnotationToFields();
+		EclipseNode node = annotationNode.up();
+		FxProperty annotationInstance = annotation.getInstance();
+		boolean readOnly = annotationInstance.readOnly();
+		
+		if (node == null) return;
+		
+		switch (node.getKind()) {
+		case FIELD:
+			createFxPropertyForFields(fields, annotationNode, readOnly);
+			break;
+		case TYPE:
+			createFxPropertyForType(node, annotationNode, readOnly);
+			break;
+		}
+	}
+	
+	private void createFxPropertyForType(EclipseNode typeNode, EclipseNode annotationNode, boolean readOnly) {
+		TypeDeclaration typeDecl = (TypeDeclaration) typeNode.get();
+		boolean notClassOrEnum = (typeDecl.modifiers & (ClassFileConstants.AccInterface | ClassFileConstants.AccAnnotation)) != 0;
+		if (notClassOrEnum) {
+			annotationNode.addError("@FxProperty is only supported on a class, an enum, or a field.");
+			return;
+		}
+		for (EclipseNode field : typeNode.down()) {
+			if (field.getKind() != Kind.FIELD) continue;
+			if (field.getName().startsWith("$")) continue;
+			
+			createFxPropertyForField(field, annotationNode, readOnly, false);
+		}
+	}
+
+	private void createFxPropertyForFields(Collection<EclipseNode> fields, EclipseNode annotationNode, boolean readOnly) {
+		for (EclipseNode field : fields) {
+			createFxPropertyForField(field, annotationNode, readOnly, true);
+		}
+	}
+
+	private void createFxPropertyForField(EclipseNode fieldNode, EclipseNode source, boolean readOnly, boolean whine) {
+		FieldDeclaration fieldDecl = (FieldDeclaration) fieldNode.get();
+		EclipseNode typeNode = upToTypeNode(fieldNode);
+		
+		FieldInfo fieldInfo = getFieldInfo(fieldNode, fieldDecl);
+		if (fieldInfo == null) {
+			if (whine) source.addError("@FxProperty is only supported on predefined JavaFx property types.");
+			return;
+		}
+		
+		addPropertyAccessor(fieldNode, source, typeNode, fieldInfo, readOnly);
+		addGetter(fieldNode, source, typeNode, fieldInfo);
+		addSetter(fieldNode, source, typeNode, fieldInfo, readOnly);
+	}
+
+	private void addGetter(EclipseNode fieldNode, EclipseNode source, EclipseNode typeNode, FieldInfo fieldInfo) {
+		String methodName = buildAccessorName(fieldNode, "get", fieldNode.getName());
+		if (methodExists(methodName, typeNode, 0) != MemberExistsResult.NOT_EXISTS) {
+			return;
+		}
+		
+		TypeDeclaration parent = (TypeDeclaration) upToTypeNode(fieldNode).get();
+		
+		MethodDeclaration method = createGetter(fieldNode, fieldInfo);
+		method.traverse(new SetGeneratedByVisitor(source.get()), parent.scope);
+		
+		injectMethod(typeNode, method);
+	}
+	
+	private void addSetter(EclipseNode fieldNode, EclipseNode source, EclipseNode typeNode, FieldInfo fieldInfo, boolean readOnly) {
+		if (fieldInfo.readOnly) return;
+		
+		String methodName = buildAccessorName(fieldNode, "set", fieldNode.getName());
+		if (methodExists(methodName, typeNode, 1) != MemberExistsResult.NOT_EXISTS) {
+			return;
+		}
+		
+		TypeDeclaration parent = (TypeDeclaration) upToTypeNode(fieldNode).get();
+		
+		MethodDeclaration method = createSetter(fieldNode, fieldInfo, readOnly);
+		method.traverse(new SetGeneratedByVisitor(source.get()), parent.scope);
+		
+		injectMethod(typeNode, method);
+	}
+	
+	private void addPropertyAccessor(EclipseNode fieldNode, EclipseNode source, EclipseNode typeNode, FieldInfo fieldInfo, boolean readOnly) {
+		String methodName = toPropertyName(fieldNode.getName());
+		if (methodExists(methodName, typeNode, 0) != MemberExistsResult.NOT_EXISTS) {
+			return;
+		}
+		
+		TypeDeclaration parent = (TypeDeclaration) upToTypeNode(fieldNode).get();
+		
+		MethodDeclaration method = createPropertyAccessor(fieldNode, fieldInfo, readOnly);
+		method.traverse(new SetGeneratedByVisitor(source.get()), parent.scope);
+		
+		injectMethod(typeNode, method);
+	}
+	
+
+	private MethodDeclaration createPropertyAccessor(EclipseNode fieldNode, FieldInfo fieldInfo, boolean readOnly) {
+		String methodName = toPropertyName(fieldNode.getName());
+		
+		TypeDeclaration parent = (TypeDeclaration) upToTypeNode(fieldNode).get();
+		
+		Expression fieldRef = createFieldAccessor(fieldNode, FieldAccess.ALWAYS_FIELD, null);
+		Statement returnStatement = new ReturnStatement(fieldRef, 0, 0);
+		
+		MethodDeclaration method = new MethodDeclaration(parent.compilationResult);
+		method.modifiers = ClassFileConstants.AccPublic;
+		method.returnType = fieldInfo.getPropertyType(readOnly);
+		method.selector = methodName.toCharArray();
+		method.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
+		method.statements = new Statement[] {returnStatement};
+		
+		return method;
+	}
+
+	private MethodDeclaration createSetter(EclipseNode fieldNode, FieldInfo fieldInfo, boolean readOnly) {
+		String methodName = buildAccessorName(fieldNode, "set", fieldNode.getName());
+		
+		TypeDeclaration parent = (TypeDeclaration) upToTypeNode(fieldNode).get();
+		
+		char[] paramName = fieldNode.getName().toCharArray();
+		Argument param = new Argument(paramName, 0, fieldInfo.getType(), Modifier.FINAL);
+		
+		Expression fieldRef = createFieldAccessor(fieldNode, FieldAccess.ALWAYS_FIELD, null);
+		NameReference fieldNameRef = new SingleNameReference(paramName, 0);
+		
+		MessageSend set = new MessageSend();
+		set.receiver = fieldRef;
+		set.selector = "set".toCharArray();
+		set.arguments = new Expression [] {fieldNameRef};
+		
+		MethodDeclaration method = new MethodDeclaration(parent.compilationResult);
+		method.modifiers = ClassFileConstants.AccFinal | (readOnly ? ClassFileConstants.AccPrivate : ClassFileConstants.AccPublic);
+		method.returnType = TypeReference.baseTypeReference(TypeIds.T_void, 0);
+		method.selector = methodName.toCharArray();
+		method.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
+		method.arguments = new Argument[] {param};
+		method.statements = new Statement[] {set};
+		
+		return method;
+	}
+
+	private MethodDeclaration createGetter(EclipseNode fieldNode, FieldInfo fieldInfo) {
+		String methodName = buildAccessorName(fieldNode, "get", fieldNode.getName());
+		
+		TypeDeclaration parent = (TypeDeclaration) upToTypeNode(fieldNode).get();
+		
+		Expression fieldRef = createFieldAccessor(fieldNode, FieldAccess.ALWAYS_FIELD, null);
+		
+		MessageSend get = new MessageSend();
+		get.receiver = fieldRef;
+		get.selector = "get".toCharArray();
+		
+		Statement returnStatement = new ReturnStatement(get, 0, 0);
+		
+		MethodDeclaration method = new MethodDeclaration(parent.compilationResult);
+		method.modifiers = ClassFileConstants.AccPublic | ClassFileConstants.AccFinal;
+		method.returnType = fieldInfo.getType();
+		method.selector = methodName.toCharArray();
+		method.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
+		method.statements = new Statement[] {returnStatement};
+		
+		return method;
+	}
+	
+	static class FieldInfo {
+		EclipseNode fieldNode;
+		String propertyType;
+		String returnType;
+		boolean readOnly;
+		private TypeReference[] typeArguments;
+
+		FieldInfo(EclipseNode fieldNode, String propertyType, String returnType) {
+			this.fieldNode = fieldNode;
+			this.propertyType = propertyType;
+			this.returnType = returnType;
+			this.readOnly = propertyType.contains("ReadOnly");
+		}
+		
+		FieldInfo(EclipseNode fieldNode, String propertyType, String returnType, TypeReference[] typeArguments) {
+			this(fieldNode, propertyType, returnType);
+			this.typeArguments = typeArguments;
+		}
+		
+		TypeReference getType() {
+			Integer primitiveType = PRIMITIVE_TYPE_MAP.get(returnType);
+			if (primitiveType != null) {
+				return TypeReference.baseTypeReference(primitiveType, 0);
+			}
+			
+			if (returnType.endsWith("Object")) {
+				return copyType(typeArguments[0]);
+			}
+			
+			char[][] qualifiedName = Eclipse.fromQualifiedName(returnType);
+			if (typeArguments == null) {
+				return generateQualifiedTypeRef(fieldNode.get(), qualifiedName);
+			}
+			
+			long[] p = Eclipse.poss(fieldNode.get(), qualifiedName.length);
+			TypeReference[][] rr = new TypeReference[qualifiedName.length][];
+			rr[rr.length - 1] = copyTypes(typeArguments, fieldNode.get());
+			return new ParameterizedQualifiedTypeReference(qualifiedName, rr, 0, p);
+		}
+		
+		TypeReference getPropertyType(boolean asReadOnly) {
+			String type = propertyType;
+			if (asReadOnly && !readOnly) {
+				type = "javafx.beans.property.ReadOnly" + propertyType.substring(22);
+			}
+			char[][] qualifiedName = Eclipse.fromQualifiedName(type);
+			if (typeArguments == null) {
+				return generateQualifiedTypeRef(fieldNode.get(), qualifiedName);
+			}
+			
+			long[] p = Eclipse.poss(fieldNode.get(), qualifiedName.length);
+			TypeReference[][] rr = new TypeReference[qualifiedName.length][];
+			rr[rr.length - 1] = copyTypes(typeArguments, fieldNode.get());
+			return new ParameterizedQualifiedTypeReference(qualifiedName, rr, 0, p);
+		}
+	}
+	
+	private static Map<String, String> SIMPLE_PROPERTY_TYPE_MAP;
+	private static Map<String, String> GENERIC_PROPERTY_TYPE_MAP;
+	static {
+		Map<String, String> m = new HashMap<String, String>();
+		m.put("javafx.beans.property.ObjectProperty", "java.lang.Object");
+		m.put("javafx.beans.property.ListProperty", "javafx.collections.ObservableList");
+		m.put("javafx.beans.property.MapProperty", "javafx.collections.ObservableMap");
+		m.put("javafx.beans.property.SetProperty", "javafx.collections.ObservableSet");
+		
+		m.put("javafx.beans.property.ReadOnlyObjectProperty", "java.lang.Object");
+		m.put("javafx.beans.property.ReadOnlyListProperty", "javafx.collections.ObservableList");
+		m.put("javafx.beans.property.ReadOnlyMapProperty", "javafx.collections.ObservableMap");
+		m.put("javafx.beans.property.ReadOnlySetProperty", "javafx.collections.ObservableSet");
+		GENERIC_PROPERTY_TYPE_MAP = Collections.unmodifiableMap(m);
+		
+		m.put("javafx.beans.property.IntegerProperty", "java.lang.Integer");
+		m.put("javafx.beans.property.LongProperty", "java.lang.Long");
+		m.put("javafx.beans.property.FloatProperty", "java.lang.Float");
+		m.put("javafx.beans.property.DoubleProperty", "java.lang.Double");
+		m.put("javafx.beans.property.BooleanProperty", "java.lang.Boolean");
+		m.put("javafx.beans.property.StringProperty", "java.lang.String");
+		
+		m.put("javafx.beans.property.ReadOnlyIntegerProperty", "java.lang.Integer");
+		m.put("javafx.beans.property.ReadOnlyLongProperty", "java.lang.Long");
+		m.put("javafx.beans.property.ReadOnlyFloatProperty", "java.lang.Float");
+		m.put("javafx.beans.property.ReadOnlyDoubleProperty", "java.lang.Double");
+		m.put("javafx.beans.property.ReadOnlyBooleanProperty", "java.lang.Boolean");
+		m.put("javafx.beans.property.ReadOnlyStringProperty", "java.lang.String");
+		SIMPLE_PROPERTY_TYPE_MAP = Collections.unmodifiableMap(m);
+	}
+	
+	private static Map<String, Integer> PRIMITIVE_TYPE_MAP;
+	static {
+		Map<String, Integer> m = new HashMap<String, Integer>();
+		m.put("java.lang.Integer", TypeIds.T_int);
+		m.put("java.lang.Long", TypeIds.T_long);
+		m.put("java.lang.Float", TypeIds.T_float);
+		m.put("java.lang.Double", TypeIds.T_double);
+		m.put("java.lang.Boolean", TypeIds.T_boolean);
+		PRIMITIVE_TYPE_MAP = Collections.unmodifiableMap(m);
+	}
+	
+	private FieldInfo getFieldInfo(EclipseNode fieldNode, FieldDeclaration fieldDecl) {
+		TypeReference vartype = fieldDecl.type;
+		
+		if (vartype.getTypeArguments() != null) {
+			if (vartype.getTypeArguments().length != 1) {
+				return null;
+			}
+			TypeReference[] arguments = vartype.getTypeArguments()[0];
+			
+			for (Entry<String, String> property : GENERIC_PROPERTY_TYPE_MAP.entrySet()) {
+				if (typeMatches(property.getKey(), fieldNode, vartype)) {
+					return new FieldInfo(fieldNode, property.getKey(), property.getValue(), arguments);
+				}
+			}
+			return null;
+		}
+		
+		for (Entry<String, String> property : SIMPLE_PROPERTY_TYPE_MAP.entrySet()) {
+			if (typeMatches(property.getKey(), fieldNode, vartype)) {
+				return new FieldInfo(fieldNode, property.getKey(), property.getValue());
+			}
+		}
+		return null;
+	}
+}

--- a/src/core/lombok/extern/javafx/FxProperty.java
+++ b/src/core/lombok/extern/javafx/FxProperty.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.extern.javafx;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Put on any field to make lombok build getter and setter for a JavaFx property.
+ * <p>
+ * Complete documentation is found at <a href="https://projectlombok.org/features/experimental/FxProperty">the project lombok features page for &#64;FxProperty</a>.
+ * <p>
+ * Example:
+ * <pre>
+ *     private &#64;FxProperty StringProperty foo;
+ * </pre>
+ * 
+ * will generate:
+ * 
+ * <pre>
+ *     public final String getFoo() {
+ *         return this.foo.get();
+ *     }
+ *     public final void setFoo(String foo) {
+ *         return this.foo.set(foo);
+ *     }
+ *     public StringProperty fooProperty() {
+ *         return this.foo;
+ *     }
+ * </pre>
+ * <p>
+ * This annotation can also be applied to a class, in which case it'll be as if all fields that don't already have
+ * a {@code @FxProperty} annotation.
+ */
+@Target({ElementType.TYPE, ElementType.FIELD})
+@Retention(RetentionPolicy.SOURCE)
+public @interface FxProperty {
+	/**
+	 * Generate a read only property instead of normal one. This will create a
+	 * private setter and converts the return type of the property accessor to
+	 * the right ReadOnly*Property. 
+	 * <p>
+	 * Example:
+	 * 
+	 * <pre>
+	 * 	private &#64;FxProperty(readOnly = true) StringProperty foo;
+	 * </pre>
+	 * 
+	 * will generate:
+	 * 
+	 * <pre>
+	 * 	public final String getFoo() {
+	 * 		return this.foo.get();
+	 * 	}
+	 * 
+	 * 	private final void setFoo(String foo) {
+	 * 		return this.foo.set(foo);
+	 * 	}
+	 * 
+	 * 	public ReadOnlyStringProperty fooProperty() {
+	 * 		return this.foo;
+	 * 	}
+	 * </pre>
+	 * 
+	 * @return
+	 */
+	boolean readOnly() default false;
+}

--- a/src/core/lombok/javac/handlers/HandleFxProperty.java
+++ b/src/core/lombok/javac/handlers/HandleFxProperty.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (C) 2020-2021 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.javac.handlers;
+
+import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.javac.Javac.*;
+import static lombok.javac.handlers.JavacHandlerUtil.*;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.tree.JCTree.JCBlock;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
+import com.sun.tools.javac.tree.JCTree.JCStatement;
+import com.sun.tools.javac.tree.JCTree.JCTypeApply;
+import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.Name;
+
+import lombok.ConfigurationKeys;
+import lombok.core.AST.Kind;
+import lombok.core.AnnotationValues;
+import lombok.core.handlers.HandlerUtil.FieldAccess;
+import lombok.extern.javafx.FxProperty;
+import lombok.javac.Javac;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.javac.JavacTreeMaker;
+import lombok.javac.JavacTreeMaker.TypeTag;
+import lombok.javac.handlers.JavacHandlerUtil.MemberExistsResult;
+import lombok.spi.Provides;
+
+/**
+ * Handles the {@link FxProperty} annotation for javac.
+ */
+@Provides
+public class HandleFxProperty extends JavacAnnotationHandler<FxProperty> {
+	
+	@Override public void handle(AnnotationValues<FxProperty> annotation, JCAnnotation ast, JavacNode annotationNode) {
+		handleFlagUsage(annotationNode, ConfigurationKeys.FXPROPERTY_FLAG_USAGE, "@FxProperty");
+		
+		Collection<JavacNode> fields = annotationNode.upFromAnnotationToFields();
+		deleteAnnotationIfNeccessary(annotationNode, FxProperty.class);
+		JavacNode node = annotationNode.up();
+		FxProperty annotationInstance = annotation.getInstance();
+		boolean readOnly = annotationInstance.readOnly();
+		
+		if (node == null) return;
+		
+		switch (node.getKind()) {
+		case FIELD:
+			createFxPropertyForFields(fields, annotationNode, readOnly);
+			break;
+		case TYPE:
+			createFxPropertyForType(node, annotationNode, readOnly);
+			break;
+		}
+	}
+	
+	private void createFxPropertyForType(JavacNode typeNode, JavacNode annotationNode, boolean readOnly) {
+		if (!isClassOrEnum(typeNode)) {
+			annotationNode.addError("@FxProperty is only supported on a class, an enum, or a field.");
+			return;
+		}
+		for (JavacNode field : typeNode.down()) {
+			if (field.getKind() != Kind.FIELD) continue;
+			if (field.getName().startsWith("$")) continue;
+			
+			createFxPropertyForField(field, annotationNode, readOnly);
+		}
+	}
+
+	private void createFxPropertyForFields(Collection<JavacNode> fields, JavacNode annotationNode, boolean readOnly) {
+		for (JavacNode field : fields) {
+			createFxPropertyForField(field, annotationNode, readOnly);
+		}
+	}
+	
+	private void createFxPropertyForField(JavacNode fieldNode, JavacNode source, boolean readOnly) {
+		JCVariableDecl fieldDecl = (JCVariableDecl)fieldNode.get();
+		JavacNode typeNode = upToTypeNode(fieldNode);
+		
+		FieldInfo fieldInfo = getFieldInfo(fieldNode, fieldDecl);
+		if (fieldInfo == null) {
+			source.addError("@FxProperty is only supported on predefined JavaFx property types.");
+			return;
+		}
+		
+		addPropertyAccessor(fieldNode, source, typeNode, fieldInfo, readOnly);
+		addGetter(fieldNode, source, typeNode, fieldInfo);
+		addSetter(fieldNode, source, typeNode, fieldInfo, readOnly);
+	}
+
+	private void addGetter(JavacNode fieldNode, JavacNode source, JavacNode typeNode, FieldInfo fieldInfo) {
+		String methodName = buildAccessorName(fieldNode, "get", fieldNode.getName());
+		if (methodExists(methodName, typeNode, 0) != MemberExistsResult.NOT_EXISTS) {
+			return;
+		}
+		
+		injectMethod(typeNode, recursiveSetGeneratedBy(createGetter(fieldNode, fieldInfo), source));
+	}
+	
+	private void addSetter(JavacNode fieldNode, JavacNode source, JavacNode typeNode, FieldInfo fieldInfo, boolean readOnly) {
+		if (fieldInfo.readOnly) return;
+		
+		String methodName = buildAccessorName(fieldNode, "set", fieldNode.getName());
+		if (methodExists(methodName, typeNode, 1) != MemberExistsResult.NOT_EXISTS) {
+			return;
+		}
+		
+		injectMethod(typeNode, recursiveSetGeneratedBy(createSetter(fieldNode, fieldInfo, readOnly), source));
+	}
+	
+	private void addPropertyAccessor(JavacNode fieldNode, JavacNode source, JavacNode typeNode, FieldInfo fieldInfo, boolean readOnly) {
+		String methodName = toPropertyName(fieldNode.getName());
+		if (methodExists(methodName, typeNode, 0) != MemberExistsResult.NOT_EXISTS) {
+			return;
+		}
+		
+		injectMethod(typeNode, recursiveSetGeneratedBy(createPropertyAccessor(fieldNode, fieldInfo, readOnly), source));
+	}
+	
+
+	private JCMethodDecl createPropertyAccessor(JavacNode fieldNode, FieldInfo fieldInfo, boolean readOnly) {
+		String methodName = toPropertyName(fieldNode.getName());
+		
+		JavacTreeMaker maker = fieldNode.getTreeMaker();
+		
+		List<JCTypeParameter> methodGenericParams = List.nil();
+		List<JCVariableDecl> parameters = List.nil();
+		List<JCExpression> throwsClauses = List.nil();
+		JCExpression defaultValue = null;
+		JCBlock methodBody = maker.Block(0, List.<JCStatement>of(maker.Return(createFieldAccessor(maker, fieldNode, FieldAccess.ALWAYS_FIELD))));
+		
+		return maker.MethodDef(maker.Modifiers(Flags.PUBLIC), fieldNode.toName(methodName), fieldInfo.getPropertyType(readOnly), methodGenericParams, parameters, throwsClauses, methodBody, defaultValue);
+	}
+
+	private JCMethodDecl createSetter(JavacNode fieldNode, FieldInfo fieldInfo, boolean readOnly) {
+		Name methodName = fieldNode.toName(buildAccessorName(fieldNode, "set", fieldNode.getName()));
+		
+		JavacTreeMaker maker = fieldNode.getTreeMaker();
+		JCVariableDecl fieldDecl = (JCVariableDecl)fieldNode.get();
+		
+		long modifiers = Flags.FINAL | (readOnly ? Flags.PRIVATE : Flags.PUBLIC);
+		List<JCTypeParameter> methodGenericParams = List.nil();
+		List<JCExpression> throwsClauses = List.nil();
+		JCExpression defaultValue = null;
+		JCExpression methodType = maker.Type(Javac.createVoidType(fieldNode.getSymbolTable(), CTC_VOID));
+		
+		Name paramName = fieldDecl.name;
+		long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, fieldNode.getContext());
+		List<JCVariableDecl> parameters = List.of(maker.VarDef(maker.Modifiers(flags, List.<JCAnnotation>nil()), paramName, fieldInfo.getType(), null));
+		
+		List<JCExpression> typeargs = List.nil();
+		JCExpression fieldRef = createFieldAccessor(maker, fieldNode, FieldAccess.ALWAYS_FIELD);
+		JCMethodInvocation write = maker.Apply(typeargs, maker.Select(fieldRef, fieldNode.toName("set")), List.<JCExpression>of(maker.Ident(paramName)));
+		JCBlock methodBody = maker.Block(0, List.<JCStatement>of(maker.Exec(write)));
+		
+		return maker.MethodDef(maker.Modifiers(modifiers), methodName, methodType, methodGenericParams, parameters, throwsClauses, methodBody, defaultValue);
+	}
+
+	private JCMethodDecl createGetter(JavacNode fieldNode, FieldInfo fieldInfo) {
+		Name methodName = fieldNode.toName(buildAccessorName(fieldNode, "get", fieldNode.getName()));
+		
+		JavacTreeMaker maker = fieldNode.getTreeMaker();
+		
+		List<JCTypeParameter> methodGenericParams = List.nil();
+		List<JCVariableDecl> parameters = List.nil();
+		List<JCExpression> throwsClauses = List.nil();
+		JCExpression defaultValue = null;
+		List<JCExpression> args = List.nil();
+		
+		List<JCExpression> typeargs = List.nil();
+		JCExpression fieldRef = createFieldAccessor(maker, fieldNode, FieldAccess.ALWAYS_FIELD);
+		JCMethodInvocation apply = maker.Apply(typeargs, maker.Select(fieldRef, fieldNode.toName("get")), args);
+		JCBlock methodBody = maker.Block(0, List.<JCStatement>of(maker.Return(apply)));
+		
+		return maker.MethodDef(maker.Modifiers(Flags.PUBLIC | Flags.FINAL), methodName, fieldInfo.getType(), methodGenericParams, parameters, throwsClauses, methodBody, defaultValue);
+	}
+	
+	static class FieldInfo {
+		JavacNode fieldNode;
+		String propertyType;
+		String returnType;
+		boolean readOnly;
+		private List<JCExpression> typeArguments;
+
+		FieldInfo(JavacNode fieldNode, String propertyType, String returnType) {
+			this.fieldNode = fieldNode;
+			this.propertyType = propertyType;
+			this.returnType = returnType;
+			this.readOnly = propertyType.contains("ReadOnly");
+		}
+		
+		FieldInfo(JavacNode fieldNode, String propertyType, String returnType, List<JCExpression> typeArguments) {
+			this(fieldNode, propertyType, returnType);
+			this.typeArguments = typeArguments;
+		}
+		
+		JCExpression getType() {
+			TypeTag primitiveTypeTag = PRIMITIVE_TYPE_MAP.get(returnType);
+			if (primitiveTypeTag != null) {
+				return fieldNode.getTreeMaker().TypeIdent(primitiveTypeTag);
+			}
+			
+			JCExpression typeRef = genTypeRef(fieldNode, returnType);
+			
+			if (typeArguments == null) return typeRef;
+			
+			if (returnType.endsWith("Object")) {
+				return typeArguments.get(0);
+			}
+			return fieldNode.getTreeMaker().TypeApply(typeRef, typeArguments);
+		}
+		
+		JCExpression getPropertyType(boolean asReadOnly) {
+			String type = propertyType;
+			if (asReadOnly && !readOnly) {
+				type = "javafx.beans.property.ReadOnly" + propertyType.substring(22);
+			}
+			return genTypeRef(fieldNode, type);
+		}
+	}
+	
+	private static Map<String, String> SIMPLE_PROPERTY_TYPE_MAP;
+	private static Map<String, String> GENERIC_PROPERTY_TYPE_MAP;
+	static {
+		Map<String, String> m = new HashMap<String, String>();
+		m.put("javafx.beans.property.ObjectProperty", "java.lang.Object");
+		m.put("javafx.beans.property.ListProperty", "javafx.collections.ObservableList");
+		m.put("javafx.beans.property.MapProperty", "javafx.collections.ObservableMap");
+		m.put("javafx.beans.property.SetProperty", "javafx.collections.ObservableSet");
+		
+		m.put("javafx.beans.property.ReadOnlyObjectProperty", "java.lang.Object");
+		m.put("javafx.beans.property.ReadOnlyListProperty", "javafx.collections.ObservableList");
+		m.put("javafx.beans.property.ReadOnlyMapProperty", "javafx.collections.ObservableMap");
+		m.put("javafx.beans.property.ReadOnlySetProperty", "javafx.collections.ObservableSet");
+		GENERIC_PROPERTY_TYPE_MAP = Collections.unmodifiableMap(m);
+		
+		m.put("javafx.beans.property.IntegerProperty", "java.lang.Integer");
+		m.put("javafx.beans.property.LongProperty", "java.lang.Long");
+		m.put("javafx.beans.property.FloatProperty", "java.lang.Float");
+		m.put("javafx.beans.property.DoubleProperty", "java.lang.Double");
+		m.put("javafx.beans.property.BooleanProperty", "java.lang.Boolean");
+		m.put("javafx.beans.property.StringProperty", "java.lang.String");
+		
+		m.put("javafx.beans.property.ReadOnlyIntegerProperty", "java.lang.Integer");
+		m.put("javafx.beans.property.ReadOnlyLongProperty", "java.lang.Long");
+		m.put("javafx.beans.property.ReadOnlyFloatProperty", "java.lang.Float");
+		m.put("javafx.beans.property.ReadOnlyDoubleProperty", "java.lang.Double");
+		m.put("javafx.beans.property.ReadOnlyBooleanProperty", "java.lang.Boolean");
+		m.put("javafx.beans.property.ReadOnlyStringProperty", "java.lang.String");
+		SIMPLE_PROPERTY_TYPE_MAP = Collections.unmodifiableMap(m);
+	}
+	
+	private static Map<String, TypeTag> PRIMITIVE_TYPE_MAP;
+	static {
+		Map<String, TypeTag> m = new HashMap<String, TypeTag>();
+		m.put("java.lang.Integer", CTC_INT);
+		m.put("java.lang.Long", CTC_LONG);
+		m.put("java.lang.Float", CTC_FLOAT);
+		m.put("java.lang.Double", CTC_DOUBLE);
+		m.put("java.lang.Boolean", CTC_BOOLEAN);
+		PRIMITIVE_TYPE_MAP = Collections.unmodifiableMap(m);
+	}
+	
+	private FieldInfo getFieldInfo(JavacNode fieldNode, JCVariableDecl fieldDecl) {
+		JCExpression vartype = fieldDecl.vartype;
+		if (vartype instanceof JCTypeApply) {
+			JCTypeApply typeApply = (JCTypeApply) vartype;
+			JCExpression clazz = typeApply.clazz;
+			List<JCExpression> arguments = typeApply.arguments;
+			
+			for (Entry<String, String> property : GENERIC_PROPERTY_TYPE_MAP.entrySet()) {
+				if (typeMatches(property.getKey(), fieldNode, clazz)) {
+					return new FieldInfo(fieldNode, property.getKey(), property.getValue(), arguments);
+				}
+			}
+			return null;
+		}
+		
+		for (Entry<String, String> property : SIMPLE_PROPERTY_TYPE_MAP.entrySet()) {
+			if (typeMatches(property.getKey(), fieldNode, vartype)) {
+				return new FieldInfo(fieldNode, property.getKey(), property.getValue());
+			}
+		}
+		return null;
+	}
+}

--- a/test/stubs/javafx/beans/property/BooleanProperty.java
+++ b/test/stubs/javafx/beans/property/BooleanProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public class BooleanProperty extends ReadOnlyBooleanProperty {
+	public void set(boolean value) { }
+}

--- a/test/stubs/javafx/beans/property/DoubleProperty.java
+++ b/test/stubs/javafx/beans/property/DoubleProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public class DoubleProperty extends ReadOnlyDoubleProperty {
+	public void set(double value) { }
+}

--- a/test/stubs/javafx/beans/property/FloatProperty.java
+++ b/test/stubs/javafx/beans/property/FloatProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public class FloatProperty extends ReadOnlyFloatProperty {
+	public void set(float value) { }
+}

--- a/test/stubs/javafx/beans/property/IntegerProperty.java
+++ b/test/stubs/javafx/beans/property/IntegerProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public class IntegerProperty extends ReadOnlyIntegerProperty {
+	public void set(int value) { }
+}

--- a/test/stubs/javafx/beans/property/ListProperty.java
+++ b/test/stubs/javafx/beans/property/ListProperty.java
@@ -1,0 +1,8 @@
+package javafx.beans.property;
+
+import javafx.collections.ObservableList;
+
+public class ListProperty<T> extends ReadOnlyListProperty<T> {
+	public void set(ObservableList<T> value) { }
+}
+

--- a/test/stubs/javafx/beans/property/LongProperty.java
+++ b/test/stubs/javafx/beans/property/LongProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public class LongProperty extends ReadOnlyLongProperty {
+	public void set(long value) { }
+}

--- a/test/stubs/javafx/beans/property/MapProperty.java
+++ b/test/stubs/javafx/beans/property/MapProperty.java
@@ -1,0 +1,7 @@
+package javafx.beans.property;
+
+import javafx.collections.ObservableMap;
+
+public class MapProperty<K, V> extends ReadOnlyMapProperty<K, V> {
+	public void set(ObservableMap<K, V> value) { }
+}

--- a/test/stubs/javafx/beans/property/ObjectProperty.java
+++ b/test/stubs/javafx/beans/property/ObjectProperty.java
@@ -1,0 +1,6 @@
+package javafx.beans.property;
+
+public class ObjectProperty<T> extends ReadOnlyObjectProperty<T> {
+	public void set(T value) { }
+}
+

--- a/test/stubs/javafx/beans/property/Property.java
+++ b/test/stubs/javafx/beans/property/Property.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public interface Property<T> extends ReadOnlyProperty<T> {
+	public void set(T value);
+}

--- a/test/stubs/javafx/beans/property/ReadOnlyBooleanProperty.java
+++ b/test/stubs/javafx/beans/property/ReadOnlyBooleanProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public class ReadOnlyBooleanProperty {
+	public boolean get() { return false; }
+}

--- a/test/stubs/javafx/beans/property/ReadOnlyDoubleProperty.java
+++ b/test/stubs/javafx/beans/property/ReadOnlyDoubleProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public class ReadOnlyDoubleProperty {
+	public double get() { return 0d; }
+}

--- a/test/stubs/javafx/beans/property/ReadOnlyFloatProperty.java
+++ b/test/stubs/javafx/beans/property/ReadOnlyFloatProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public class ReadOnlyFloatProperty {
+	public float get() { return 0f; }
+}

--- a/test/stubs/javafx/beans/property/ReadOnlyIntegerProperty.java
+++ b/test/stubs/javafx/beans/property/ReadOnlyIntegerProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public class ReadOnlyIntegerProperty {
+	public int get() { return 0; }
+}

--- a/test/stubs/javafx/beans/property/ReadOnlyListProperty.java
+++ b/test/stubs/javafx/beans/property/ReadOnlyListProperty.java
@@ -1,0 +1,8 @@
+package javafx.beans.property;
+
+import javafx.collections.ObservableList;
+
+public class ReadOnlyListProperty<T> {
+	public ObservableList<T> get() { return null; }
+}
+

--- a/test/stubs/javafx/beans/property/ReadOnlyLongProperty.java
+++ b/test/stubs/javafx/beans/property/ReadOnlyLongProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public class ReadOnlyLongProperty {
+	public long get() { return 0; }
+}

--- a/test/stubs/javafx/beans/property/ReadOnlyMapProperty.java
+++ b/test/stubs/javafx/beans/property/ReadOnlyMapProperty.java
@@ -1,0 +1,7 @@
+package javafx.beans.property;
+
+import javafx.collections.ObservableMap;
+
+public class ReadOnlyMapProperty<K, V> {
+	public ObservableMap<K, V> get() { return null; }
+}

--- a/test/stubs/javafx/beans/property/ReadOnlyObjectProperty.java
+++ b/test/stubs/javafx/beans/property/ReadOnlyObjectProperty.java
@@ -1,0 +1,6 @@
+package javafx.beans.property;
+
+public class ReadOnlyObjectProperty<T> {
+	public T get() { return null; }
+}
+

--- a/test/stubs/javafx/beans/property/ReadOnlyProperty.java
+++ b/test/stubs/javafx/beans/property/ReadOnlyProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public interface ReadOnlyProperty<T> {
+	public T get();
+}

--- a/test/stubs/javafx/beans/property/ReadOnlySetProperty.java
+++ b/test/stubs/javafx/beans/property/ReadOnlySetProperty.java
@@ -1,0 +1,7 @@
+package javafx.beans.property;
+
+import javafx.collections.ObservableSet;
+
+public class ReadOnlySetProperty<T> {
+	public ObservableSet<T> get() { return null; }
+}

--- a/test/stubs/javafx/beans/property/ReadOnlyStringProperty.java
+++ b/test/stubs/javafx/beans/property/ReadOnlyStringProperty.java
@@ -1,0 +1,5 @@
+package javafx.beans.property;
+
+public class ReadOnlyStringProperty {
+	public String get() { return null; }
+}

--- a/test/stubs/javafx/beans/property/SetProperty.java
+++ b/test/stubs/javafx/beans/property/SetProperty.java
@@ -1,0 +1,8 @@
+package javafx.beans.property;
+
+import javafx.collections.ObservableSet;
+
+public class SetProperty<T> {
+	public ObservableSet<T> get() { return null; }
+	public void set(ObservableSet<T> value) { }
+}

--- a/test/stubs/javafx/beans/property/StringProperty.java
+++ b/test/stubs/javafx/beans/property/StringProperty.java
@@ -1,0 +1,6 @@
+package javafx.beans.property;
+
+public class StringProperty {
+	public String get() { return null; }
+	public void set(String value) { }
+}

--- a/test/stubs/javafx/collections/ObservableList.java
+++ b/test/stubs/javafx/collections/ObservableList.java
@@ -1,0 +1,5 @@
+package javafx.collections;
+
+public class ObservableList<T> {
+	
+}

--- a/test/stubs/javafx/collections/ObservableMap.java
+++ b/test/stubs/javafx/collections/ObservableMap.java
@@ -1,0 +1,5 @@
+package javafx.collections;
+
+public class ObservableMap<K, V> {
+	
+}

--- a/test/stubs/javafx/collections/ObservableSet.java
+++ b/test/stubs/javafx/collections/ObservableSet.java
@@ -1,0 +1,5 @@
+package javafx.collections;
+
+public class ObservableSet<T> {
+	
+}

--- a/test/transform/resource/after-delombok/FxPropertyExisting.java
+++ b/test/transform/resource/after-delombok/FxPropertyExisting.java
@@ -1,0 +1,18 @@
+import java.math.BigDecimal;
+import javafx.beans.property.*;
+
+class FxPropertyExisting {
+	private IntegerProperty integer;
+
+	public ReadOnlyIntegerProperty integerProperty() {
+		return this.integer;
+	}
+
+	public int getInteger() {
+		return this.integer.get();
+	}
+
+	public void setInteger(int integer) {
+		this.integer.set(integer);
+	}
+}

--- a/test/transform/resource/after-delombok/FxPropertyOnClass.java
+++ b/test/transform/resource/after-delombok/FxPropertyOnClass.java
@@ -1,0 +1,275 @@
+import java.math.BigDecimal;
+import javafx.beans.property.*;
+
+class FxPropertyOnClass {
+	private IntegerProperty integer1;
+	private LongProperty long1;
+	private FloatProperty float1;
+	private DoubleProperty double1;
+	private BooleanProperty boolean1;
+	private StringProperty string1;
+	private ObjectProperty<BigDecimal> object1;
+	private ListProperty<String> list1;
+	private SetProperty<String> set1;
+	private MapProperty<String, String> map1;
+	private ReadOnlyIntegerProperty integer2;
+	private ReadOnlyLongProperty long2;
+	private ReadOnlyFloatProperty float2;
+	private ReadOnlyDoubleProperty double2;
+	private ReadOnlyBooleanProperty boolean2;
+	private ReadOnlyStringProperty string2;
+	private ReadOnlyObjectProperty<BigDecimal> object2;
+	private ReadOnlyListProperty<String> list2;
+	private ReadOnlySetProperty<String> set2;
+	private ReadOnlyMapProperty<String, String> map2;
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.IntegerProperty integer1Property() {
+		return this.integer1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final int getInteger1() {
+		return this.integer1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setInteger1(final int integer1) {
+		this.integer1.set(integer1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.LongProperty long1Property() {
+		return this.long1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final long getLong1() {
+		return this.long1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setLong1(final long long1) {
+		this.long1.set(long1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.FloatProperty float1Property() {
+		return this.float1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final float getFloat1() {
+		return this.float1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setFloat1(final float float1) {
+		this.float1.set(float1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.DoubleProperty double1Property() {
+		return this.double1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final double getDouble1() {
+		return this.double1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setDouble1(final double double1) {
+		this.double1.set(double1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.BooleanProperty boolean1Property() {
+		return this.boolean1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final boolean getBoolean1() {
+		return this.boolean1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setBoolean1(final boolean boolean1) {
+		this.boolean1.set(boolean1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.StringProperty string1Property() {
+		return this.string1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final java.lang.String getString1() {
+		return this.string1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setString1(final java.lang.String string1) {
+		this.string1.set(string1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ObjectProperty object1Property() {
+		return this.object1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final BigDecimal getObject1() {
+		return this.object1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setObject1(final BigDecimal object1) {
+		this.object1.set(object1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ListProperty list1Property() {
+		return this.list1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableList<String> getList1() {
+		return this.list1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setList1(final javafx.collections.ObservableList<String> list1) {
+		this.list1.set(list1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.SetProperty set1Property() {
+		return this.set1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableSet<String> getSet1() {
+		return this.set1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setSet1(final javafx.collections.ObservableSet<String> set1) {
+		this.set1.set(set1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.MapProperty map1Property() {
+		return this.map1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableMap<String, String> getMap1() {
+		return this.map1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setMap1(final javafx.collections.ObservableMap<String, String> map1) {
+		this.map1.set(map1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyIntegerProperty integer2Property() {
+		return this.integer2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final int getInteger2() {
+		return this.integer2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyLongProperty long2Property() {
+		return this.long2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final long getLong2() {
+		return this.long2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyFloatProperty float2Property() {
+		return this.float2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final float getFloat2() {
+		return this.float2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyDoubleProperty double2Property() {
+		return this.double2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final double getDouble2() {
+		return this.double2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyBooleanProperty boolean2Property() {
+		return this.boolean2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final boolean getBoolean2() {
+		return this.boolean2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyStringProperty string2Property() {
+		return this.string2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final java.lang.String getString2() {
+		return this.string2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyObjectProperty object2Property() {
+		return this.object2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final BigDecimal getObject2() {
+		return this.object2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyListProperty list2Property() {
+		return this.list2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableList<String> getList2() {
+		return this.list2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlySetProperty set2Property() {
+		return this.set2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableSet<String> getSet2() {
+		return this.set2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyMapProperty map2Property() {
+		return this.map2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableMap<String, String> getMap2() {
+		return this.map2.get();
+	}
+}

--- a/test/transform/resource/after-delombok/FxPropertyReadOnly.java
+++ b/test/transform/resource/after-delombok/FxPropertyReadOnly.java
@@ -1,0 +1,32 @@
+import java.math.BigDecimal;
+import javafx.beans.property.*;
+
+class FxPropertyReadOnly {
+	private IntegerProperty integer1;
+	private ReadOnlyIntegerProperty integer2;
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyIntegerProperty integer1Property() {
+		return this.integer1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final int getInteger1() {
+		return this.integer1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	private final void setInteger1(final int integer1) {
+		this.integer1.set(integer1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyIntegerProperty integer2Property() {
+		return this.integer2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final int getInteger2() {
+		return this.integer2.get();
+	}
+}

--- a/test/transform/resource/after-delombok/FxPropertySimple.java
+++ b/test/transform/resource/after-delombok/FxPropertySimple.java
@@ -1,0 +1,275 @@
+import java.math.BigDecimal;
+import javafx.beans.property.*;
+
+class FxPropertySimple {
+	private IntegerProperty integer1;
+	private LongProperty long1;
+	private FloatProperty float1;
+	private DoubleProperty double1;
+	private BooleanProperty boolean1;
+	private StringProperty string1;
+	private ObjectProperty<BigDecimal> object1;
+	private ListProperty<String> list1;
+	private SetProperty<String> set1;
+	private MapProperty<String, String> map1;
+	private ReadOnlyIntegerProperty integer2;
+	private ReadOnlyLongProperty long2;
+	private ReadOnlyFloatProperty float2;
+	private ReadOnlyDoubleProperty double2;
+	private ReadOnlyBooleanProperty boolean2;
+	private ReadOnlyStringProperty string2;
+	private ReadOnlyObjectProperty<BigDecimal> object2;
+	private ReadOnlyListProperty<String> list2;
+	private ReadOnlySetProperty<String> set2;
+	private ReadOnlyMapProperty<String, String> map2;
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.IntegerProperty integer1Property() {
+		return this.integer1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final int getInteger1() {
+		return this.integer1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setInteger1(final int integer1) {
+		this.integer1.set(integer1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.LongProperty long1Property() {
+		return this.long1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final long getLong1() {
+		return this.long1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setLong1(final long long1) {
+		this.long1.set(long1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.FloatProperty float1Property() {
+		return this.float1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final float getFloat1() {
+		return this.float1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setFloat1(final float float1) {
+		this.float1.set(float1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.DoubleProperty double1Property() {
+		return this.double1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final double getDouble1() {
+		return this.double1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setDouble1(final double double1) {
+		this.double1.set(double1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.BooleanProperty boolean1Property() {
+		return this.boolean1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final boolean getBoolean1() {
+		return this.boolean1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setBoolean1(final boolean boolean1) {
+		this.boolean1.set(boolean1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.StringProperty string1Property() {
+		return this.string1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final java.lang.String getString1() {
+		return this.string1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setString1(final java.lang.String string1) {
+		this.string1.set(string1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ObjectProperty object1Property() {
+		return this.object1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final BigDecimal getObject1() {
+		return this.object1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setObject1(final BigDecimal object1) {
+		this.object1.set(object1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ListProperty list1Property() {
+		return this.list1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableList<String> getList1() {
+		return this.list1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setList1(final javafx.collections.ObservableList<String> list1) {
+		this.list1.set(list1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.SetProperty set1Property() {
+		return this.set1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableSet<String> getSet1() {
+		return this.set1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setSet1(final javafx.collections.ObservableSet<String> set1) {
+		this.set1.set(set1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.MapProperty map1Property() {
+		return this.map1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableMap<String, String> getMap1() {
+		return this.map1.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final void setMap1(final javafx.collections.ObservableMap<String, String> map1) {
+		this.map1.set(map1);
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyIntegerProperty integer2Property() {
+		return this.integer2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final int getInteger2() {
+		return this.integer2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyLongProperty long2Property() {
+		return this.long2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final long getLong2() {
+		return this.long2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyFloatProperty float2Property() {
+		return this.float2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final float getFloat2() {
+		return this.float2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyDoubleProperty double2Property() {
+		return this.double2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final double getDouble2() {
+		return this.double2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyBooleanProperty boolean2Property() {
+		return this.boolean2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final boolean getBoolean2() {
+		return this.boolean2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyStringProperty string2Property() {
+		return this.string2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final java.lang.String getString2() {
+		return this.string2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyObjectProperty object2Property() {
+		return this.object2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final BigDecimal getObject2() {
+		return this.object2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyListProperty list2Property() {
+		return this.list2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableList<String> getList2() {
+		return this.list2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlySetProperty set2Property() {
+		return this.set2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableSet<String> getSet2() {
+		return this.set2.get();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public javafx.beans.property.ReadOnlyMapProperty map2Property() {
+		return this.map2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public final javafx.collections.ObservableMap<String, String> getMap2() {
+		return this.map2.get();
+	}
+}

--- a/test/transform/resource/after-ecj/FxPropertyExisting.java
+++ b/test/transform/resource/after-ecj/FxPropertyExisting.java
@@ -1,0 +1,18 @@
+import java.math.BigDecimal;
+import javafx.beans.property.*;
+import lombok.extern.javafx.FxProperty;
+class FxPropertyExisting {
+  private @FxProperty IntegerProperty integer;
+  FxPropertyExisting() {
+    super();
+  }
+  public ReadOnlyIntegerProperty integerProperty() {
+    return this.integer;
+  }
+  public int getInteger() {
+    return this.integer.get();
+  }
+  public void setInteger(int integer) {
+    this.integer.set(integer);
+  }
+}

--- a/test/transform/resource/after-ecj/FxPropertyOnClass.java
+++ b/test/transform/resource/after-ecj/FxPropertyOnClass.java
@@ -1,0 +1,178 @@
+import java.math.BigDecimal;
+import javafx.beans.property.*;
+import lombok.extern.javafx.FxProperty;
+@FxProperty class FxPropertyOnClass {
+  private IntegerProperty integer1;
+  private LongProperty long1;
+  private FloatProperty float1;
+  private DoubleProperty double1;
+  private BooleanProperty boolean1;
+  private StringProperty string1;
+  private ObjectProperty<BigDecimal> object1;
+  private ListProperty<String> list1;
+  private SetProperty<String> set1;
+  private MapProperty<String, String> map1;
+  private ReadOnlyIntegerProperty integer2;
+  private ReadOnlyLongProperty long2;
+  private ReadOnlyFloatProperty float2;
+  private ReadOnlyDoubleProperty double2;
+  private ReadOnlyBooleanProperty boolean2;
+  private ReadOnlyStringProperty string2;
+  private ReadOnlyObjectProperty<BigDecimal> object2;
+  private ReadOnlyListProperty<String> list2;
+  private ReadOnlySetProperty<String> set2;
+  private ReadOnlyMapProperty<String, String> map2;
+  FxPropertyOnClass() {
+    super();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.IntegerProperty integer1Property() {
+    return this.integer1;
+  }
+  public final @java.lang.SuppressWarnings("all") int getInteger1() {
+    return this.integer1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setInteger1(final int integer1) {
+    this.integer1.set(integer1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.LongProperty long1Property() {
+    return this.long1;
+  }
+  public final @java.lang.SuppressWarnings("all") long getLong1() {
+    return this.long1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setLong1(final long long1) {
+    this.long1.set(long1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.FloatProperty float1Property() {
+    return this.float1;
+  }
+  public final @java.lang.SuppressWarnings("all") float getFloat1() {
+    return this.float1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setFloat1(final float float1) {
+    this.float1.set(float1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.DoubleProperty double1Property() {
+    return this.double1;
+  }
+  public final @java.lang.SuppressWarnings("all") double getDouble1() {
+    return this.double1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setDouble1(final double double1) {
+    this.double1.set(double1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.BooleanProperty boolean1Property() {
+    return this.boolean1;
+  }
+  public final @java.lang.SuppressWarnings("all") boolean getBoolean1() {
+    return this.boolean1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setBoolean1(final boolean boolean1) {
+    this.boolean1.set(boolean1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.StringProperty string1Property() {
+    return this.string1;
+  }
+  public final @java.lang.SuppressWarnings("all") java.lang.String getString1() {
+    return this.string1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setString1(final java.lang.String string1) {
+    this.string1.set(string1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ObjectProperty<BigDecimal> object1Property() {
+    return this.object1;
+  }
+  public final @java.lang.SuppressWarnings("all") BigDecimal getObject1() {
+    return this.object1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setObject1(final BigDecimal object1) {
+    this.object1.set(object1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ListProperty<String> list1Property() {
+    return this.list1;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableList<String> getList1() {
+    return this.list1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setList1(final javafx.collections.ObservableList<String> list1) {
+    this.list1.set(list1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.SetProperty<String> set1Property() {
+    return this.set1;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableSet<String> getSet1() {
+    return this.set1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setSet1(final javafx.collections.ObservableSet<String> set1) {
+    this.set1.set(set1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.MapProperty<String, String> map1Property() {
+    return this.map1;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableMap<String, String> getMap1() {
+    return this.map1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setMap1(final javafx.collections.ObservableMap<String, String> map1) {
+    this.map1.set(map1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyIntegerProperty integer2Property() {
+    return this.integer2;
+  }
+  public final @java.lang.SuppressWarnings("all") int getInteger2() {
+    return this.integer2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyLongProperty long2Property() {
+    return this.long2;
+  }
+  public final @java.lang.SuppressWarnings("all") long getLong2() {
+    return this.long2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyFloatProperty float2Property() {
+    return this.float2;
+  }
+  public final @java.lang.SuppressWarnings("all") float getFloat2() {
+    return this.float2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyDoubleProperty double2Property() {
+    return this.double2;
+  }
+  public final @java.lang.SuppressWarnings("all") double getDouble2() {
+    return this.double2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyBooleanProperty boolean2Property() {
+    return this.boolean2;
+  }
+  public final @java.lang.SuppressWarnings("all") boolean getBoolean2() {
+    return this.boolean2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyStringProperty string2Property() {
+    return this.string2;
+  }
+  public final @java.lang.SuppressWarnings("all") java.lang.String getString2() {
+    return this.string2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyObjectProperty<BigDecimal> object2Property() {
+    return this.object2;
+  }
+  public final @java.lang.SuppressWarnings("all") BigDecimal getObject2() {
+    return this.object2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyListProperty<String> list2Property() {
+    return this.list2;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableList<String> getList2() {
+    return this.list2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlySetProperty<String> set2Property() {
+    return this.set2;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableSet<String> getSet2() {
+    return this.set2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyMapProperty<String, String> map2Property() {
+    return this.map2;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableMap<String, String> getMap2() {
+    return this.map2.get();
+  }
+}

--- a/test/transform/resource/after-ecj/FxPropertyReadOnly.java
+++ b/test/transform/resource/after-ecj/FxPropertyReadOnly.java
@@ -1,0 +1,25 @@
+import java.math.BigDecimal;
+import javafx.beans.property.*;
+import lombok.extern.javafx.FxProperty;
+@FxProperty(readOnly = true) class FxPropertyReadOnly {
+  private IntegerProperty integer1;
+  private ReadOnlyIntegerProperty integer2;
+  FxPropertyReadOnly() {
+    super();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyIntegerProperty integer1Property() {
+    return this.integer1;
+  }
+  public final @java.lang.SuppressWarnings("all") int getInteger1() {
+    return this.integer1.get();
+  }
+  private final @java.lang.SuppressWarnings("all") void setInteger1(final int integer1) {
+    this.integer1.set(integer1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyIntegerProperty integer2Property() {
+    return this.integer2;
+  }
+  public final @java.lang.SuppressWarnings("all") int getInteger2() {
+    return this.integer2.get();
+  }
+}

--- a/test/transform/resource/after-ecj/FxPropertySimple.java
+++ b/test/transform/resource/after-ecj/FxPropertySimple.java
@@ -1,0 +1,178 @@
+import java.math.BigDecimal;
+import javafx.beans.property.*;
+import lombok.extern.javafx.FxProperty;
+class FxPropertySimple {
+  private @FxProperty IntegerProperty integer1;
+  private @FxProperty LongProperty long1;
+  private @FxProperty FloatProperty float1;
+  private @FxProperty DoubleProperty double1;
+  private @FxProperty BooleanProperty boolean1;
+  private @FxProperty StringProperty string1;
+  private @FxProperty ObjectProperty<BigDecimal> object1;
+  private @FxProperty ListProperty<String> list1;
+  private @FxProperty SetProperty<String> set1;
+  private @FxProperty MapProperty<String, String> map1;
+  private @FxProperty ReadOnlyIntegerProperty integer2;
+  private @FxProperty ReadOnlyLongProperty long2;
+  private @FxProperty ReadOnlyFloatProperty float2;
+  private @FxProperty ReadOnlyDoubleProperty double2;
+  private @FxProperty ReadOnlyBooleanProperty boolean2;
+  private @FxProperty ReadOnlyStringProperty string2;
+  private @FxProperty ReadOnlyObjectProperty<BigDecimal> object2;
+  private @FxProperty ReadOnlyListProperty<String> list2;
+  private @FxProperty ReadOnlySetProperty<String> set2;
+  private @FxProperty ReadOnlyMapProperty<String, String> map2;
+  FxPropertySimple() {
+    super();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.IntegerProperty integer1Property() {
+    return this.integer1;
+  }
+  public final @java.lang.SuppressWarnings("all") int getInteger1() {
+    return this.integer1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setInteger1(final int integer1) {
+    this.integer1.set(integer1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.LongProperty long1Property() {
+    return this.long1;
+  }
+  public final @java.lang.SuppressWarnings("all") long getLong1() {
+    return this.long1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setLong1(final long long1) {
+    this.long1.set(long1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.FloatProperty float1Property() {
+    return this.float1;
+  }
+  public final @java.lang.SuppressWarnings("all") float getFloat1() {
+    return this.float1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setFloat1(final float float1) {
+    this.float1.set(float1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.DoubleProperty double1Property() {
+    return this.double1;
+  }
+  public final @java.lang.SuppressWarnings("all") double getDouble1() {
+    return this.double1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setDouble1(final double double1) {
+    this.double1.set(double1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.BooleanProperty boolean1Property() {
+    return this.boolean1;
+  }
+  public final @java.lang.SuppressWarnings("all") boolean getBoolean1() {
+    return this.boolean1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setBoolean1(final boolean boolean1) {
+    this.boolean1.set(boolean1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.StringProperty string1Property() {
+    return this.string1;
+  }
+  public final @java.lang.SuppressWarnings("all") java.lang.String getString1() {
+    return this.string1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setString1(final java.lang.String string1) {
+    this.string1.set(string1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ObjectProperty<BigDecimal> object1Property() {
+    return this.object1;
+  }
+  public final @java.lang.SuppressWarnings("all") BigDecimal getObject1() {
+    return this.object1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setObject1(final BigDecimal object1) {
+    this.object1.set(object1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ListProperty<String> list1Property() {
+    return this.list1;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableList<String> getList1() {
+    return this.list1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setList1(final javafx.collections.ObservableList<String> list1) {
+    this.list1.set(list1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.SetProperty<String> set1Property() {
+    return this.set1;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableSet<String> getSet1() {
+    return this.set1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setSet1(final javafx.collections.ObservableSet<String> set1) {
+    this.set1.set(set1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.MapProperty<String, String> map1Property() {
+    return this.map1;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableMap<String, String> getMap1() {
+    return this.map1.get();
+  }
+  public final @java.lang.SuppressWarnings("all") void setMap1(final javafx.collections.ObservableMap<String, String> map1) {
+    this.map1.set(map1);
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyIntegerProperty integer2Property() {
+    return this.integer2;
+  }
+  public final @java.lang.SuppressWarnings("all") int getInteger2() {
+    return this.integer2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyLongProperty long2Property() {
+    return this.long2;
+  }
+  public final @java.lang.SuppressWarnings("all") long getLong2() {
+    return this.long2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyFloatProperty float2Property() {
+    return this.float2;
+  }
+  public final @java.lang.SuppressWarnings("all") float getFloat2() {
+    return this.float2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyDoubleProperty double2Property() {
+    return this.double2;
+  }
+  public final @java.lang.SuppressWarnings("all") double getDouble2() {
+    return this.double2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyBooleanProperty boolean2Property() {
+    return this.boolean2;
+  }
+  public final @java.lang.SuppressWarnings("all") boolean getBoolean2() {
+    return this.boolean2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyStringProperty string2Property() {
+    return this.string2;
+  }
+  public final @java.lang.SuppressWarnings("all") java.lang.String getString2() {
+    return this.string2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyObjectProperty<BigDecimal> object2Property() {
+    return this.object2;
+  }
+  public final @java.lang.SuppressWarnings("all") BigDecimal getObject2() {
+    return this.object2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyListProperty<String> list2Property() {
+    return this.list2;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableList<String> getList2() {
+    return this.list2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlySetProperty<String> set2Property() {
+    return this.set2;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableSet<String> getSet2() {
+    return this.set2.get();
+  }
+  public @java.lang.SuppressWarnings("all") javafx.beans.property.ReadOnlyMapProperty<String, String> map2Property() {
+    return this.map2;
+  }
+  public final @java.lang.SuppressWarnings("all") javafx.collections.ObservableMap<String, String> getMap2() {
+    return this.map2.get();
+  }
+}

--- a/test/transform/resource/before/FxPropertyExisting.java
+++ b/test/transform/resource/before/FxPropertyExisting.java
@@ -1,0 +1,20 @@
+import java.math.BigDecimal;
+
+import javafx.beans.property.*;
+import lombok.extern.javafx.FxProperty;
+
+class FxPropertyExisting {
+	@FxProperty private IntegerProperty integer;
+
+	public ReadOnlyIntegerProperty integerProperty() {
+		return this.integer;
+	}
+
+	public int getInteger() {
+		return this.integer.get();
+	}
+	
+	public void setInteger(int integer) {
+		this.integer.set(integer);
+	}
+}

--- a/test/transform/resource/before/FxPropertyOnClass.java
+++ b/test/transform/resource/before/FxPropertyOnClass.java
@@ -1,0 +1,29 @@
+import java.math.BigDecimal;
+
+import javafx.beans.property.*;
+import lombok.extern.javafx.FxProperty;
+
+@FxProperty
+class FxPropertyOnClass {
+	private IntegerProperty integer1;
+	private LongProperty long1;
+	private FloatProperty float1;
+	private DoubleProperty double1;
+	private BooleanProperty boolean1;
+	private StringProperty string1;
+	private ObjectProperty<BigDecimal> object1;
+	private ListProperty<String> list1;
+	private SetProperty<String> set1;
+	private MapProperty<String, String> map1;
+	
+	private ReadOnlyIntegerProperty integer2;
+	private ReadOnlyLongProperty long2;
+	private ReadOnlyFloatProperty float2;
+	private ReadOnlyDoubleProperty double2;
+	private ReadOnlyBooleanProperty boolean2;
+	private ReadOnlyStringProperty string2;
+	private ReadOnlyObjectProperty<BigDecimal> object2;
+	private ReadOnlyListProperty<String> list2;
+	private ReadOnlySetProperty<String> set2;
+	private ReadOnlyMapProperty<String, String> map2;
+}

--- a/test/transform/resource/before/FxPropertyReadOnly.java
+++ b/test/transform/resource/before/FxPropertyReadOnly.java
@@ -1,0 +1,10 @@
+import java.math.BigDecimal;
+
+import javafx.beans.property.*;
+import lombok.extern.javafx.FxProperty;
+
+@FxProperty(readOnly = true)
+class FxPropertyReadOnly {
+	private IntegerProperty integer1;
+	private ReadOnlyIntegerProperty integer2;
+}

--- a/test/transform/resource/before/FxPropertySimple.java
+++ b/test/transform/resource/before/FxPropertySimple.java
@@ -1,0 +1,28 @@
+import java.math.BigDecimal;
+
+import javafx.beans.property.*;
+import lombok.extern.javafx.FxProperty;
+
+class FxPropertySimple {
+	@FxProperty private IntegerProperty integer1;
+	@FxProperty private LongProperty long1;
+	@FxProperty private FloatProperty float1;
+	@FxProperty private DoubleProperty double1;
+	@FxProperty private BooleanProperty boolean1;
+	@FxProperty private StringProperty string1;
+	@FxProperty private ObjectProperty<BigDecimal> object1;
+	@FxProperty private ListProperty<String> list1;
+	@FxProperty private SetProperty<String> set1;
+	@FxProperty private MapProperty<String, String> map1;
+	
+	@FxProperty private ReadOnlyIntegerProperty integer2;
+	@FxProperty private ReadOnlyLongProperty long2;
+	@FxProperty private ReadOnlyFloatProperty float2;
+	@FxProperty private ReadOnlyDoubleProperty double2;
+	@FxProperty private ReadOnlyBooleanProperty boolean2;
+	@FxProperty private ReadOnlyStringProperty string2;
+	@FxProperty private ReadOnlyObjectProperty<BigDecimal> object2;
+	@FxProperty private ReadOnlyListProperty<String> list2;
+	@FxProperty private ReadOnlySetProperty<String> set2;
+	@FxProperty private ReadOnlyMapProperty<String, String> map2;
+}


### PR DESCRIPTION
This PR fixes #521 

I just updated the branch and adjusted a few minor things to be comaptible with the current master. It seems to be complete as there were no complaints about missing stuff in the linked issue. The implementation is based on the [JavaFX Property Architecture documentation](https://wiki.openjdk.java.net/display/OpenJFX/JavaFX+Property+Architecture). For each field `@FxProperty` generates a final getter, a final setter (optional) and a property getter.