### PR TITLE
Eclipse integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 /website/lombokSupporters
 /pom.xml
 /jvm.locations
+/testenv

--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -43,7 +43,7 @@
 		<dependency org="org.apache.ant" name="ant-junit" rev="1.10.5" conf="build->default" />
 		
 		<!-- test deps -->
-		<dependency org="junit" name="junit" rev="4.8.2" conf="test->default; sources" />
+		<dependency org="junit" name="junit" rev="4.13.2" conf="test->default; sources" />
 		<dependency org="log4j" name="log4j" rev="1.2.17" conf="test->default; sources" />
 		<dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.17.1" conf="test->default; sources" />
 		<dependency org="commons-logging" name="commons-logging" rev="1.2" conf="test->default; sources" />

--- a/buildScripts/setup.ant.xml
+++ b/buildScripts/setup.ant.xml
@@ -34,8 +34,10 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 	
 	<property name="jdk6-rt.loc" location="lib/openjdk6_rt.jar" />
 	<property name="jdk8-rt.loc" location="lib/openjdk8_rt.jar" />
+	<property name="rtstubs18.loc" location="lib/rtstubs18.jar" />
 	<available file="${jdk6-rt.loc}" property="jdk6-rt.available" />
 	<available file="${jdk8-rt.loc}" property="jdk8-rt.available" />
+	<available file="${rtstubs18.loc}" property="rtstubs18.available" />
 	<property name="ssh.configuration.file" location="ssh.configuration" />
 	
 	<target name="-setup.ssh.ask">
@@ -167,12 +169,26 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 		<get src="https://projectlombok.org/ivyrepo/langtools/rt-openjdk8.jar" dest="${jdk8-rt.loc}" verbose="true" usetimestamp="true" />
 	</target>
 	
+	<target name="deps.rtstubs18" unless="rtstubs18.available">
+		<echo>To test in eclipse, we need a java runtime, which will now be downloaded...</echo>
+		<mkdir dir="lib" />
+		<get src="https://github.com/eclipse-jdt/eclipse.jdt.ui/raw/master/org.eclipse.jdt.ui.tests/testresources/rtstubs18.jar" dest="${rtstubs18.loc}" verbose="true" usetimestamp="true" />
+	</target>
+	
 	<target name="deps.jdk-runtime" depends="deps.jdk6-runtime, deps.jdk8-runtime" />
 	
 	<target name="deps.custom" depends="ivy.config" description="Download the dependencies that comprise a configuration (from ivy.xml)">
 		<fail unless="deps.conf">Supply ant with -Ddeps.conf=confname to pick the configuration you want to fetch</fail>
 		<ivy:resolve file="buildScripts/ivy.xml" refresh="true" conf="${deps.conf}" />
 		<ivy:retrieve symlink="true" />
+	</target>
+	
+	<target name="deps.eclipse.oxygen" depends="deps.rtstubs18, compile.support">
+		<fetchdep.eclipse.osgi name="oxygen" version="4.7/R-4.7-201706120950" />
+	</target>
+	
+	<target name="deps.eclipse.2022-03" depends="deps.rtstubs18, compile.support">
+		<fetchdep.eclipse.osgi name="2022-03" version="4.23/R-4.23-202203080310" />
 	</target>
 	
 	<macrodef name="fetchdep.ecj">
@@ -192,6 +208,132 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 			<ivy:retrieve symlink="true" />
 			<ivy:cachepath pathid="cp.eclipse-@{version}" conf="eclipse-@{version}" />
 			<property name="cp.eclipse-@{version}" refid="cp.eclipse-@{version}" />
