### PR TITLE
Fix typo in StandardException documentation

### DIFF
--- a/website/templates/features/experimental/StandardException.html
+++ b/website/templates/features/experimental/StandardException.html
@@ -10,7 +10,7 @@
 
 	<@f.overview>
 		<p>
-			Put this annotation on your own exception types (new classes that <code>extends Exception</code> or anything else that inherits from <code>Throwable</code>. This annotation will then generate up to 4 constructors:
+			Put this annotation on your own exception types (new classes that <code>extends Exception</code> or anything else that inherits from <code>Throwable</code>). This annotation will then generate up to 4 constructors:
 		</p><ul>
 			<li>A no-args constructor (<code>MyException()</code>), representing no message, and no cause.</li>
 			<li>A message-only constructor (<code>MyException(String message)</code>), representing the provided message, and no cause.</li>


### PR DESCRIPTION
Closed parenthesis in the StandardException page of the website.