### PR TITLE
Copy field name arrays in (Super)Builder

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -983,7 +983,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 				}
 				
 				if (field == null) {
-					FieldDeclaration fd = new FieldDeclaration(bfd.builderFieldName, 0, 0);
+					FieldDeclaration fd = new FieldDeclaration(bfd.builderFieldName.clone(), 0, 0);
 					fd.bits |= Eclipse.ECLIPSE_DO_NOT_TOUCH_FLAG;
 					fd.modifiers = ClassFileConstants.AccPrivate;
 					fd.type = copyType(bfd.type);

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -948,7 +948,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 				}
 				
 				if (field == null) {
-					FieldDeclaration fd = new FieldDeclaration(bfd.builderFieldName, 0, 0);
+					FieldDeclaration fd = new FieldDeclaration(bfd.builderFieldName.clone(), 0, 0);
 					fd.bits |= Eclipse.ECLIPSE_DO_NOT_TOUCH_FLAG;
 					fd.modifiers = ClassFileConstants.AccPrivate;
 					fd.type = copyType(bfd.type);


### PR DESCRIPTION
This PR fixes #3181

@snjeza already provided a fix and I also added it to `@SuperBuilder`. The `.clone()` is required because the `SelectionEngine` compares identities to find the correct field and fails if there are multiple fields sharing the same array.