+		</sequential>
+	</macrodef>
+	
+	<macrodef name="fetchdep.eclipse.osgi">
+		<attribute name="target" default="testenv" />
+		<attribute name="name" />
+		<attribute name="version" />
+		<sequential>
+			<java classname="lombok.eclipse.dependencies.DownloadEclipseDependencies" failonerror="true">
+				<classpath>
+					<path refid="cp.buildtools" />
+					<pathelement location="build/support" />
+				</classpath>
+				<arg value="@{target}" />
+				<arg value="eclipse-@{name}" />
+				<arg value="https://download.eclipse.org/eclipse/updates/@{version}/plugins/" />
+				<arg value="com.ibm.icu" />
+				<arg value="com.sun.jna" />
+				<arg value="com.sun.jna.platform" />
+				<arg value="javax.inject" />
+				<arg value="javax.annotation" />
+				<arg value="org.apache.batik.constants" />
+				<arg value="org.apache.batik.css" />
+				<arg value="org.apache.batik.i18n" />
+				<arg value="org.apache.batik.util" />
+				<arg value="org.apache.commons.io" />
+				<arg value="org.apache.commons.logging" />
+				<arg value="org.apache.commons.jxpath" />
+				<arg value="org.apache.felix.scr" />
+				<arg value="org.apache.xmlgraphics" />
+				<arg value="org.bouncycastle.bcpg" />
+				<arg value="org.bouncycastle.bcprov" />
+				<arg value="org.eclipse.compare" />
+				<arg value="org.eclipse.compare.core" />
+				<arg value="org.eclipse.core.commands" />
+				<arg value="org.eclipse.core.contenttype" />
+				<arg value="org.eclipse.core.databinding" />
+				<arg value="org.eclipse.core.databinding.observable" />
+				<arg value="org.eclipse.core.databinding.property" />
+				<arg value="org.eclipse.core.expressions" />
+				<arg value="org.eclipse.core.filebuffers" />
+				<arg value="org.eclipse.core.filesystem" />
+				<arg value="org.eclipse.core.jobs" />
+				<arg value="org.eclipse.core.resources" />
+				<arg value="org.eclipse.core.runtime" />
+				<arg value="org.eclipse.core.variables" />
+				<arg value="org.eclipse.debug.core" />
+				<arg value="org.eclipse.debug.ui" />
+				<arg value="org.eclipse.e4.core.commands" />
+				<arg value="org.eclipse.e4.core.contexts" />
+				<arg value="org.eclipse.e4.core.di" />
+				<arg value="org.eclipse.e4.core.di.annotations" />
+				<arg value="org.eclipse.e4.core.di.extensions" />
+				<arg value="org.eclipse.e4.core.di.extensions.supplier" />
+				<arg value="org.eclipse.e4.core.services" />
+				<arg value="org.eclipse.e4.emf.xpath" />
+				<arg value="org.eclipse.e4.ui.bindings" />
+				<arg value="org.eclipse.e4.ui.css.core" />
+				<arg value="org.eclipse.e4.ui.css.swt" />
+				<arg value="org.eclipse.e4.ui.css.swt.theme" />
+				<arg value="org.eclipse.e4.ui.di" />
+				<arg value="org.eclipse.e4.ui.dialogs" />
+				<arg value="org.eclipse.e4.ui.ide" />
+				<arg value="org.eclipse.e4.ui.model.workbench" />
+				<arg value="org.eclipse.e4.ui.services" />
+				<arg value="org.eclipse.e4.ui.widgets" />
+				<arg value="org.eclipse.e4.ui.workbench" />
+				<arg value="org.eclipse.e4.ui.workbench.addons.swt" />
+				<arg value="org.eclipse.e4.ui.workbench.renderers.swt" />
+				<arg value="org.eclipse.e4.ui.workbench.swt" />
+				<arg value="org.eclipse.e4.ui.workbench3" />
+				<arg value="org.eclipse.emf.common" />
+				<arg value="org.eclipse.emf.ecore" />
+				<arg value="org.eclipse.emf.ecore.change" />
+				<arg value="org.eclipse.emf.ecore.xmi" />
+				<arg value="org.eclipse.equinox.app" />
+				<arg value="org.eclipse.equinox.bidi" />
+				<arg value="org.eclipse.equinox.common" />
+				<arg value="org.eclipse.equinox.p2.artifact.repository" />
+				<arg value="org.eclipse.equinox.p2.core" />
+				<arg value="org.eclipse.equinox.p2.engine" />
+				<arg value="org.eclipse.equinox.p2.jarprocessor" />
+				<arg value="org.eclipse.equinox.p2.metadata" />
+				<arg value="org.eclipse.equinox.p2.metadata.repository" />
+				<arg value="org.eclipse.equinox.p2.repository" />
+				<arg value="org.eclipse.equinox.preferences" />
+				<arg value="org.eclipse.equinox.registry" />
+				<arg value="org.eclipse.equinox.security" />
+				<arg value="org.eclipse.help" />
+				<arg value="org.eclipse.jdt.core" />
+				<arg value="org.eclipse.jdt.core.manipulation" />
+				<arg value="org.eclipse.jdt.debug" />
+				<arg value="org.eclipse.jdt.launching" />
+				<arg value="org.eclipse.jdt.ui" />
+				<arg value="org.eclipse.jface" />
+				<arg value="org.eclipse.jface.databinding" />
+				<arg value="org.eclipse.jface.text" />
+				<arg value="org.eclipse.ltk.core.refactoring" />
+				<arg value="org.eclipse.ltk.ui.refactoring" />
+				<arg value="org.eclipse.osgi" />
+				<arg value="org.eclipse.osgi.services" />
+				<arg value="org.eclipse.osgi.util" />
+				<arg value="org.eclipse.search" />
+				<arg value="org.eclipse.swt" />
+				<arg value="org.eclipse.swt.gtk.linux.x86_64" />
+				<arg value="org.eclipse.team.core" />
+				<arg value="org.eclipse.team.ui" />
+				<arg value="org.eclipse.text" />
+				<arg value="org.eclipse.ui" />
+				<arg value="org.eclipse.ui.console" />
+				<arg value="org.eclipse.ui.editors" />
+				<arg value="org.eclipse.ui.forms" />
+				<arg value="org.eclipse.ui.ide" />
+				<arg value="org.eclipse.ui.navigator" />
+				<arg value="org.eclipse.ui.navigator.resources" />
+				<arg value="org.eclipse.ui.views" />
+				<arg value="org.eclipse.ui.views.properties.tabbed" />
+				<arg value="org.eclipse.ui.workbench" />
+				<arg value="org.eclipse.ui.workbench.texteditor" />
+				<arg value="org.eclipse.urischeme" />
+				<arg value="org.tukaani.xz" />
+				<arg value="org.w3c.css.sac" />
+				<arg value="org.w3c.dom.events" />
+				<arg value="org.w3c.dom.smil" />
+				<arg value="org.w3c.dom.svg" />
+			</java>
 		</sequential>
 	</macrodef>
 	

--- a/buildScripts/tests.ant.xml
+++ b/buildScripts/tests.ant.xml
@@ -55,6 +55,24 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 		</ivy:compile>
 	</target>
 	
+	<target name="test.eclipse.compile" depends="deps.eclipse.oxygen, compile" description="compiles the eclipse tests" unless="skip.tests">
+		<mkdir dir="build/tests" />
+		<path id="cp.eclipse">
+			<fileset dir="testenv/eclipse-oxygen/plugins">
+				<include name="*.jar" />
+			</fileset>
+		</path>
+		<ivy:compile destdir="build/tests" source="1.8" target="1.8" ecj="true" nowarn="true">
+			<bootclasspath path="${jdk8-rt.loc}" />
+			<classpath refid="cp.eclipse" />
+			<classpath refid="cp.test" />
+			<classpath refid="cp.javac8" />
+			<classpath refid="packing.basedirs.path" />
+			<classpath path="build/tests" />
+			<src path="test/eclipse/src" />
+		</ivy:compile>
+	</target>
+	
 	<target name="test.ecj11.call" depends="deps, dist" description="Runs a few ecj-specific tests" unless="skip.tests">
 		<java jar="lib/ecj11/org.eclipse.jdt-ecj.jar" fork="true" failonerror="true">
 			<jvmarg value="-javaagent:dist/lombok.jar=ecj" />
@@ -224,6 +242,38 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 	<target name="test.ecj16" depends="test.formatter.compile, test.compile" description="runs the tests on your default VM, testing the ecj11 release">
 		<fetchdep.ecj version="16" />
 		<test.ecj-X version="16" />
