### PR TITLE
Update inner class type when creating a static class

### DIFF
--- a/src/core/lombok/javac/handlers/HandleUtilityClass.java
+++ b/src/core/lombok/javac/handlers/HandleUtilityClass.java
@@ -25,6 +25,9 @@ import static lombok.core.handlers.HandlerUtil.handleExperimentalFlagUsage;
 import static lombok.javac.handlers.JavacHandlerUtil.*;
 
 import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Type.ClassType;
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
@@ -124,6 +127,10 @@ public class HandleUtilityClass extends JavacAnnotationHandler<UtilityClass> {
 			} else if (element.getKind() == Kind.TYPE) {
 				JCClassDecl innerClassDecl = (JCClassDecl) element.get();
 				innerClassDecl.mods.flags |= Flags.STATIC;
+				ClassSymbol innerClassSymbol = innerClassDecl.sym;
+				if (innerClassSymbol != null && innerClassSymbol.type instanceof ClassType) {
+					((ClassType) innerClassSymbol.type).setEnclosingType(Type.noType);
+				}
 			}
 		}
 		

--- a/test/transform/resource/after-delombok/UtilityClass.java
+++ b/test/transform/resource/after-delombok/UtilityClass.java
@@ -2,8 +2,13 @@ final class UtilityClass {
 	private static long someField = System.currentTimeMillis();
 	static void someMethod() {
 		System.out.println();
+		new InnerClass();
+		new InnerStaticClass();
 	}
 	protected static class InnerClass {
+		private String innerInnerMember;
+	}
+	protected static class InnerStaticClass {
 		private String innerInnerMember;
 	}
 	@java.lang.SuppressWarnings("all")

--- a/test/transform/resource/after-ecj/UtilityClass.java
+++ b/test/transform/resource/after-ecj/UtilityClass.java
@@ -5,11 +5,19 @@ final @lombok.experimental.UtilityClass class UtilityClass {
       super();
     }
   }
+  protected static class InnerStaticClass {
+    private String innerInnerMember;
+    protected InnerStaticClass() {
+      super();
+    }
+  }
   private static long someField = System.currentTimeMillis();
   <clinit>() {
   }
   static void someMethod() {
     System.out.println();
+    new InnerClass();
+    new InnerStaticClass();
   }
   private @java.lang.SuppressWarnings("all") UtilityClass() {
     super();

--- a/test/transform/resource/before/UtilityClass.java
+++ b/test/transform/resource/before/UtilityClass.java
@@ -4,9 +4,15 @@ class UtilityClass {
 	
 	void someMethod() {
 		System.out.println();
+		new InnerClass();
+		new InnerStaticClass();
 	}
 	
 	protected class InnerClass {
+		private String innerInnerMember;
+	}
+	
+	protected static class InnerStaticClass {
 		private String innerInnerMember;
 	}
 }


### PR DESCRIPTION
This PR fixes #3097

Inner classes reference the outer type, if we convert it into a static class we have to remove this reference because `javac` > 8 checks if this reference is valid.