### PR TITLE
Delay default annotation removal

### DIFF
--- a/src/core/lombok/javac/handlers/HandleBuilderDefaultRemove.java
+++ b/src/core/lombok/javac/handlers/HandleBuilderDefaultRemove.java
@@ -40,5 +40,6 @@ import lombok.spi.Provides;
 public class HandleBuilderDefaultRemove extends JavacAnnotationHandler<Builder.Default> {
 	@Override public void handle(AnnotationValues<Default> annotation, JCAnnotation ast, JavacNode annotationNode) {
 		deleteAnnotationIfNeccessary(annotationNode, Builder.Default.class);
+		deleteImportFromCompilationUnit(annotationNode, Builder.class.getName());
 	}
 }

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -177,7 +177,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		boolean valuePresent = (hasAnnotation(lombok.Value.class, parent) || hasAnnotation("lombok.experimental.Value", parent));
 		for (JavacNode fieldNode : HandleConstructor.findAllFields(parent, true)) {
 			JCVariableDecl fd = (JCVariableDecl) fieldNode.get();
-			JavacNode isDefault = findAnnotation(Builder.Default.class, fieldNode, true);
+			JavacNode isDefault = findAnnotation(Builder.Default.class, fieldNode, false);
 			boolean isFinal = (fd.mods.flags & Flags.FINAL) != 0 || (valuePresent && !hasAnnotation(NonFinal.class, fieldNode));
 			BuilderFieldData bfd = new BuilderFieldData();
 			bfd.rawName = fd.name;
@@ -190,11 +190,13 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			
 			if (bfd.singularData != null && isDefault != null) {
 				isDefault.addError("@Builder.Default and @Singular cannot be mixed.");
+				findAnnotation(Builder.Default.class, fieldNode, true);
 				isDefault = null;
 			}
 			
 			if (fd.init == null && isDefault != null) {
 				isDefault.addWarning("@Builder.Default requires an initializing expression (' = something;').");
+				findAnnotation(Builder.Default.class, fieldNode, true);
 				isDefault = null;
 			}
 			

--- a/test/transform/resource/after-delombok/ConstructorsWithSuperBuilderDefaults.java
+++ b/test/transform/resource/after-delombok/ConstructorsWithSuperBuilderDefaults.java
@@ -1,0 +1,94 @@
+class ConstructorsWithSuperBuilderDefaults {
+	int x;
+	int y;
+
+	@java.lang.SuppressWarnings("all")
+	private static int $default$x() {
+		return 5;
+	}
+
+
+	@java.lang.SuppressWarnings("all")
+	public static abstract class ConstructorsWithSuperBuilderDefaultsBuilder<C extends ConstructorsWithSuperBuilderDefaults, B extends ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilder<C, B>> {
+		@java.lang.SuppressWarnings("all")
+		private boolean x$set;
+		@java.lang.SuppressWarnings("all")
+		private int x$value;
+		@java.lang.SuppressWarnings("all")
+		private int y;
+
+		@java.lang.SuppressWarnings("all")
+		protected abstract B self();
+
+		@java.lang.SuppressWarnings("all")
+		public abstract C build();
+
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public B x(final int x) {
+			this.x$value = x;
+			x$set = true;
+			return self();
+		}
+
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public B y(final int y) {
+			this.y = y;
+			return self();
+		}
+
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilder(x$value=" + this.x$value + ", y=" + this.y + ")";
+		}
+	}
+
+
+	@java.lang.SuppressWarnings("all")
+	private static final class ConstructorsWithSuperBuilderDefaultsBuilderImpl extends ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilder<ConstructorsWithSuperBuilderDefaults, ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilderImpl> {
+		@java.lang.SuppressWarnings("all")
+		private ConstructorsWithSuperBuilderDefaultsBuilderImpl() {
+		}
+
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		protected ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilderImpl self() {
+			return this;
+		}
+
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public ConstructorsWithSuperBuilderDefaults build() {
+			return new ConstructorsWithSuperBuilderDefaults(this);
+		}
+	}
+
+	@java.lang.SuppressWarnings("all")
+	protected ConstructorsWithSuperBuilderDefaults(final ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilder<?, ?> b) {
+		if (b.x$set) this.x = b.x$value;
+		 else this.x = ConstructorsWithSuperBuilderDefaults.$default$x();
+		this.y = b.y;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public static ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilder<?, ?> builder() {
+		return new ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilderImpl();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public ConstructorsWithSuperBuilderDefaults() {
+		this.x = ConstructorsWithSuperBuilderDefaults.$default$x();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public ConstructorsWithSuperBuilderDefaults(final int x, final int y) {
+		this.x = x;
+		this.y = y;
+	}
+}

--- a/test/transform/resource/after-delombok/SuperBuilderWithDefaultsAndTargetTyping.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithDefaultsAndTargetTyping.java
@@ -1,5 +1,4 @@
 import java.util.Arrays;
-import lombok.Builder;
 
 public class SuperBuilderWithDefaultsAndTargetTyping {
 

--- a/test/transform/resource/after-ecj/ConstructorsWithSuperBuilderDefaults.java
+++ b/test/transform/resource/after-ecj/ConstructorsWithSuperBuilderDefaults.java
@@ -1,0 +1,70 @@
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.Builder;
+@NoArgsConstructor @AllArgsConstructor @SuperBuilder class ConstructorsWithSuperBuilderDefaults {
+  public static abstract @java.lang.SuppressWarnings("all") class ConstructorsWithSuperBuilderDefaultsBuilder<C extends ConstructorsWithSuperBuilderDefaults, B extends ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilder<C, B>> {
+    private @java.lang.SuppressWarnings("all") int x$value;
+    private @java.lang.SuppressWarnings("all") boolean x$set;
+    private @java.lang.SuppressWarnings("all") int y;
+    public ConstructorsWithSuperBuilderDefaultsBuilder() {
+      super();
+    }
+    protected abstract @java.lang.SuppressWarnings("all") B self();
+    public abstract @java.lang.SuppressWarnings("all") C build();
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") B x(final int x) {
+      this.x$value = x;
+      x$set = true;
+      return self();
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") B y(final int y) {
+      this.y = y;
+      return self();
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (((("ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilder(x$value=" + this.x$value) + ", y=") + this.y) + ")");
+    }
+  }
+  private static final @java.lang.SuppressWarnings("all") class ConstructorsWithSuperBuilderDefaultsBuilderImpl extends ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilder<ConstructorsWithSuperBuilderDefaults, ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilderImpl> {
+    private ConstructorsWithSuperBuilderDefaultsBuilderImpl() {
+      super();
+    }
+    protected @java.lang.Override @java.lang.SuppressWarnings("all") ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilderImpl self() {
+      return this;
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") ConstructorsWithSuperBuilderDefaults build() {
+      return new ConstructorsWithSuperBuilderDefaults(this);
+    }
+  }
+  @Builder.Default int x;
+  int y;
+  private static @java.lang.SuppressWarnings("all") int $default$x() {
+    return 5;
+  }
+  protected @java.lang.SuppressWarnings("all") ConstructorsWithSuperBuilderDefaults(final ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilder<?, ?> b) {
+    super();
+    if (b.x$set)
+        this.x = b.x$value;
+    else
+        this.x = ConstructorsWithSuperBuilderDefaults.$default$x();
+    this.y = b.y;
+  }
+  public static @java.lang.SuppressWarnings("all") ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilder<?, ?> builder() {
+    return new ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilderImpl();
+  }
+  public @java.lang.SuppressWarnings("all") ConstructorsWithSuperBuilderDefaults() {
+    super();
+    this.x = ConstructorsWithSuperBuilderDefaults.$default$x();
+  }
+  public @java.lang.SuppressWarnings("all") ConstructorsWithSuperBuilderDefaults(final int x, final int y) {
+    super();
+    this.x = x;
+    this.y = y;
+  }
+}

--- a/test/transform/resource/before/ConstructorsWithSuperBuilderDefaults.java
+++ b/test/transform/resource/before/ConstructorsWithSuperBuilderDefaults.java
@@ -1,0 +1,12 @@
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.Builder;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+class ConstructorsWithSuperBuilderDefaults {
+	@Builder.Default int x = 5;
+	int y;
+}


### PR DESCRIPTION
This PR fixes #3053

Some time ago `@NoArgsConstructor` was changed to also use `@Builder.Default` initializers. Unlike `@Builder`, `@SuperBuilder` removes this annotation while doing its work and `@NoArgsConstructor` is unable to detect these fields.