+	</target>
+	
+	<macrodef name="test.eclipse-X-full">
+		<attribute name="version" />
+		<sequential>
+			<path id="cp.eclipse-@{version}">
+				<fileset dir="testenv/eclipse-@{version}/plugins">
+					<include name="*.jar" />
+				</fileset>
+			</path>
+			<echo>Running EclipseTests on eclipse-@{version} on JVM${ant.java.version}</echo>
+			<junit haltonfailure="yes" fork="true" forkmode="once">
+				<formatter classname="lombok.ant.SimpleTestFormatter" usefile="false" unless="tests.quiet" />
+				<jvmarg value="-javaagent:dist/lombok.jar" />
+				<jvmarg value="-Dlombok.testenv=testenv/eclipse-@{version}" />
+				<classpath refid="cp.eclipse-@{version}" />
+				<classpath location="build/ant" />
+				<classpath refid="cp.test" />
+				<classpath refid="cp.eclipse-@{version}" />
+				<classpath refid="packing.basedirs.path" />
+				<classpath location="build/tests" />
+				<test name="lombok.eclipse.EclipseTests" />
+			</junit>
+		</sequential>
+	</macrodef>
+
+	<target name="test.eclipse-oxygen-full" depends="test.formatter.compile, test.eclipse.compile, deps.eclipse.oxygen" description="runs the full eclipse tests on your default VM, testing the oxygen release of eclipse">
+		<test.eclipse-X-full version="oxygen" />
+	</target>
+	
+	<target name="test.eclipse-2022-03-full" depends="test.formatter.compile, test.eclipse.compile, deps.eclipse.2022-03" description="runs the full eclipse tests on your default VM, testing the 2022-03 release of eclipse">
+		<test.eclipse-X-full version="2022-03" />
 	</target>
 	
 	<target name="test" depends="test.javacCurrent, test.eclipse-202006" description="runs the tests against the default JVM, javac, and eclipse" />

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -983,7 +983,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 				}
 				
 				if (field == null) {
-					FieldDeclaration fd = new FieldDeclaration(bfd.builderFieldName, 0, 0);
+					FieldDeclaration fd = new FieldDeclaration(bfd.builderFieldName.clone(), 0, 0);
 					fd.bits |= Eclipse.ECLIPSE_DO_NOT_TOUCH_FLAG;
 					fd.modifiers = ClassFileConstants.AccPrivate;
 					fd.type = copyType(bfd.type);

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -948,7 +948,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 				}
 				
 				if (field == null) {
-					FieldDeclaration fd = new FieldDeclaration(bfd.builderFieldName, 0, 0);
+					FieldDeclaration fd = new FieldDeclaration(bfd.builderFieldName.clone(), 0, 0);
 					fd.bits |= Eclipse.ECLIPSE_DO_NOT_TOUCH_FLAG;
 					fd.modifiers = ClassFileConstants.AccPrivate;
 					fd.type = copyType(bfd.type);

--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -109,6 +109,8 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 		patchRenameField(sm);
 		patchNullCheck(sm);
 		
+		patchForTests(sm);
+		
 		if (reloadExistingClasses) sm.reloadClasses(instrumentation);
 	}
 	
@@ -1005,6 +1007,14 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 				.wrapMethod(new Hook("lombok.launch.PatchFixesHider$PatchFixes", "getRealMethodDeclarationNode", "org.eclipse.jdt.core.dom.MethodDeclaration", "org.eclipse.jdt.core.dom.MethodDeclaration", "org.eclipse.jdt.core.IMethod", "org.eclipse.jdt.core.dom.CompilationUnit"))
 				.request(StackRequest.RETURN_VALUE, StackRequest.PARAM1, StackRequest.PARAM2)
 				.transplant()
+				.build());
+	}
+	
+	private static void patchForTests(ScriptManager sm) {
+		sm.addScriptIfWitness(new String[] {"lombok/eclipse/EclipseTests"}, ScriptBuilder.wrapReturnValue()
+				.target(new MethodTarget("org.osgi.framework.FrameworkUtil", "getBundle", "org.osgi.framework.Bundle", "java.lang.Class"))
+				.request(StackRequest.RETURN_VALUE, StackRequest.PARAM1)
+				.wrapMethod(new Hook("lombok.launch.PatchFixesHider$Tests", "getBundle", "java.lang.Object", "java.lang.Object", "java.lang.Class"))
 				.build());
 	}
 

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.security.CodeSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
@@ -852,6 +853,30 @@ final class PatchFixesHider {
 		
 		public static boolean skipRewriteVisibility(IncomingMemberVisibilityAdjustment adjustment) {
 			return isGenerated(adjustment.getMember());
+		}
+	}
+	
+	public static class Tests {
+		public static Object getBundle(Object original, Class<?> c) {
+			if (original != null) {
+				return original;
+			}
+			
+			CodeSource codeSource = c.getProtectionDomain().getCodeSource();
+			if (codeSource == null) {
+				return null;
+			}
+			
+			String jar = codeSource.getLocation().getFile();
+			String bundleName = jar.substring(jar.lastIndexOf("/") + 1, jar.indexOf("_"));
+			
+			org.osgi.framework.Bundle[] bundles = org.eclipse.core.runtime.adaptor.EclipseStarter.getSystemBundleContext().getBundles();
+			for (org.osgi.framework.Bundle bundle : bundles) {
+				if (bundleName.equals(bundle.getSymbolicName())) {
+					return bundle;
+				}
+			}
+			return null;
 		}
 	}
 }

