### PR TITLE
Search patched method also by parameters

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -332,10 +332,16 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 	
 	private static void patchHideGeneratedNodes(ScriptManager sm) {
 		sm.addScriptIfWitness(OSGI_TYPES, ScriptBuilder.wrapReturnValue()
-				.target(new MethodTarget("org.eclipse.jdt.internal.corext.dom.LinkedNodeFinder", "findByNode"))
+				.target(new MethodTarget("org.eclipse.jdt.internal.corext.dom.LinkedNodeFinder", "findByNode", "org.eclipse.jdt.core.dom.SimpleName[]", "org.eclipse.jdt.core.dom.ASTNode", "org.eclipse.jdt.core.dom.SimpleName"))
 				.target(new MethodTarget("org.eclipse.jdt.internal.corext.dom.LinkedNodeFinder", "findByBinding"))
 				.wrapMethod(new Hook("lombok.launch.PatchFixesHider$PatchFixes", "removeGeneratedSimpleNames", "org.eclipse.jdt.core.dom.SimpleName[]",
 						"org.eclipse.jdt.core.dom.SimpleName[]"))
+				.request(StackRequest.RETURN_VALUE).build());
+		
+		sm.addScriptIfWitness(OSGI_TYPES, ScriptBuilder.wrapReturnValue()
+				.target(new MethodTarget("org.eclipse.jdt.internal.corext.dom.LinkedNodeFinder", "findByNode", "org.eclipse.jdt.core.dom.Name[]", "org.eclipse.jdt.core.dom.ASTNode", "org.eclipse.jdt.core.dom.Name"))
+				.wrapMethod(new Hook("lombok.launch.PatchFixesHider$PatchFixes", "removeGeneratedNames", "org.eclipse.jdt.core.dom.Name[]",
+						"org.eclipse.jdt.core.dom.Name[]"))
 				.request(StackRequest.RETURN_VALUE).build());
 		
 		sm.addScriptIfWitness(OSGI_TYPES, ScriptBuilder.exitEarly()

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.Type;
@@ -778,6 +779,22 @@ final class PatchFixesHider {
 				if (in[i] == null || !((Boolean)f.get(in[i])).booleanValue()) newSimpleNames[count++] = in[i];
 			}
 			return newSimpleNames;
+		}
+		
+		public static Name[] removeGeneratedNames(Name[] in) throws Exception {
+			Field f = Name.class.getField("$isGenerated");
+			
+			int count = 0;
+			for (int i = 0; i < in.length; i++) {
+				if (in[i] == null || !((Boolean)f.get(in[i])).booleanValue()) count++;
+			}
+			if (count == in.length) return in;
+			Name[] newNames = new Name[count];
+			count = 0;
+			for (int i = 0; i < in.length; i++) {
+				if (in[i] == null || !((Boolean)f.get(in[i])).booleanValue()) newNames[count++] = in[i];
+			}
+			return newNames;
 		}
 		
 		public static Annotation[] convertAnnotations(Annotation[] out, IAnnotatable annotatable) {


### PR DESCRIPTION
This PR fixes #3134

Eclipse added a new `findByNode` method to `LinkedNodeFinder`. Because both use the same name we need to include the parameters in the search to find the correct one. I also added a patch for the new method.