### PR TITLE
Generate @return and @param JavaDoc tags for @Getter and @Setter annotations

### DIFF
--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -895,6 +895,7 @@ public class HandlerUtil {
 	
 	private static final Pattern SECTION_FINDER = Pattern.compile("^\\s*\\**\\s*[-*][-*]+\\s*([GS]ETTER|WITH(?:ER)?)\\s*[-*][-*]+\\s*\\**\\s*$", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 	private static final Pattern LINE_BREAK_FINDER = Pattern.compile("(\\r?\\n)?");
+	private static final Pattern MAIN_SENTENCE_FINDER = Pattern.compile("\r?\n\\s*?[\r\n]|<p>|^\\s*@");
 	
 	public enum JavadocTag {
 		PARAM("@param(?:eter)?"),
@@ -905,6 +906,18 @@ public class HandlerUtil {
 		JavadocTag(String regexpFragment) {
 			pattern = Pattern.compile("\\s?^[ \\t]*\\**[ \\t]*" + regexpFragment + "(\\S|\\s)*?(?=(\\s^\\s*\\**\\s*@|\\Z))", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 		}
+		
+		public boolean isPartOf(String javadoc) {
+			return pattern.matcher(javadoc).find();
+		}
+	}
+	
+	public static String getMainSentenceOfJavaDoc(String javadoc) {
+		if (javadoc == null || javadoc.isEmpty()) return javadoc;
+		
+		String trimmedJavadoc = javadoc.trim();
+		Matcher matcher = MAIN_SENTENCE_FINDER.matcher(trimmedJavadoc);
+		return matcher.find() ? trimmedJavadoc.substring(0, matcher.start()).trim() : trimmedJavadoc;
 	}
 	
 	public static String stripLinesWithTagFromJavadoc(String javadoc, JavadocTag tag) {

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -2205,6 +2205,12 @@ public class JavacHandlerUtil {
 				if (!sectionBased) {
 					out = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), JavadocTag.PARAM);
 				}
+				if (!JavadocTag.RETURN.isPartOf(out)) {
+					String mainSentence = getMainSentenceOfJavaDoc(out);
+					if (mainSentence != null && !mainSentence.isEmpty()) {
+						out = addJavadocLine(out, "@return " + mainSentence);
+					}
+				}
 				node.getAst().cleanupTask("javadocfilter-getter", n, new CleanupTask() {
 					@Override public void cleanup() {
 						String javadoc = Javac.getDocComment(cu, n);
@@ -2245,6 +2251,12 @@ public class JavacHandlerUtil {
 			final boolean sectionBased = out != null;
 			if (!sectionBased) {
 				out = stripLinesWithTagFromJavadoc(stripSectionsFromJavadoc(javadoc), JavadocTag.RETURN);
+			}
+			if (!JavadocTag.PARAM.isPartOf(out)) {
+				String mainSentence = getMainSentenceOfJavaDoc(out);
+				if (mainSentence != null && !mainSentence.isEmpty()) {
+					out = addJavadocLine(out, "@param " + node.getName() + ' ' + mainSentence);
+				}
 			}
 			node.getAst().cleanupTask("javadocfilter-setter", n, new CleanupTask() {
 				@Override public void cleanup() {

--- a/test/transform/resource/after-delombok/GetterJavaDoc.java
+++ b/test/transform/resource/after-delombok/GetterJavaDoc.java
@@ -1,0 +1,111 @@
+class GetterJavaDoc {
+	int noJavaDoc;
+	/**
+	 */
+	int emptyJavaDoc;
+	/**
+	 */
+	int emptyJavaDocLine;
+	/**
+	 * Some text
+	 */
+	int oneLine;
+	/**
+	 * Some text
+	 * in a second line
+	 */
+	int twoLines;
+	/**
+	 * Some text
+	 * in a second line
+	 * 
+	 * And a second paragraph
+	 */
+	int secondParagraph;
+	/**
+	 * Some text
+	 * in a second line
+	 * <p>
+	 * And a second paragraph
+	 */
+	int secondParagraphHtml;
+	/**
+	 * Some text
+	 */
+	int withCustomReturnTag;
+
+	@java.lang.SuppressWarnings("all")
+	public int getNoJavaDoc() {
+		return this.noJavaDoc;
+	}
+
+	/**
+	 */
+	@java.lang.SuppressWarnings("all")
+	public int getEmptyJavaDoc() {
+		return this.emptyJavaDoc;
+	}
+
+	/**
+	 */
+	@java.lang.SuppressWarnings("all")
+	public int getEmptyJavaDocLine() {
+		return this.emptyJavaDocLine;
+	}
+
+	/**
+	 * Some text
+	 * @return Some text
+	 */
+	@java.lang.SuppressWarnings("all")
+	public int getOneLine() {
+		return this.oneLine;
+	}
+
+	/**
+	 * Some text
+	 * in a second line
+	 * @return Some text
+	 * in a second line
+	 */
+	@java.lang.SuppressWarnings("all")
+	public int getTwoLines() {
+		return this.twoLines;
+	}
+
+	/**
+	 * Some text
+	 * in a second line
+	 * 
+	 * And a second paragraph
+	 * @return Some text
+	 * in a second line
+	 */
+	@java.lang.SuppressWarnings("all")
+	public int getSecondParagraph() {
+		return this.secondParagraph;
+	}
+
+	/**
+	 * Some text
+	 * in a second line
+	 * <p>
+	 * And a second paragraph
+	 * @return Some text
+	 * in a second line
+	 */
+	@java.lang.SuppressWarnings("all")
+	public int getSecondParagraphHtml() {
+		return this.secondParagraphHtml;
+	}
+
+	/**
+	 * Some text
+	 *
+	 * @return some custom text
+	 */
+	@java.lang.SuppressWarnings("all")
+	public int getWithCustomReturnTag() {
+		return this.withCustomReturnTag;
+	}
+}

--- a/test/transform/resource/after-delombok/SetterJavaDoc.java
+++ b/test/transform/resource/after-delombok/SetterJavaDoc.java
@@ -1,0 +1,111 @@
+class SetterJavaDoc {
+	int noJavaDoc;
+	/**
+	 */
+	int emptyJavaDoc;
+	/**
+	 */
+	int emptyJavaDocLine;
+	/**
+	 * Some text
+	 */
+	int oneLine;
+	/**
+	 * Some text
+	 * in a second line
+	 */
+	int twoLines;
+	/**
+	 * Some text
+	 * in a second line
+	 * 
+	 * And a second paragraph
+	 */
+	int secondParagraph;
+	/**
+	 * Some text
+	 * in a second line
+	 * <p>
+	 * And a second paragraph
+	 */
+	int secondParagraphHtml;
+	/**
+	 * Some text
+	 */
+	int withCustomParamTag;
+
+	@java.lang.SuppressWarnings("all")
+	public void setNoJavaDoc(final int noJavaDoc) {
+		this.noJavaDoc = noJavaDoc;
+	}
+
+	/**
+	 */
+	@java.lang.SuppressWarnings("all")
+	public void setEmptyJavaDoc(final int emptyJavaDoc) {
+		this.emptyJavaDoc = emptyJavaDoc;
+	}
+
+	/**
+	 */
+	@java.lang.SuppressWarnings("all")
+	public void setEmptyJavaDocLine(final int emptyJavaDocLine) {
+		this.emptyJavaDocLine = emptyJavaDocLine;
+	}
+
+	/**
+	 * Some text
+	 * @param oneLine Some text
+	 */
+	@java.lang.SuppressWarnings("all")
+	public void setOneLine(final int oneLine) {
+		this.oneLine = oneLine;
+	}
+
+	/**
+	 * Some text
+	 * in a second line
+	 * @param twoLines Some text
+	 * in a second line
+	 */
+	@java.lang.SuppressWarnings("all")
+	public void setTwoLines(final int twoLines) {
+		this.twoLines = twoLines;
+	}
+
+	/**
+	 * Some text
+	 * in a second line
+	 * 
+	 * And a second paragraph
+	 * @param secondParagraph Some text
+	 * in a second line
+	 */
+	@java.lang.SuppressWarnings("all")
+	public void setSecondParagraph(final int secondParagraph) {
+		this.secondParagraph = secondParagraph;
+	}
+
+	/**
+	 * Some text
+	 * in a second line
+	 * <p>
+	 * And a second paragraph
+	 * @param secondParagraphHtml Some text
+	 * in a second line
+	 */
+	@java.lang.SuppressWarnings("all")
+	public void setSecondParagraphHtml(final int secondParagraphHtml) {
+		this.secondParagraphHtml = secondParagraphHtml;
+	}
+
+	/**
+	 * Some text
+	 *
+	 * @param withCustomParamTag some custom text
+	 */
+	@java.lang.SuppressWarnings("all")
+	public void setWithCustomParamTag(final int withCustomParamTag) {
+		this.withCustomParamTag = withCustomParamTag;
+	}
+}

--- a/test/transform/resource/before/GetterJavaDoc.java
+++ b/test/transform/resource/before/GetterJavaDoc.java
@@ -1,0 +1,56 @@
+import lombok.Getter;
+
+class GetterJavaDoc {
+	@Getter
+	int noJavaDoc;
+	
+	/**
+	 */
+	@Getter
+	int emptyJavaDoc;
+	
+	/**
+	 * 
+	 */
+	@Getter
+	int emptyJavaDocLine;
+	
+	/**
+	 * Some text
+	 */
+	@Getter
+	int oneLine;
+	
+	/**
+	 * Some text
+	 * in a second line
+	 */
+	@Getter
+	int twoLines;
+	
+	/**
+	 * Some text
+	 * in a second line
+	 * 
+	 * And a second paragraph
+	 */
+	@Getter
+	int secondParagraph;
+	
+	/**
+	 * Some text
+	 * in a second line
+	 * <p>
+	 * And a second paragraph
+	 */
+	@Getter
+	int secondParagraphHtml;
+	
+	/**
+	 * Some text
+	 *
+	 * @return some custom text
+	 */
+	@Getter
+	int withCustomReturnTag;
+}

--- a/test/transform/resource/before/SetterJavaDoc.java
+++ b/test/transform/resource/before/SetterJavaDoc.java
@@ -1,0 +1,56 @@
+import lombok.Setter;
+
+class SetterJavaDoc {
+	@Setter
+	int noJavaDoc;
+	
+	/**
+	 */
+	@Setter
+	int emptyJavaDoc;
+	
+	/**
+	 * 
+	 */
+	@Setter
+	int emptyJavaDocLine;
+	
+	/**
+	 * Some text
+	 */
+	@Setter
+	int oneLine;
+	
+	/**
+	 * Some text
+	 * in a second line
+	 */
+	@Setter
+	int twoLines;
+	
+	/**
+	 * Some text
+	 * in a second line
+	 * 
+	 * And a second paragraph
+	 */
+	@Setter
+	int secondParagraph;
+	
+	/**
+	 * Some text
+	 * in a second line
+	 * <p>
+	 * And a second paragraph
+	 */
+	@Setter
+	int secondParagraphHtml;
+	
+	/**
+	 * Some text
+	 *
+	 * @param withCustomParamTag some custom text
+	 */
+	@Setter
+	int withCustomParamTag;
+}


### PR DESCRIPTION
I suggest to generate the JavaDoc tags `@return` and `@param` for the lombok annotations `@Getter` and `@Setter` unless they are specified by the developer manually.

Missing JavaDoc tags cause warnings in javac of JDK11 and later. That's why I came across this idea, which literally avoids developers to copy over JavaDoc code of really simple getters and setters for the `@return` or `@param` JavaDoc tags.

I hope this makes sense. Feel free to give me feedback to the general idea, the implementation, code style and so on.

This Pull Request contains multiple test cases for both lombok annotations inside `src/test/resources/transform/...`, while here comes one example to show the use of this request:

*Lombok code:*
```Java
/**
 * First name of the employee
 */
String firstName;
```

*Delomboked code:*
```Java
/**
 * First name of the employee
 */
@Getter
String firstName;

/**
 * First name of the employee
 * @return First name of the employee
 */
public String getFirstName() {
    return this.firstName;
}
```
