### PR TITLE
Improve the handling of ExtensionMethod arguments

### DIFF
--- a/test/transform/resource/after-delombok/ExtensionMethodFunctional.java
+++ b/test/transform/resource/after-delombok/ExtensionMethodFunctional.java
@@ -11,6 +11,7 @@ class ExtensionMethodFunctional {
 		test = ExtensionMethodFunctional.Extensions.map(test, s -> ExtensionMethodFunctional.Extensions.reverse(s));
 		ExtensionMethodFunctional.Extensions.consume(test, s -> System.out.println("1: " + s), s -> System.out.println("2: " + s));
 		ExtensionMethodFunctional.Extensions.consume(test, System.out::println, System.out::println);
+		ExtensionMethodFunctional.Extensions.consume(test, test.length() > 0 ? System.out::println : null);
 		ExtensionMethodFunctional.Extensions.toList1(Stream.of("a", "b", "c").map(String::toUpperCase));
 		List<Integer> i2 = ExtensionMethodFunctional.Extensions.toList2(Stream.of("a", "b", "c").map(String::toUpperCase));
 	}

--- a/test/transform/resource/after-ecj/ExtensionMethodFunctional.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodFunctional.java
@@ -36,6 +36,7 @@ import lombok.experimental.ExtensionMethod;
     test = ExtensionMethodFunctional.Extensions.map(test, (<no type> s) -> ExtensionMethodFunctional.Extensions.reverse(s));
     ExtensionMethodFunctional.Extensions.consume(test, (<no type> s) -> System.out.println(("1: " + s)), (<no type> s) -> System.out.println(("2: " + s)));
     ExtensionMethodFunctional.Extensions.consume(test, System.out::println, System.out::println);
+    ExtensionMethodFunctional.Extensions.consume(test, ((test.length() > 0) ? System.out::println : null));
     ExtensionMethodFunctional.Extensions.toList1(Stream.of("a", "b", "c").map(String::toUpperCase));
     List<Integer> i2 = ExtensionMethodFunctional.Extensions.toList2(Stream.of("a", "b", "c").map(String::toUpperCase));
   }

--- a/test/transform/resource/before/ExtensionMethodFunctional.java
+++ b/test/transform/resource/before/ExtensionMethodFunctional.java
@@ -16,6 +16,8 @@ class ExtensionMethodFunctional {
 		test.consume(s -> System.out.println("1: " + s), s -> System.out.println("2: " + s));
 		test.consume(System.out::println, System.out::println);
 		
+		test.consume(test.length() > 0 ? System.out::println : null);
+		
 		Stream.of("a", "b", "c").map(String::toUpperCase).toList1();
 		List<Integer> i2 = Stream.of("a", "b", "c").map(String::toUpperCase).toList2();
 	}


### PR DESCRIPTION
This PR fixes #3153

A conditional expression with at least one functional part must be treated in the same way as a functional expression.