--- a/src/support/lombok/eclipse/dependencies/DownloadEclipseDependencies.java
+++ b/src/support/lombok/eclipse/dependencies/DownloadEclipseDependencies.java
@@ -1,0 +1,131 @@
+package lombok.eclipse.dependencies;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Download eclipse bundles.
+ */
+public class DownloadEclipseDependencies {
+	
+	public static void main(String[] args) throws IOException {
+		String target = args[0];
+		String eclipseVersion = args[1];
+		String updatePage = args[2];
+		String[] packages = Arrays.copyOfRange(args, 3, args.length);
+		
+		String pluginTarget = target + "/" + eclipseVersion + "/plugins/";
+		
+		String indexData = readUrlAsString(updatePage);
+		
+		for (String pkg : packages) {
+			Matcher matcher = Pattern.compile("(" + pkg.replace(".", "\\.") + "_.*?\\.jar)").matcher(indexData);
+			if (matcher.find()) {
+				String path = matcher.group(1);
+				
+				try {
+					downloadFile(path, updatePage, pluginTarget);
+				} catch (Exception e) {
+				}
+				try {
+					int index = path.lastIndexOf("_");
+					String source = path.substring(0, index) + ".source" + path.substring(index);
+					downloadFile(source, updatePage, pluginTarget);
+				} catch (Exception e) {
+				}
+			} else {
+				System.out.println("Bundle \"" + pkg + "\" not found");
+			}
+		}
+		
+		writeEclipseLibrary(target, eclipseVersion);
+	}
+	
+	private static String readUrlAsString(String url) throws MalformedURLException, IOException {
+		InputStream in = getStreamForUrl(url);
+		
+		StringBuilder sb = new StringBuilder();
+		
+		int bufferSize = 1024;
+		char[] buffer = new char[bufferSize];
+		InputStreamReader reader = new InputStreamReader(in, "UTF-8");
+		for (int count = 0;  (count = reader.read(buffer, 0, bufferSize)) > 0;) {
+			sb.append(buffer, 0, count);
+		}
+		return sb.toString();
+	}
+	
+	private static void downloadFile(String filename, String repositoryUrl, String target) throws IOException {
+		Files.createDirectories(Paths.get(target));
+		Path targetFile = Paths.get(target, filename);
+		if (Files.exists(targetFile)) {
+			System.out.println("File '" + filename + "' already exists");
+			return;
+		}
+		System.out.print("Downloading '" + filename + "'... ");
+		try {
+			Files.copy(getStreamForUrl(repositoryUrl + filename), targetFile, StandardCopyOption.REPLACE_EXISTING);
+			System.out.println("[done]");
+		} catch(IOException e) {
+			System.out.println("[error]");
+		}
+	}
+	
+	private static InputStream getStreamForUrl(String url) throws IOException, MalformedURLException {
+		HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+		connection.setRequestProperty("User-Agent", "lombok");
+		connection.setRequestProperty("Accept", "*/*");
+		InputStream in = new BufferedInputStream(connection.getInputStream());
+		return in;
+	}
+
+	private static void writeEclipseLibrary(String target, String eclipseVersion) throws IOException {
+		StringBuilder sb = new StringBuilder();
+		sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
+		sb.append("<eclipse-userlibraries version=\"2\">\n");
+		sb.append("<library name=\"");
+		sb.append(eclipseVersion);
+		sb.append("\" systemlibrary=\"false\">\n");
+		
+		File[] files = new File(new File(target, eclipseVersion), "plugins").listFiles(new FilenameFilter() {
+			@Override public boolean accept(File dir, String name) {
+				return name.endsWith(".jar") && !name.contains(".source_");
+			}
+		});
+		Arrays.sort(files);
+		
+		for (File file : files) {
+			sb.append("<archive path=\"");
+			sb.append(file.getAbsolutePath());
+			sb.append("\"");
+			
+			String path = file.getAbsolutePath();
+			int index = path.lastIndexOf("_");
+			
+			sb.append(" source=\"");
+			sb.append(path.substring(0, index) + ".source" + path.substring(index));
+			sb.append("\"");
+			
+			sb.append(" />\n");
+		}
+		
+		sb.append("</library>\n");
+		sb.append("</eclipse-userlibraries>\n");
+		
+		Files.writeString(Paths.get(target, eclipseVersion + ".userlibraries"), sb.toString());
+	}
+}

