### PR TITLE
Make CheckerFramework's This a type annotation

### DIFF
--- a/src/core/lombok/core/configuration/CheckerFrameworkVersion.java
+++ b/src/core/lombok/core/configuration/CheckerFrameworkVersion.java
@@ -56,11 +56,11 @@ public final class CheckerFrameworkVersion implements ConfigurationValueType {
 	}
 	
 	public boolean generateReturnsReceiver() {
-		return version > 3999;
+		return version >= 3100;
 	}
 	
 	public boolean generateCalledMethods() {
-		return version > 3999;
+		return version >= 3100;
 	}
 	
 	public static CheckerFrameworkVersion valueOf(String versionString) {

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -2096,6 +2096,15 @@ public class EclipseHandlerUtil {
 		return newAnnotationArray;
 	}
 	
+	public static void addCheckerFrameworkReturnsReceiver(TypeReference returnType, ASTNode source, CheckerFrameworkVersion cfv) {
+		if (cfv.generateReturnsReceiver()) {
+			Annotation rrAnn = generateNamedAnnotation(source, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER);
+			int levels = returnType.getAnnotatableLevels();
+			returnType.annotations = new Annotation[levels][];
+			returnType.annotations[levels-1] = new Annotation[] {rrAnn};
+		}
+	}
+	
 	private static boolean arrayHasOnlyElementsOfType(Object[] array, Class<?> clazz) {
 		for (Object element : array) {
 			if (!clazz.isInstance(element))

--- a/src/core/lombok/eclipse/handlers/EclipseSingularsRecipes.java
+++ b/src/core/lombok/eclipse/handlers/EclipseSingularsRecipes.java
@@ -300,13 +300,10 @@ public class EclipseSingularsRecipes {
 		
 		// -- Utility methods --
 		
-		protected Annotation[] generateSelfReturnAnnotations(boolean deprecate, CheckerFrameworkVersion cfv, ASTNode source) {
+		protected Annotation[] generateSelfReturnAnnotations(boolean deprecate, ASTNode source) {
 			Annotation deprecated = deprecate ? generateDeprecatedAnnotation(source) : null;
-			Annotation returnsReceiver = cfv.generateReturnsReceiver() ? generateNamedAnnotation(source, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER) : null;
-			if (deprecated == null && returnsReceiver == null) return null;
-			if (deprecated == null) return new Annotation[] {returnsReceiver};
-			if (returnsReceiver == null) return new Annotation[] {deprecated};
-			return new Annotation[] {deprecated, returnsReceiver};
+			if (deprecated == null) return null;
+			return new Annotation[] {deprecated};
 		}
 		
 		/**

--- a/src/core/lombok/eclipse/handlers/HandleSetter.java
+++ b/src/core/lombok/eclipse/handlers/HandleSetter.java
@@ -34,7 +34,6 @@ import lombok.AccessLevel;
 import lombok.ConfigurationKeys;
 import lombok.Setter;
 import lombok.core.AST.Kind;
-import lombok.core.configuration.CheckerFrameworkVersion;
 import lombok.core.AnnotationValues;
 import lombok.eclipse.EclipseAnnotationHandler;
 import lombok.eclipse.EclipseNode;
@@ -191,14 +190,12 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 		ReturnStatement returnThis = null;
 		if (shouldReturnThis) {
 			returnType = cloneSelfType(fieldNode, source);
+			addCheckerFrameworkReturnsReceiver(returnType, source, getCheckerFrameworkVersion(sourceNode));
 			ThisReference thisRef = new ThisReference(pS, pE);
 			returnThis = new ReturnStatement(thisRef, pS, pE);
 		}
 		
 		MethodDeclaration d = createSetter(parent, deprecate, fieldNode, name, paramName, booleanFieldToSet, returnType, returnThis, modifier, sourceNode, onMethod, onParam);
-		if (shouldReturnThis && getCheckerFrameworkVersion(sourceNode).generateReturnsReceiver()) {
-			d.annotations = copyAnnotations(source, d.annotations, new Annotation[] { generateNamedAnnotation(source, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER) });
-		}
 		return d;
 	}
 	

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseGuavaSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseGuavaSingularizer.java
@@ -129,13 +129,14 @@ abstract class EclipseGuavaSingularizer extends EclipseSingularizer {
 		md.selector = HandlerUtil.buildAccessorName(builderType, "clear", new String(data.getPluralName())).toCharArray();
 		md.statements = returnStatement != null ? new Statement[] {a, returnStatement} : new Statement[] {a};
 		md.returnType = returnType;
-		md.annotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		addCheckerFrameworkReturnsReceiver(md.returnType, data.getSource(), cfv);
+		md.annotations = generateSelfReturnAnnotations(deprecate, data.getSource());
 		
 		data.setGeneratedByRecursive(md);
 		if (returnStatement != null) createRelevantNonNullAnnotation(builderType, md);
 		injectMethod(builderType, md);
 	}
-	
+
 	void generateSingularMethod(CheckerFrameworkVersion cfv, boolean deprecate, TypeReference returnType, Statement returnStatement, SingularData data, EclipseNode builderType, boolean fluent, AccessLevel access) {
 		LombokImmutableList<String> suffixes = getArgumentSuffixes();
 		char[][] names = new char[suffixes.size()][];
@@ -173,9 +174,10 @@ abstract class EclipseGuavaSingularizer extends EclipseSingularizer {
 			md.arguments[i].annotations = typeUseAnns;
 		}
 		md.returnType = returnType;
+		addCheckerFrameworkReturnsReceiver(md.returnType, data.getSource(), cfv);
 		char[] prefixedSingularName = data.getSetterPrefix().length == 0 ? data.getSingularName() : HandlerUtil.buildAccessorName(builderType, new String(data.getSetterPrefix()), new String(data.getSingularName())).toCharArray();
 		md.selector = fluent ? prefixedSingularName : HandlerUtil.buildAccessorName(builderType, "add", new String(data.getSingularName())).toCharArray();
-		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, data.getSource());
 		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToBuilderSingularSetterAnnotations(data.getAnnotation().up()));
 		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
 
@@ -213,9 +215,10 @@ abstract class EclipseGuavaSingularizer extends EclipseSingularizer {
 		
 		md.arguments = new Argument[] {param};
 		md.returnType = returnType;
+		addCheckerFrameworkReturnsReceiver(md.returnType, data.getSource(), cfv);
 		char[] prefixedSelector = data.getSetterPrefix().length == 0 ? data.getPluralName() : HandlerUtil.buildAccessorName(builderType, new String(data.getSetterPrefix()), new String(data.getPluralName())).toCharArray();
 		md.selector = fluent ? prefixedSelector : HandlerUtil.buildAccessorName(builderType, "addAll", new String(data.getPluralName())).toCharArray();
-		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, data.getSource());
 		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToSetterAnnotations(data.getAnnotation().up()));
 		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
 

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilListSetSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilListSetSingularizer.java
@@ -119,7 +119,8 @@ abstract class EclipseJavaUtilListSetSingularizer extends EclipseJavaUtilSingula
 		Statement clearStatement = new IfStatement(new EqualExpression(thisDotField, new NullLiteral(0, 0), OperatorIds.NOT_EQUAL), clearMsg, 0, 0);
 		md.statements = returnStatement != null ? new Statement[] {clearStatement, returnStatement} : new Statement[] {clearStatement};
 		md.returnType = returnType;
-		md.annotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		addCheckerFrameworkReturnsReceiver(md.returnType, data.getSource(), cfv);
+		md.annotations = generateSelfReturnAnnotations(deprecate, data.getSource());
 		
 		data.setGeneratedByRecursive(md);
 		if (returnStatement != null) createRelevantNonNullAnnotation(builderType, md);
@@ -151,9 +152,10 @@ abstract class EclipseJavaUtilListSetSingularizer extends EclipseJavaUtilSingula
 		param.annotations = typeUseAnns;
 		md.arguments = new Argument[] {param};
 		md.returnType = returnType;
+		addCheckerFrameworkReturnsReceiver(md.returnType, data.getSource(), cfv);
 		char[] prefixedSingularName = data.getSetterPrefix().length == 0 ? data.getSingularName() : HandlerUtil.buildAccessorName(builderType, new String(data.getSetterPrefix()), new String(data.getSingularName())).toCharArray();
 		md.selector = fluent ? prefixedSingularName : HandlerUtil.buildAccessorName(builderType, "add", new String(data.getSingularName())).toCharArray();
-		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, data.getSource());
 		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToBuilderSingularSetterAnnotations(data.getAnnotation().up()));
 		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
 		
@@ -189,9 +191,10 @@ abstract class EclipseJavaUtilListSetSingularizer extends EclipseJavaUtilSingula
 		
 		md.arguments = new Argument[] {param};
 		md.returnType = returnType;
+		addCheckerFrameworkReturnsReceiver(md.returnType, data.getSource(), cfv);
 		char[] prefixedSelector = data.getSetterPrefix().length == 0 ? data.getPluralName() : HandlerUtil.buildAccessorName(builderType, new String(data.getSetterPrefix()), new String(data.getPluralName())).toCharArray();
 		md.selector = fluent ? prefixedSelector : HandlerUtil.buildAccessorName(builderType, "addAll", new String(data.getPluralName())).toCharArray();
-		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, data.getSource());
 		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToSetterAnnotations(data.getAnnotation().up()));
 		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
 		

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilMapSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilMapSingularizer.java
@@ -189,7 +189,8 @@ public class EclipseJavaUtilMapSingularizer extends EclipseJavaUtilSingularizer 
 		Statement clearStatement = new IfStatement(new EqualExpression(thisDotField, new NullLiteral(0, 0), OperatorIds.NOT_EQUAL), clearMsgs, 0, 0);
 		md.statements = returnStatement != null ? new Statement[] {clearStatement, returnStatement} : new Statement[] {clearStatement};
 		md.returnType = returnType;
-		md.annotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		addCheckerFrameworkReturnsReceiver(md.returnType, data.getSource(), cfv);
+		md.annotations = generateSelfReturnAnnotations(deprecate, data.getSource());
 		
 		if (returnStatement != null) createRelevantNonNullAnnotation(builderType, md);
 		data.setGeneratedByRecursive(md);
@@ -246,13 +247,14 @@ public class EclipseJavaUtilMapSingularizer extends EclipseJavaUtilSingularizer 
 		valueParam.annotations = typeUseAnnsValue;
 		md.arguments = new Argument[] {keyParam, valueParam};
 		md.returnType = returnType;
+		addCheckerFrameworkReturnsReceiver(md.returnType, data.getSource(), cfv);
 		
 		String name = new String(data.getSingularName());
 		String setterPrefix = data.getSetterPrefix().length > 0 ? new String(data.getSetterPrefix()) : fluent ? "" : "put";
 		String setterName = HandlerUtil.buildAccessorName(builderType, setterPrefix, name);
 		
 		md.selector = setterName.toCharArray();
-		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, data.getSource());
 		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToBuilderSingularSetterAnnotations(data.getAnnotation().up()));
 		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
 		
@@ -322,13 +324,14 @@ public class EclipseJavaUtilMapSingularizer extends EclipseJavaUtilSingularizer 
 		
 		md.arguments = new Argument[] {param};
 		md.returnType = returnType;
+		addCheckerFrameworkReturnsReceiver(md.returnType, data.getSource(), cfv);
 		
 		String name = new String(data.getPluralName());
 		String setterPrefix = data.getSetterPrefix().length > 0 ? new String(data.getSetterPrefix()) : fluent ? "" : "put";
 		String setterName = HandlerUtil.buildAccessorName(builderType, setterPrefix, name);
 		
 		md.selector = setterName.toCharArray();
-		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, cfv, data.getSource());
+		Annotation[] selfReturnAnnotations = generateSelfReturnAnnotations(deprecate, data.getSource());
 		Annotation[] copyToSetterAnnotations = copyAnnotations(md, findCopyableToSetterAnnotations(data.getAnnotation().up()));
 		md.annotations = concat(selfReturnAnnotations, copyToSetterAnnotations, Annotation.class);
 		

--- a/src/core/lombok/javac/handlers/HandleSetter.java
+++ b/src/core/lombok/javac/handlers/HandleSetter.java
@@ -32,7 +32,6 @@ import lombok.ConfigurationKeys;
 import lombok.Setter;
 import lombok.core.AST.Kind;
 import lombok.core.AnnotationValues;
-import lombok.core.configuration.CheckerFrameworkVersion;
 import lombok.javac.Javac;
 import lombok.javac.JavacAnnotationHandler;
 import lombok.javac.JavacNode;
@@ -195,17 +194,11 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 		JCReturn returnStatement = null;
 		if (shouldReturnThis) {
 			returnType = cloneSelfType(field);
+			returnType = addCheckerFrameworkReturnsReceiver(returnType, treeMaker, field, getCheckerFrameworkVersion(source));
 			returnStatement = treeMaker.Return(treeMaker.Ident(field.toName("this")));
 		}
 		
 		JCMethodDecl d = createSetter(access, deprecate, field, treeMaker, setterName, paramName, booleanFieldToSet, returnType, returnStatement, source, onMethod, onParam);
-		if (shouldReturnThis && getCheckerFrameworkVersion(source).generateReturnsReceiver()) {
-			List<JCAnnotation> annotations = d.mods.annotations;
-			if (annotations == null) annotations = List.nil();
-			JCAnnotation anno = treeMaker.Annotation(genTypeRef(source, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER), List.<JCExpression>nil());
-			recursiveSetGeneratedBy(anno, source);
-			d.mods.annotations = annotations.prepend(anno);
-		}
 		return d;
 	}
 	
@@ -214,17 +207,11 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 		JCReturn returnStatement = null;
 		if (shouldReturnThis) {
 			returnType = cloneSelfType(field);
+			returnType = addCheckerFrameworkReturnsReceiver(returnType, treeMaker, field, getCheckerFrameworkVersion(source));
 			returnStatement = treeMaker.Return(treeMaker.Ident(field.toName("this")));
 		}
 		
 		JCMethodDecl d = createSetterWithRecv(access, deprecate, field, treeMaker, setterName, paramName, booleanFieldToSet, returnType, returnStatement, source, onMethod, onParam, recv);
-		if (shouldReturnThis && getCheckerFrameworkVersion(source).generateReturnsReceiver()) {
-			List<JCAnnotation> annotations = d.mods.annotations;
-			if (annotations == null) annotations = List.nil();
-			JCAnnotation anno = treeMaker.Annotation(genTypeRef(source, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER), List.<JCExpression>nil());
-			recursiveSetGeneratedBy(anno, source);
-			d.mods.annotations = annotations.prepend(anno);
-		}
 		return d;
 	}
 	

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -786,15 +786,14 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		JavacTreeMaker maker = job.getTreeMaker();
 		List<JCAnnotation> annotations = List.nil();
 		JCAnnotation overrideAnnotation = override ? maker.Annotation(genJavaLangTypeRef(job.builderType, "Override"), List.<JCExpression>nil()) : null;
-		JCAnnotation rrAnnotation = job.checkerFramework.generateReturnsReceiver() ? maker.Annotation(genTypeRef(job.builderType, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER), List.<JCExpression>nil()) : null;
 		JCAnnotation sefAnnotation = job.checkerFramework.generatePure() ? maker.Annotation(genTypeRef(job.builderType, CheckerFrameworkVersion.NAME__PURE), List.<JCExpression>nil()) : null;
 		if (sefAnnotation != null) annotations = annotations.prepend(sefAnnotation);
-		if (rrAnnotation != null) annotations = annotations.prepend(rrAnnotation);
 		if (overrideAnnotation != null) annotations = annotations.prepend(overrideAnnotation);
 		JCModifiers modifiers = maker.Modifiers(Flags.PROTECTED | Flags.ABSTRACT, annotations);
 		Name name = job.toName(SELF_METHOD);
 		JCExpression returnType = maker.Ident(job.toName(builderGenericName));
-		
+		returnType = addCheckerFrameworkReturnsReceiver(returnType, maker, job.builderType, job.checkerFramework);
+
 		return maker.MethodDef(modifiers, name, returnType, List.<JCTypeParameter>nil(), List.<JCVariableDecl>nil(), List.<JCExpression>nil(), null, null);
 	}
 	
@@ -802,17 +801,16 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		JavacTreeMaker maker = job.getTreeMaker();
 		
 		JCAnnotation overrideAnnotation = maker.Annotation(genJavaLangTypeRef(job.builderType, "Override"), List.<JCExpression>nil());
-		JCAnnotation rrAnnotation = job.checkerFramework.generateReturnsReceiver() ? maker.Annotation(genTypeRef(job.builderType, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER), List.<JCExpression>nil()) : null;
 		JCAnnotation sefAnnotation = job.checkerFramework.generatePure() ? maker.Annotation(genTypeRef(job.builderType, CheckerFrameworkVersion.NAME__PURE), List.<JCExpression>nil()) : null;
 		List<JCAnnotation> annsOnMethod = List.nil();
 		if (sefAnnotation != null) annsOnMethod = annsOnMethod.prepend(sefAnnotation);
-		if (rrAnnotation != null) annsOnMethod = annsOnMethod.prepend(rrAnnotation);
 		annsOnMethod = annsOnMethod.prepend(overrideAnnotation);
 		
 		JCModifiers modifiers = maker.Modifiers(Flags.PROTECTED, annsOnMethod);
 		Name name = job.toName(SELF_METHOD);
 		
 		JCExpression returnType = namePlusTypeParamsToTypeReference(maker, job.builderType.up(), job.getBuilderClassName(), false, job.typeParams);
+		returnType = addCheckerFrameworkReturnsReceiver(returnType, maker, job.builderType, job.checkerFramework);
 		JCStatement statement = maker.Return(maker.Ident(job.toName("this")));
 		JCBlock body = maker.Block(0, List.<JCStatement>of(statement));
 		
@@ -961,15 +959,9 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		JavacTreeMaker maker = fieldNode.getTreeMaker();
 		
 		List<JCAnnotation> methodAnns = JavacHandlerUtil.findCopyableToSetterAnnotations(originalFieldNode);
+		returnType = addCheckerFrameworkReturnsReceiver(returnType, maker, job.builderType, job.checkerFramework);
+
 		JCMethodDecl newMethod = HandleSetter.createSetter(Flags.PUBLIC, deprecate, fieldNode, maker, setterName, paramName, nameOfSetFlag, returnType, returnStatement, job.sourceNode, methodAnns, annosOnParam);
-		if (job.checkerFramework.generateReturnsReceiver()) {
-			List<JCAnnotation> annotations = newMethod.mods.annotations;
-			if (annotations == null) annotations = List.nil();
-			JCAnnotation anno = maker.Annotation(genTypeRef(job.builderType, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER), List.<JCExpression>nil());
-			recursiveSetGeneratedBy(anno, job.sourceNode);
-			newMethod.mods.annotations = annotations.prepend(anno);
-		}
-		
 		injectMethod(job.builderType, newMethod);
 	}
 	

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1407,6 +1407,14 @@ public class JavacHandlerUtil {
 		mods.annotations = mods.annotations.append(annotation);
 	}
 	
+	static JCExpression addCheckerFrameworkReturnsReceiver(JCExpression returnType, JavacTreeMaker maker, JavacNode typeNode, CheckerFrameworkVersion cfv) {
+		if (cfv.generateReturnsReceiver()) {
+			JCAnnotation rrAnnotation = maker.Annotation(genTypeRef(typeNode, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER), List.<JCExpression>nil());
+			returnType = maker.AnnotatedType(List.of(rrAnnotation), returnType);
+		}
+		return returnType;
+	}
+	
 	private static List<JCTree> addAllButOne(List<JCTree> defs, int idx) {
 		ListBuffer<JCTree> out = new ListBuffer<JCTree>();
 		int i = 0;

--- a/test/stubs/org/checkerframework/common/returnsreceiver/qual/This.java
+++ b/test/stubs/org/checkerframework/common/returnsreceiver/qual/This.java
@@ -1,12 +1,10 @@
 package org.checkerframework.common.returnsreceiver.qual;
 
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-@Inherited
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface This {}

--- a/test/transform/resource/after-delombok/CheckerFrameworkBasic.java
+++ b/test/transform/resource/after-delombok/CheckerFrameworkBasic.java
@@ -1,3 +1,4 @@
+// skip-idempotent
 //version 8:
 class CheckerFrameworkBasic {
 	private final int x;
@@ -21,9 +22,8 @@ class CheckerFrameworkBasic {
 	/**
 	 * @return {@code this}.
 	 */
-	@org.checkerframework.common.returnsreceiver.qual.This
 	@java.lang.SuppressWarnings("all")
-	public CheckerFrameworkBasic setZ(final int z) {
+	public @org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBasic setZ(final int z) {
 		this.z = z;
 		return this;
 	}

--- a/test/transform/resource/after-delombok/CheckerFrameworkBuilder.java
+++ b/test/transform/resource/after-delombok/CheckerFrameworkBuilder.java
@@ -1,4 +1,3 @@
-// skip-idempotent
 import java.util.List;
 class CheckerFrameworkBuilder {
 	int x;
@@ -34,9 +33,8 @@ class CheckerFrameworkBuilder {
 		/**
 		 * @return {@code this}.
 		 */
-		@org.checkerframework.common.returnsreceiver.qual.This
 		@java.lang.SuppressWarnings("all")
-		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder x(final int x) {
+		public CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder x(final int x) {
 			this.x$value = x;
 			x$set = true;
 			return this;
@@ -44,31 +42,27 @@ class CheckerFrameworkBuilder {
 		/**
 		 * @return {@code this}.
 		 */
-		@org.checkerframework.common.returnsreceiver.qual.This
 		@java.lang.SuppressWarnings("all")
-		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder y(final int y) {
+		public CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder y(final int y) {
 			this.y = y;
 			return this;
 		}
 		/**
 		 * @return {@code this}.
 		 */
-		@org.checkerframework.common.returnsreceiver.qual.This
 		@java.lang.SuppressWarnings("all")
-		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder z(final int z) {
+		public CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder z(final int z) {
 			this.z = z;
 			return this;
 		}
-		@org.checkerframework.common.returnsreceiver.qual.This
 		@java.lang.SuppressWarnings("all")
-		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder name(final String name) {
+		public CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder name(final String name) {
 			if (this.names == null) this.names = new java.util.ArrayList<String>();
 			this.names.add(name);
 			return this;
 		}
-		@org.checkerframework.common.returnsreceiver.qual.This
 		@java.lang.SuppressWarnings("all")
-		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder names(final java.util.Collection<? extends String> names) {
+		public CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder names(final java.util.Collection<? extends String> names) {
 			if (names == null) {
 				throw new java.lang.NullPointerException("names cannot be null");
 			}
@@ -76,9 +70,8 @@ class CheckerFrameworkBuilder {
 			this.names.addAll(names);
 			return this;
 		}
-		@org.checkerframework.common.returnsreceiver.qual.This
 		@java.lang.SuppressWarnings("all")
-		public CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder clearNames() {
+		public CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder clearNames() {
 			if (this.names != null) this.names.clear();
 			return this;
 		}

--- a/test/transform/resource/after-delombok/CheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-delombok/CheckerFrameworkSuperBuilder.java
@@ -1,3 +1,4 @@
+// skip-idempotent
 //version 8:
 import java.util.List;
 class CheckerFrameworkSuperBuilder {
@@ -22,19 +23,17 @@ class CheckerFrameworkSuperBuilder {
 			private int z;
 			@java.lang.SuppressWarnings("all")
 			private java.util.ArrayList<String> names;
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@org.checkerframework.dataflow.qual.Pure
 			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
+			protected abstract @org.checkerframework.common.returnsreceiver.qual.This B self();
 			@org.checkerframework.dataflow.qual.SideEffectFree
 			@java.lang.SuppressWarnings("all")
 			public abstract C build(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilder<C, B> this);
 			/**
 			 * @return {@code this}.
 			 */
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B x(final int x) {
+			public @org.checkerframework.common.returnsreceiver.qual.This B x(final int x) {
 				this.x$value = x;
 				x$set = true;
 				return self();
@@ -42,31 +41,27 @@ class CheckerFrameworkSuperBuilder {
 			/**
 			 * @return {@code this}.
 			 */
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B y(final int y) {
+			public @org.checkerframework.common.returnsreceiver.qual.This B y(final int y) {
 				this.y = y;
 				return self();
 			}
 			/**
 			 * @return {@code this}.
 			 */
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B z(final int z) {
+			public @org.checkerframework.common.returnsreceiver.qual.This B z(final int z) {
 				this.z = z;
 				return self();
 			}
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B name(final String name) {
+			public @org.checkerframework.common.returnsreceiver.qual.This B name(final String name) {
 				if (this.names == null) this.names = new java.util.ArrayList<String>();
 				this.names.add(name);
 				return self();
 			}
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B names(final java.util.Collection<? extends String> names) {
+			public @org.checkerframework.common.returnsreceiver.qual.This B names(final java.util.Collection<? extends String> names) {
 				if (names == null) {
 					throw new java.lang.NullPointerException("names cannot be null");
 				}
@@ -74,9 +69,8 @@ class CheckerFrameworkSuperBuilder {
 				this.names.addAll(names);
 				return self();
 			}
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B clearNames() {
+			public @org.checkerframework.common.returnsreceiver.qual.This B clearNames() {
 				if (this.names != null) this.names.clear();
 				return self();
 			}
@@ -93,10 +87,9 @@ class CheckerFrameworkSuperBuilder {
 			private ParentBuilderImpl() {
 			}
 			@java.lang.Override
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@org.checkerframework.dataflow.qual.Pure
 			@java.lang.SuppressWarnings("all")
-			protected CheckerFrameworkSuperBuilder.Parent.ParentBuilderImpl self() {
+			protected CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.common.returnsreceiver.qual.This ParentBuilderImpl self() {
 				return this;
 			}
 			@org.checkerframework.dataflow.qual.SideEffectFree
@@ -148,10 +141,9 @@ class CheckerFrameworkSuperBuilder {
 			@java.lang.SuppressWarnings("all")
 			private int b;
 			@java.lang.Override
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@org.checkerframework.dataflow.qual.Pure
 			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
+			protected abstract @org.checkerframework.common.returnsreceiver.qual.This B self();
 			@org.checkerframework.dataflow.qual.SideEffectFree
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
@@ -159,9 +151,8 @@ class CheckerFrameworkSuperBuilder {
 			/**
 			 * @return {@code this}.
 			 */
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B a(final int a) {
+			public @org.checkerframework.common.returnsreceiver.qual.This B a(final int a) {
 				this.a$value = a;
 				a$set = true;
 				return self();
@@ -169,9 +160,8 @@ class CheckerFrameworkSuperBuilder {
 			/**
 			 * @return {@code this}.
 			 */
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@java.lang.SuppressWarnings("all")
-			public B b(final int b) {
+			public @org.checkerframework.common.returnsreceiver.qual.This B b(final int b) {
 				this.b = b;
 				return self();
 			}
@@ -188,10 +178,9 @@ class CheckerFrameworkSuperBuilder {
 			private ZChildBuilderImpl() {
 			}
 			@java.lang.Override
-			@org.checkerframework.common.returnsreceiver.qual.This
 			@org.checkerframework.dataflow.qual.Pure
 			@java.lang.SuppressWarnings("all")
-			protected CheckerFrameworkSuperBuilder.ZChild.ZChildBuilderImpl self() {
+			protected CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.common.returnsreceiver.qual.This ZChildBuilderImpl self() {
 				return this;
 			}
 			@org.checkerframework.dataflow.qual.SideEffectFree

--- a/test/transform/resource/after-ecj/CheckerFrameworkBasic.java
+++ b/test/transform/resource/after-ecj/CheckerFrameworkBasic.java
@@ -24,7 +24,7 @@ import lombok.With;
   /**
    * @return {@code this}.
    */
-  public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBasic setZ(final int z) {
+  public @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBasic setZ(final int z) {
     this.z = z;
     return this;
   }

--- a/test/transform/resource/after-ecj/CheckerFrameworkBuilder.java
+++ b/test/transform/resource/after-ecj/CheckerFrameworkBuilder.java
@@ -14,7 +14,7 @@ import lombok.Singular;
     /**
      * @return {@code this}.
      */
-    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder x(final int x) {
+    public @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder x(final int x) {
       this.x$value = x;
       x$set = true;
       return this;
@@ -22,24 +22,24 @@ import lombok.Singular;
     /**
      * @return {@code this}.
      */
-    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder y(final int y) {
+    public @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder y(final int y) {
       this.y = y;
       return this;
     }
     /**
      * @return {@code this}.
      */
-    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder z(final int z) {
+    public @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder z(final int z) {
       this.z = z;
       return this;
     }
-    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder name(final String name) {
+    public @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder name(final String name) {
       if ((this.names == null))
           this.names = new java.util.ArrayList<String>();
       this.names.add(name);
       return this;
     }
-    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder names(final java.util.Collection<? extends String> names) {
+    public @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder names(final java.util.Collection<? extends String> names) {
       if ((names == null))
           {
             throw new java.lang.NullPointerException("names cannot be null");
@@ -49,7 +49,7 @@ import lombok.Singular;
       this.names.addAll(names);
       return this;
     }
-    public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder clearNames() {
+    public @java.lang.SuppressWarnings("all") CheckerFrameworkBuilder.@org.checkerframework.common.returnsreceiver.qual.This CheckerFrameworkBuilderBuilder clearNames() {
       if ((this.names != null))
           this.names.clear();
       return this;

--- a/test/transform/resource/after-ecj/CheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-ecj/CheckerFrameworkSuperBuilder.java
@@ -11,12 +11,12 @@ class CheckerFrameworkSuperBuilder {
       public ParentBuilder() {
         super();
       }
-      protected abstract @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") B self();
+      protected abstract @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B self();
       public abstract @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilder<C, B> this);
       /**
        * @return {@code this}.
        */
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B x(final int x) {
+      public @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B x(final int x) {
         this.x$value = x;
         x$set = true;
         return self();
@@ -24,24 +24,24 @@ class CheckerFrameworkSuperBuilder {
       /**
        * @return {@code this}.
        */
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B y(final int y) {
+      public @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B y(final int y) {
         this.y = y;
         return self();
       }
       /**
        * @return {@code this}.
        */
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B z(final int z) {
+      public @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B z(final int z) {
         this.z = z;
         return self();
       }
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B name(final String name) {
+      public @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B name(final String name) {
         if ((this.names == null))
             this.names = new java.util.ArrayList<String>();
         this.names.add(name);
         return self();
       }
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B names(final java.util.Collection<? extends String> names) {
+      public @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B names(final java.util.Collection<? extends String> names) {
         if ((names == null))
             {
               throw new java.lang.NullPointerException("names cannot be null");
@@ -51,7 +51,7 @@ class CheckerFrameworkSuperBuilder {
         this.names.addAll(names);
         return self();
       }
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B clearNames() {
+      public @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B clearNames() {
         if ((this.names != null))
             this.names.clear();
         return self();
@@ -64,7 +64,7 @@ class CheckerFrameworkSuperBuilder {
       private ParentBuilderImpl() {
         super();
       }
-      protected @java.lang.Override @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.Parent.ParentBuilderImpl self() {
+      protected @java.lang.Override @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.common.returnsreceiver.qual.This ParentBuilderImpl self() {
         return this;
       }
       public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.Parent build(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilderImpl this) {
@@ -111,12 +111,12 @@ class CheckerFrameworkSuperBuilder {
       public ZChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") B self();
+      protected abstract @java.lang.Override @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B self();
       public abstract @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(CheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilder<C, B> this);
       /**
        * @return {@code this}.
        */
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B a(final int a) {
+      public @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B a(final int a) {
         this.a$value = a;
         a$set = true;
         return self();
@@ -124,7 +124,7 @@ class CheckerFrameworkSuperBuilder {
       /**
        * @return {@code this}.
        */
-      public @org.checkerframework.common.returnsreceiver.qual.This @java.lang.SuppressWarnings("all") B b(final int b) {
+      public @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B b(final int b) {
         this.b = b;
         return self();
       }
@@ -136,7 +136,7 @@ class CheckerFrameworkSuperBuilder {
       private ZChildBuilderImpl() {
         super();
       }
-      protected @java.lang.Override @org.checkerframework.common.returnsreceiver.qual.This @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.ZChild.ZChildBuilderImpl self() {
+      protected @java.lang.Override @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.common.returnsreceiver.qual.This ZChildBuilderImpl self() {
         return this;
       }
       public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") CheckerFrameworkSuperBuilder.ZChild build(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilderImpl this) {


### PR DESCRIPTION
This PR makes lombok generate Checker Framework's `@This` as type annotation, as it is defined by the Checker Framework.
It fixes #3081.

Furthermore, it generates `@This` and `@CalledMethods` already starting at CF version 3.10.0. These annotations may even be added earlier, but I did not go through all the CF history; I guess 3.10.0 is far enough in the past. ;)

Note: I have no idea why these changes break the idempotent tests for `CheckerFrameworkSuperBuilder` and `CheckerFrameworkBasic`, but `CheckerFrameworkBuilder` works.