### PR TITLE
[fixes #1498] Respect @Tolerate when using @Singular

### DIFF
--- a/src/core/lombok/eclipse/handlers/EclipseSingularsRecipes.java
+++ b/src/core/lombok/eclipse/handlers/EclipseSingularsRecipes.java
@@ -226,6 +226,7 @@ public class EclipseSingularsRecipes {
 				}
 				case METHOD: {
 					AbstractMethodDeclaration method = (AbstractMethodDeclaration) child.get();
+					if (isTolerate(child, method)) continue;
 					char[] name = method.selector;
 					if (name == null) continue;
 					if (getGeneratedBy(method) != null) continue;

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -208,6 +208,7 @@ public class JavacSingularsRecipes {
 				}
 				case METHOD: {
 					JCMethodDecl method = (JCMethodDecl) child.get();
+					if (isTolerate(child, method)) continue;
 					Name name = method.name;
 					if (name == null) break;
 					if (getGeneratedBy(method) != null) continue;


### PR DESCRIPTION
This fixes #1498 and provides a solution to #1841.

```java
import java.util.List;

import lombok.Builder;
import lombok.Singular;
import lombok.experimental.Tolerate;

@Builder
public class Foo {
	
	public static class FooBuilder {
		
		@Tolerate
		public FooBuilder bar(Integer i) {
			bar(i.toString());
			return this;
		}
	}
	
	@Singular
	private final List<String> bars;
}

```

This code currently produces the following error: `Manually adding a method that @Singular @Builder would generate is not supported. If you want to manually manage the builder aspect for this field/parameter, don't use @Singular.`

With this fix, it is possible to manually suppress this error with `@Tolerate`. It enables adding convenience methods with the same name as the generated methods.