--- a/test/core/src/lombok/RunTestsViaEcj.java
+++ b/test/core/src/lombok/RunTestsViaEcj.java
@@ -289,6 +289,10 @@ public class RunTestsViaEcj extends AbstractRunTests {
 		@Override public char[][] getPackageName() {
 			return null;
 		}
+
+		@Override public boolean ignoreOptionalProblems() {
+			return false;
+		}
 	}
 	
 	private static final class TestCompilationUnitEclipse extends org.eclipse.jdt.internal.core.CompilationUnit {
@@ -324,7 +328,7 @@ public class RunTestsViaEcj extends AbstractRunTests {
 			return null;
 		}
 		
-		@Override public char[] getModuleName() {
+		public char[] getModuleName() {
 			return null;
 		}
 	}

--- a/test/eclipse/resource/cleanup/useThis/after/A.java
+++ b/test/eclipse/resource/cleanup/useThis/after/A.java
@@ -1,0 +1,18 @@
+package pkg;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.With;
+import lombok.experimental.WithBy;
+
+@Data
+@Builder
+@With
+@WithBy
+public class A {
+	private String string;
+	
+	public void a() {
+		this.string = "a";
+	}
+}

--- a/test/eclipse/resource/cleanup/useThis/before/A.java
+++ b/test/eclipse/resource/cleanup/useThis/before/A.java
@@ -1,0 +1,18 @@
+package pkg;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.With;
+import lombok.experimental.WithBy;
+
+@Data
+@Builder
+@With
+@WithBy
+public class A {
+	private String string;
+	
+	public void a() {
+		string = "a";
+	}
+}

--- a/test/eclipse/resource/extractinterface/simple/after/A.java
+++ b/test/eclipse/resource/extractinterface/simple/after/A.java
@@ -1,0 +1,15 @@
+package pkg;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+public class A implements Interface {
+	private String string;
+	private int integer;
+}

--- a/test/eclipse/resource/extractinterface/simple/after/Interface.java
+++ b/test/eclipse/resource/extractinterface/simple/after/Interface.java
@@ -1,0 +1,21 @@
+package pkg;
+
+public interface Interface {
+
+	boolean equals(java.lang.Object o);
+
+	boolean canEqual(java.lang.Object other);
+
+	int hashCode();
+
+	String getString();
+
+	int getInteger();
+
+	void setString(String string);
+
+	void setInteger(int integer);
+
+	java.lang.String toString();
+
+}

--- a/test/eclipse/resource/extractinterface/simple/before/A.java
+++ b/test/eclipse/resource/extractinterface/simple/before/A.java
@@ -1,0 +1,15 @@
+package pkg;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+public class A {
+	private String string;
+	private int integer;
+}

--- a/test/eclipse/resource/extractinterface/usage/after/A.java
+++ b/test/eclipse/resource/extractinterface/usage/after/A.java
@@ -1,0 +1,15 @@
+package pkg;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+public class A implements Interface {
+	private String string;
+	private int integer;
+}

--- a/test/eclipse/resource/extractinterface/usage/after/B.java
+++ b/test/eclipse/resource/extractinterface/usage/after/B.java
@@ -1,0 +1,12 @@
+package pkg;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class B {
+	private Interface a = new A();
+	private String string = a.getString();
+	private int integer = a.getInteger();
+}

--- a/test/eclipse/resource/extractinterface/usage/after/Interface.java
+++ b/test/eclipse/resource/extractinterface/usage/after/Interface.java
@@ -1,0 +1,21 @@
+package pkg;
+
+public interface Interface {
+
+	boolean equals(java.lang.Object o);
+
+	boolean canEqual(java.lang.Object other);
+
+	int hashCode();
+
+	String getString();
+
+	int getInteger();
+
+	void setString(String string);
+
+	void setInteger(int integer);
+
+	java.lang.String toString();
+
+}

--- a/test/eclipse/resource/extractinterface/usage/before/A.java
+++ b/test/eclipse/resource/extractinterface/usage/before/A.java
@@ -1,0 +1,15 @@
+package pkg;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+public class A {
+	private String string;
+	private int integer;
+}

--- a/test/eclipse/resource/extractinterface/usage/before/B.java
+++ b/test/eclipse/resource/extractinterface/usage/before/B.java
@@ -1,0 +1,12 @@
+package pkg;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class B {
+	private A a = new A();
+	private String string = a.getString();
+	private int integer = a.getInteger();
+}

--- a/test/eclipse/resource/rename/builderField/after/A.java
+++ b/test/eclipse/resource/rename/builderField/after/A.java
@@ -1,0 +1,8 @@
+package pkg;
+
+import lombok.Builder;
+
+@Builder
+public class A {
+	private String newString;
+}

--- a/test/eclipse/resource/rename/builderField/before/A.java
+++ b/test/eclipse/resource/rename/builderField/before/A.java
@@ -1,0 +1,8 @@
+package pkg;
+
+import lombok.Builder;
+
+@Builder
+public class A {
+	private String string;
+}

--- a/test/eclipse/resource/rename/simple/after/A.java
+++ b/test/eclipse/resource/rename/simple/after/A.java
@@ -1,0 +1,14 @@
+package pkg;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+public class A {
+	private String newString;
+}

--- a/test/eclipse/resource/rename/simple/before/A.java
+++ b/test/eclipse/resource/rename/simple/before/A.java
@@ -1,0 +1,14 @@
+package pkg;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+public class A {
+	private String string;
+}

--- a/test/eclipse/resource/rename/withGetter/after/A.java
+++ b/test/eclipse/resource/rename/withGetter/after/A.java
@@ -1,0 +1,18 @@
+package pkg;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+public class A {
+	private String newString;
+	
+	public String test() {
+		return getNewString();
+	}
+}

--- a/test/eclipse/resource/rename/withGetter/before/A.java
+++ b/test/eclipse/resource/rename/withGetter/before/A.java
@@ -1,0 +1,18 @@
+package pkg;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+public class A {
+	private String string;
+	
+	public String test() {
+		return getString();
+	}
+}

--- a/test/eclipse/resource/rename/withGetterDifferentFile/after/A.java
+++ b/test/eclipse/resource/rename/withGetterDifferentFile/after/A.java
@@ -1,0 +1,14 @@
+package pkg;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+public class A {
+	private String newString;
+}

--- a/test/eclipse/resource/rename/withGetterDifferentFile/after/B.java
+++ b/test/eclipse/resource/rename/withGetterDifferentFile/after/B.java
@@ -1,0 +1,7 @@
+package pkg;
+
+public class B {
+	public String test() {
+		return new A().getNewString();
+	}
+}

--- a/test/eclipse/resource/rename/withGetterDifferentFile/before/A.java
+++ b/test/eclipse/resource/rename/withGetterDifferentFile/before/A.java
@@ -1,0 +1,14 @@
+package pkg;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@Getter
+@Setter
+@ToString
+public class A {
+	private String string;
+}

--- a/test/eclipse/resource/rename/withGetterDifferentFile/before/B.java
+++ b/test/eclipse/resource/rename/withGetterDifferentFile/before/B.java
@@ -1,0 +1,7 @@
+package pkg;
+
+public class B {
+	public String test() {
+		return new A().getString();
+	}
+}

--- a/test/eclipse/resource/select/builderField/A.java
+++ b/test/eclipse/resource/select/builderField/A.java
@@ -1,0 +1,8 @@
+package pkg;
+
+import lombok.Builder;
+
+@Builder
+public class A {
+	private String id;
+}

--- a/test/eclipse/resource/select/superbuilderField/A.java
+++ b/test/eclipse/resource/select/superbuilderField/A.java
@@ -1,0 +1,8 @@
+package pkg;
+
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+public class A {
+	private String id;
+}

--- a/test/eclipse/src/lombok/eclipse/EclipseRunner.java
+++ b/test/eclipse/src/lombok/eclipse/EclipseRunner.java
@@ -1,0 +1,154 @@
+package lombok.eclipse;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.runtime.adaptor.EclipseStarter;
+import org.eclipse.osgi.container.Module;
+import org.eclipse.osgi.container.Module.StartOptions;
+import org.eclipse.osgi.container.Module.State;
+import org.eclipse.osgi.internal.location.EquinoxLocations;
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.BundleWire;
+import org.osgi.framework.wiring.BundleWiring;
+
+/**
+ * We have to load the osgi/eclipse classes before we run the test case. This is only possible using a custom runner.
+ *
+ */
+public class EclipseRunner extends Runner {
+	private Runner runner;
+	private boolean debug = false;
+	private static boolean setupDone;
+	
+	public EclipseRunner(Class<?> klass) throws InitializationError {
+		try {
+			if (!setupDone) {
+				debug = System.getProperty("lombok.debug") != null;
+				startEclipse(System.getProperty("lombok.testenv"));
+				setupDone = true;
+			}
+		} catch (Throwable e) {
+			throw new InitializationError(e);
+		}
+		
+		runner = new BlockJUnit4ClassRunner(klass);
+		
+	}
+	
+	@Override
+	public Description getDescription() {
+		return runner.getDescription();
+	}
+	
+	@Override
+	public void run(RunNotifier notifier) {
+		runner.run(notifier);
+	}
+	
+	private void startEclipse(String path) throws Exception {
+		Map<String, String> initialProperties = new HashMap<String, String>();
+		
+		File rootDir = new File(path);
+		File pluginDir = new File(rootDir, "plugins/");
+		
+		StringBuilder bundleString = new StringBuilder();
+		String osgiPlugin = null;
+		File[] bundles = pluginDir.listFiles();
+		Arrays.sort(bundles);
+		for (File plugin : bundles) {
+			String fileName = plugin.getName();
+			String bundleName = fileName.substring(0, fileName.indexOf("_"));
+			
+			if (bundleName.equals("org.eclipse.osgi")) {
+				osgiPlugin = plugin.toURI().toString();
+			}
+			
+			if (bundleString.length() > 0) {
+				bundleString.append(",");
+			}
+			bundleString.append(bundleName);
+		}
+		
+		initialProperties.put(EclipseStarter.PROP_BUNDLES, bundleString.toString());
+		initialProperties.put(EclipseStarter.PROP_INSTALL_AREA, "file:" + path);
+		initialProperties.put(EquinoxLocations.PROP_INSTANCE_AREA, "file:" + path);
+		initialProperties.put(EclipseStarter.PROP_FRAMEWORK, osgiPlugin);
+		initialProperties.put("osgi.framework.useSystemProperties", "false");
+		initialProperties.put(EclipseStarter.PROP_NOSHUTDOWN, "false");
+		
+		initialProperties.put("osgi.parentClassloader", "fwk");
+		initialProperties.put("osgi.frameworkParentClassloader", "fwk");
+		initialProperties.put("osgi.contextClassLoaderParent", "ext");
+		initialProperties.put("osgi.context.bootdelegation", "*");
+		initialProperties.put("org.osgi.framework.bootdelegation", "*");
+		
+		EclipseStarter.setInitialProperties(initialProperties);
+		String[] args = new String[] {"-clean"};
+		if (debug) args = new String[] {"-clean", "-console", "-consoleLog", "-debug"};
+		BundleContext context = EclipseStarter.startup(args, null);
+		
+		Map<String, Module> moduleMap = new HashMap<String, Module>();
+		for (Bundle b : context.getBundles()) {
+			Module module = b.adapt(Module.class);
+			moduleMap.put(b.getSymbolicName(), module);
+		}
+		
+		Set<String> startedBundles = new HashSet<String>();
+		// Mark the debug bundle as started, it will fail anyway...
+		startedBundles.add("org.eclipse.debug.ui");
+		
+		startBundle(moduleMap, startedBundles, "org.apache.felix.scr");
+		startBundle(moduleMap, startedBundles, "org.eclipse.jdt.core.manipulation");
+		startBundle(moduleMap, startedBundles, "org.eclipse.jdt.ui");
+		
+		if (debug) {
+			for (Bundle b : context.getBundles()) {
+				System.out.println("BUNDLE: " + b.getSymbolicName() + " " + b.getVersion() + " " + b.getLocation() + " " + b.getState());
+			}
+		}
+	}
+	
+	private void startBundle(Map<String, Module> moduleMap, Set<String> started, String bundle) throws BundleException {
+		if (started.contains(bundle)) return;
+		
+		Module module = moduleMap.get(bundle);
+		started.add(bundle);
+		
+		BundleWiring wiring = module.getBundle().adapt(BundleWiring.class);
+		List<BundleWire> requiredWires = wiring.getRequiredWires(BundleRevision.PACKAGE_NAMESPACE);
+		requiredWires.addAll(wiring.getRequiredWires(BundleRevision.BUNDLE_NAMESPACE));
+		
+		for (BundleWire bundleWire : requiredWires) {
+			startBundle(moduleMap, started, bundleWire.getProvider().getSymbolicName());
+		}
+		
+		startModule(module);
+	}
+	
+	private void startModule(Module module) throws BundleException {
+		if (module.getState() == State.LAZY_STARTING || module.getState() == State.RESOLVED) {
+			if (debug) System.out.print("Starting bundle " + module.getBundle().getSymbolicName() + "...");
+			try {
+				module.start(StartOptions.LAZY_TRIGGER);
+				if (debug) System.out.println(" [done]");
+			} catch (Exception e) {
+				if (debug) System.out.println(" [error]");
+				e.printStackTrace();
+			}
+		}
+	}
+}

--- a/test/eclipse/src/lombok/eclipse/EclipseTests.java
+++ b/test/eclipse/src/lombok/eclipse/EclipseTests.java
@@ -1,0 +1,16 @@
+package lombok.eclipse;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import lombok.eclipse.cleanup.CleanupTest;
+import lombok.eclipse.edit.SelectTest;
+import lombok.eclipse.refactoring.ExtractInterfaceTest;
+import lombok.eclipse.refactoring.RenameTest;
+
+@RunWith(Suite.class)
+@SuiteClasses({ExtractInterfaceTest.class, RenameTest.class, SelectTest.class, CleanupTest.class})
+public class EclipseTests {
+	
+}

--- a/test/eclipse/src/lombok/eclipse/RefactoringUtils.java
+++ b/test/eclipse/src/lombok/eclipse/RefactoringUtils.java
@@ -1,0 +1,30 @@
+package lombok.eclipse;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ltk.core.refactoring.CheckConditionsOperation;
+import org.eclipse.ltk.core.refactoring.CreateChangeOperation;
+import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
+import org.eclipse.ltk.core.refactoring.Refactoring;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.participants.ProcessorBasedRefactoring;
+import org.eclipse.ltk.core.refactoring.participants.RefactoringProcessor;
+
+public class RefactoringUtils {
+	public static void performRefactoring(RefactoringProcessor proccessor) throws CoreException {
+		performRefactoring(new ProcessorBasedRefactoring(proccessor));
+	}
+	
+	public static void performRefactoring(Refactoring refactoring) throws CoreException {
+		CheckConditionsOperation checkConditionsOperation = new CheckConditionsOperation(refactoring, CheckConditionsOperation.ALL_CONDITIONS);
+		CreateChangeOperation change = new CreateChangeOperation(checkConditionsOperation, RefactoringStatus.FATAL);
+		final PerformChangeOperation perform = new PerformChangeOperation(change);
+		
+		ResourcesPlugin.getWorkspace().run(perform, null);
+		
+		assertTrue("Condition failed", change.getConditionCheckingStatus().isOK());
+		assertTrue("Perform failed", perform.changeExecuted());
+	}
+}

--- a/test/eclipse/src/lombok/eclipse/SetupBeforeAfterTest.java
+++ b/test/eclipse/src/lombok/eclipse/SetupBeforeAfterTest.java
@@ -1,0 +1,52 @@
+package lombok.eclipse;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.junit.runner.Description;
+
+public class SetupBeforeAfterTest extends SetupTest {
+	
+	private File before;
+	private File after;
+	
+	@Override
+	protected void starting(Description description) {
+		super.starting(description);
+		
+		before = new File(root, "/before/");
+		after = new File(root, "/after/");
+		
+		try {
+			copyBeforeFiles();
+		} catch (Throwable e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	@Override
+	protected void succeeded(Description description) {
+		try {
+			compareWithAfter();
+		} catch (Throwable e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	private void compareWithAfter() throws FileNotFoundException, JavaModelException {
+		for (ICompilationUnit result : packageFragment.getCompilationUnits()) {
+			assertEquals(getContent(new File(after, result.getElementName())), result.getSource());
+		}
+	}
+	
+	void copyBeforeFiles() throws JavaModelException, FileNotFoundException {
+		for (File file : before.listFiles()) {
+			createCompilationUnit(file, packageFragment);
+		}
+		
+	}
+}

--- a/test/eclipse/src/lombok/eclipse/SetupSingleFileTest.java
+++ b/test/eclipse/src/lombok/eclipse/SetupSingleFileTest.java
@@ -1,0 +1,28 @@
+package lombok.eclipse;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import org.eclipse.jdt.core.JavaModelException;
+import org.junit.runner.Description;
+
+public class SetupSingleFileTest extends SetupTest {
+	
+	@Override
+	protected void starting(Description description) {
+		super.starting(description);
+		
+		try {
+			copyRootFiles();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	private void copyRootFiles() throws JavaModelException, FileNotFoundException {
+		for (File file : root.listFiles()) {
+			createCompilationUnit(file, packageFragment);
+		}
+		
+	}
+}

--- a/test/eclipse/src/lombok/eclipse/SetupTest.java
+++ b/test/eclipse/src/lombok/eclipse/SetupTest.java
@@ -1,0 +1,107 @@
+package lombok.eclipse;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Scanner;
+
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+public abstract class SetupTest extends TestWatcher {
+	
+	private IJavaProject javaProject;
+	protected IPackageFragment packageFragment;
+	private IWorkspace workspace;
+	protected File root;
+	
+	public IJavaProject getJavaProject() {
+		return javaProject;
+	}
+	
+	public IPackageFragment getPackageFragment() {
+		return packageFragment;
+	}
+	
+	public IWorkspace getWorkspace() {
+		return workspace;
+	}
+	
+	@Override
+	protected void starting(Description description) {
+		String category = description.getTestClass().getSimpleName().toLowerCase().replaceAll("test$", "");
+		String testname = description.getMethodName();
+		
+		root = new File("test/eclipse/resource/" + category + "/" + testname);
+		
+		try {
+			createProject(category, description.getMethodName());
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	private void createProject(String category, String test) throws CoreException {
+		workspace = ResourcesPlugin.getWorkspace();
+		
+		IWorkspaceRoot root = getWorkspace().getRoot();
+		IProject project = root.getProject(category + "_" + test);
+		
+		if (project.exists()) {
+			project.delete(true, true, null);
+		}
+		project.create(null);
+		project.open(null);
+		
+		IFolder targetFolder = createFolder(project, "target");
+		IFolder srcFolder = createFolder(project, "src");
+		
+		IProjectDescription description = project.getDescription();
+		description.setNatureIds(new String[] {JavaCore.NATURE_ID});
+		project.setDescription(description, null);
+		
+		javaProject = JavaCore.create(project);
+		javaProject.setOutputLocation(targetFolder.getFullPath(), null);
+		JavaCore.setComplianceOptions(JavaCore.VERSION_1_8, javaProject.getOptions(false));
+		
+		IClasspathEntry classpathEntry = JavaCore.newSourceEntry(srcFolder.getFullPath());
+		IClasspathEntry newLibraryEntry = JavaCore.newLibraryEntry(new Path(new File("dist/lombok.jar").getAbsolutePath()), null, null);
+		IClasspathEntry javaRtEntry = JavaCore.newLibraryEntry(new Path(new File("lib/rtstubs18.jar").getAbsolutePath()), null, null);
+		javaProject.setRawClasspath(new IClasspathEntry[] {classpathEntry, newLibraryEntry, javaRtEntry}, null);
+		
+		packageFragment = javaProject.getPackageFragmentRoot(srcFolder).createPackageFragment("pkg", false, null);
+	}
+	
+	protected IFolder createFolder(IProject project, String name) throws CoreException {
+		IFolder folder = project.getFolder(name);
+		if (folder.exists()) {
+			folder.delete(true, null);
+		}
+		folder.create(false, true, null);
+		return folder;
+	}
+	
+	protected ICompilationUnit createCompilationUnit(File file, IPackageFragment pkg) throws JavaModelException, FileNotFoundException {
+		return pkg.createCompilationUnit(file.getName(), getContent(file), true, null);
+	}
+	
+	protected String getContent(File f) throws FileNotFoundException {
+		Scanner scanner = new Scanner(f);
+		String text = scanner.useDelimiter("\\A").next();
+		scanner.close();
+		return text;
+	}
+}

--- a/test/eclipse/src/lombok/eclipse/cleanup/CleanupTest.java
+++ b/test/eclipse/src/lombok/eclipse/cleanup/CleanupTest.java
@@ -1,0 +1,45 @@
+package lombok.eclipse.cleanup;
+
+import static lombok.eclipse.RefactoringUtils.performRefactoring;
+
+import java.util.Map.Entry;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
+import org.eclipse.jdt.internal.corext.fix.CleanUpRefactoring;
+import org.eclipse.jdt.internal.corext.fix.CleanUpRegistry;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.internal.ui.fix.CodeStyleCleanUp;
+import org.eclipse.jdt.internal.ui.fix.MapCleanUpOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import lombok.eclipse.EclipseRunner;
+import lombok.eclipse.SetupBeforeAfterTest;
+
+@RunWith(EclipseRunner.class)
+public class CleanupTest {
+	
+	@Rule
+	public SetupBeforeAfterTest setup = new SetupBeforeAfterTest();
+	
+	@Test
+	public void useThis() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
+		
+		CleanUpRegistry cleanUpRegistry = JavaPlugin.getDefault().getCleanUpRegistry();
+		MapCleanUpOptions options = cleanUpRegistry.getDefaultOptions(CleanUpConstants.DEFAULT_CLEAN_UP_OPTIONS);
+		for (Entry<String, String> entry : options.getMap().entrySet()) {
+			entry.setValue(MapCleanUpOptions.FALSE);
+		}
+		options.setOption(CleanUpConstants.MEMBER_ACCESSES_NON_STATIC_FIELD_USE_THIS, MapCleanUpOptions.TRUE);
+		options.setOption(CleanUpConstants.MEMBER_ACCESSES_NON_STATIC_FIELD_USE_THIS_ALWAYS, MapCleanUpOptions.TRUE);
+		
+		CleanUpRefactoring ref = new CleanUpRefactoring();
+		ref.addCompilationUnit(cu);
+		ref.addCleanUp(new CodeStyleCleanUp(options.getMap()));
+		
+		performRefactoring(ref);
+	}
+}

--- a/test/eclipse/src/lombok/eclipse/edit/SelectTest.java
+++ b/test/eclipse/src/lombok/eclipse/edit/SelectTest.java
@@ -1,0 +1,48 @@
+package lombok.eclipse.edit;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.IType;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import lombok.eclipse.EclipseRunner;
+import lombok.eclipse.SetupSingleFileTest;
+
+@RunWith(EclipseRunner.class)
+public class SelectTest {
+	
+	@Rule
+	public SetupSingleFileTest setup = new SetupSingleFileTest();
+	
+	@Test
+	public void builderField() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
+		IType type = cu.findPrimaryType();
+		IField field = type.getField("id");
+		
+		ISourceRange sourceRange = field.getNameRange();
+		IJavaElement[] codeSelect = cu.codeSelect(sourceRange.getOffset(), sourceRange.getLength());
+		
+		assertEquals(1, codeSelect.length);
+		assertEquals(field, codeSelect[0]);
+	}
+	
+	@Test
+	public void superbuilderField() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
+		IType type = cu.findPrimaryType();
+		IField field = type.getField("id");
+		
+		ISourceRange sourceRange = field.getNameRange();
+		IJavaElement[] codeSelect = cu.codeSelect(sourceRange.getOffset(), sourceRange.getLength());
+		
+		assertEquals(1, codeSelect.length);
+		assertEquals(field, codeSelect[0]);
+	}
+}

--- a/test/eclipse/src/lombok/eclipse/refactoring/ExtractInterfaceTest.java
+++ b/test/eclipse/src/lombok/eclipse/refactoring/ExtractInterfaceTest.java
@@ -1,0 +1,47 @@
+package lombok.eclipse.refactoring;
+
+import static lombok.eclipse.RefactoringUtils.performRefactoring;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.internal.corext.refactoring.structure.ExtractInterfaceProcessor;
+import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesSettings;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import lombok.eclipse.EclipseRunner;
+import lombok.eclipse.SetupBeforeAfterTest;
+
+@RunWith(EclipseRunner.class)
+public class ExtractInterfaceTest {
+	
+	@Rule
+	public SetupBeforeAfterTest setup = new SetupBeforeAfterTest();
+	
+	@Test
+	public void simple() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
+		IType type = cu.findPrimaryType();
+		
+		ExtractInterfaceProcessor extractInterfaceProcessor = new ExtractInterfaceProcessor(type, JavaPreferencesSettings.getCodeGenerationSettings(setup.getJavaProject()));
+		extractInterfaceProcessor.setExtractedMembers(type.getMethods());
+		extractInterfaceProcessor.setTypeName("Interface");
+		
+		performRefactoring(extractInterfaceProcessor);
+	}
+	
+	@Test
+	public void usage() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
+		IType type = cu.findPrimaryType();
+		
+		ExtractInterfaceProcessor extractInterfaceProcessor = new ExtractInterfaceProcessor(type, JavaPreferencesSettings.getCodeGenerationSettings(setup.getJavaProject()));
+		extractInterfaceProcessor.setExtractedMembers(type.getMethods());
+		extractInterfaceProcessor.setTypeName("Interface");
+		extractInterfaceProcessor.setReplace(true);
+		
+		performRefactoring(extractInterfaceProcessor);
+	}
+	
+}

--- a/test/eclipse/src/lombok/eclipse/refactoring/RenameTest.java
+++ b/test/eclipse/src/lombok/eclipse/refactoring/RenameTest.java
@@ -1,0 +1,71 @@
+package lombok.eclipse.refactoring;
+
+import static lombok.eclipse.RefactoringUtils.performRefactoring;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.internal.corext.refactoring.rename.RenameFieldProcessor;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import lombok.eclipse.EclipseRunner;
+import lombok.eclipse.SetupBeforeAfterTest;
+
+@RunWith(EclipseRunner.class)
+public class RenameTest {
+	
+	@Rule
+	public SetupBeforeAfterTest setup = new SetupBeforeAfterTest();
+	
+	@Test
+	public void simple() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
+		IType type = cu.findPrimaryType();
+		IField field = type.getField("string");
+		
+		RenameFieldProcessor renameFieldProcessor = new RenameFieldProcessor(field);
+		renameFieldProcessor.setNewElementName("newString");
+		
+		performRefactoring(renameFieldProcessor);
+	}
+	
+	@Test
+	public void withGetter() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
+		IType type = cu.findPrimaryType();
+		IField field = type.getField("string");
+		
+		RenameFieldProcessor renameFieldProcessor = new RenameFieldProcessor(field);
+		renameFieldProcessor.setNewElementName("newString");
+		renameFieldProcessor.setRenameGetter(true);
+		
+		performRefactoring(renameFieldProcessor);
+	}
+	
+	@Test
+	public void withGetterDifferentFile() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
+		IType type = cu.findPrimaryType();
+		IField field = type.getField("string");
+		
+		RenameFieldProcessor renameFieldProcessor = new RenameFieldProcessor(field);
+		renameFieldProcessor.setNewElementName("newString");
+		renameFieldProcessor.setRenameGetter(true);
+		
+		performRefactoring(renameFieldProcessor);
+	}
+	
+	@Test
+	public void builderField() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
+		IType type = cu.findPrimaryType();
+		IField field = type.getField("string");
+		
+		RenameFieldProcessor renameFieldProcessor = new RenameFieldProcessor(field);
+		renameFieldProcessor.setNewElementName("newString");
+		
+		performRefactoring(renameFieldProcessor);
+	}
+}


### PR DESCRIPTION
This PR adds support for eclipse integration tests.

The test runner starts the OSGI bundles and the dependencies, after that it is possible to use a lot of the eclipse features for test. All classes share the same classloader, thats why I added an additional patch to detect the bundle. There might be an easier solution for that but I couldn't find one.

I also added some `ant` targets to run the tests and download all the required dependencies. The dependency downloader also generates a eclipse user library that can be imported in eclipse.

It would be great if someone can try if all this stuff works.