### PR TITLE
Add null check for end positions

### DIFF
--- a/src/utils/lombok/javac/Javac.java
+++ b/src/utils/lombok/javac/Javac.java
@@ -392,6 +392,7 @@ public class Javac {
 	public static void storeEnd(JCTree tree, int pos, JCCompilationUnit top) {
 		try {
 			Object endPositions = JCCOMPILATIONUNIT_ENDPOSITIONS.get(top);
+			if (endPositions == null) return;
 			storeEnd.invoke(endPositions, tree, pos);
 		} catch (IllegalAccessException e) {
 			throw sneakyThrow(e);


### PR DESCRIPTION
This PR fixes #3043

This problem was not discovered by the test cases because the `CommentCollectingParser` always extends the `EndPosParser` which obviously always sets end positions. I tried change the parent to `Parser` but that breaks the test cases because `CapturingDiagnosticListener` and `PrettyPrinter` need the positions.