### PR TITLE
Add annotation bits to annotation copy targets

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleConstructor.java
+++ b/src/core/lombok/eclipse/handlers/HandleConstructor.java
@@ -41,6 +41,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.core.AST.Kind;
 import lombok.core.configuration.CheckerFrameworkVersion;
 import lombok.core.AnnotationValues;
+import lombok.eclipse.Eclipse;
 import lombok.eclipse.EclipseAnnotationHandler;
 import lombok.eclipse.EclipseNode;
 import lombok.eclipse.handlers.EclipseHandlerUtil.MemberExistsResult;
@@ -414,6 +415,10 @@ public class HandleConstructor {
 				if (nullCheck != null) nullChecks.add(nullCheck);
 			}
 			parameter.annotations = copyAnnotations(source, copyableAnnotations);
+			if (parameter.annotations != null) {
+				parameter.bits |= Eclipse.HasTypeAnnotations;
+				constructor.bits |= Eclipse.HasTypeAnnotations;
+			}
 			params.add(parameter);
 		}
 		
@@ -555,6 +560,10 @@ public class HandleConstructor {
 			
 			Argument parameter = new Argument(field.name, fieldPos, copyType(field.type, source), Modifier.FINAL);
 			parameter.annotations = copyAnnotations(source, findCopyableAnnotations(fieldNode));
+			if (parameter.annotations != null) {
+				parameter.bits |= Eclipse.HasTypeAnnotations;
+				constructor.bits |= Eclipse.HasTypeAnnotations;
+			}
 			params.add(parameter);
 		}
 		

--- a/src/core/lombok/eclipse/handlers/HandleSetter.java
+++ b/src/core/lombok/eclipse/handlers/HandleSetter.java
@@ -35,6 +35,7 @@ import lombok.ConfigurationKeys;
 import lombok.Setter;
 import lombok.core.AST.Kind;
 import lombok.core.AnnotationValues;
+import lombok.eclipse.Eclipse;
 import lombok.eclipse.EclipseAnnotationHandler;
 import lombok.eclipse.EclipseNode;
 import lombok.experimental.Accessors;
@@ -256,6 +257,10 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 		}
 		method.statements = statements.toArray(new Statement[0]);
 		param.annotations = copyAnnotations(source, copyableAnnotations, onParam.toArray(new Annotation[0]));
+		if (param.annotations != null) {
+			param.bits |= Eclipse.HasTypeAnnotations;
+			method.bits |= Eclipse.HasTypeAnnotations;
+		}
 		
 		if (returnType != null && returnStatement != null) createRelevantNonNullAnnotation(sourceNode, method);
 		

--- a/src/utils/lombok/eclipse/Eclipse.java
+++ b/src/utils/lombok/eclipse/Eclipse.java
@@ -66,6 +66,7 @@ public class Eclipse {
 	public static final int AccRecord = ASTNode.Bit25; // ECM.AccRecord
 	public static final int IsCanonicalConstructor = ASTNode.Bit10; // ASTNode.IsCanonicalConstructor
 	public static final int IsImplicit = ASTNode.Bit11; // ASTNode.IsImplicit
+	public static final int HasTypeAnnotations = ASTNode.Bit21; // ASTNode.HasTypeAnnotations
 	
 	private static final Pattern SPLIT_AT_DOT = Pattern.compile("\\.");
 	


### PR DESCRIPTION
This PR fixes #3133

The bits are required to generate the correct bytecode.