### PR TITLE
SuperBuilder: check extends/implements for collisions (fixes #3202)

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -51,7 +51,6 @@ import org.eclipse.jdt.internal.compiler.ast.FieldDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.FieldReference;
 import org.eclipse.jdt.internal.compiler.ast.IfStatement;
 import org.eclipse.jdt.internal.compiler.ast.Initializer;
-import org.eclipse.jdt.internal.compiler.ast.MarkerAnnotation;
 import org.eclipse.jdt.internal.compiler.ast.MessageSend;
 import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.NullLiteral;
@@ -1100,13 +1099,28 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		if (td.fields != null) {
 			for (FieldDeclaration field : td.fields) {
 				if (field instanceof Initializer) continue; 
-				char[][] typeName = field.type.getTypeName();
-				if (typeName.length >= 1) // Add the first token, because only that can collide.
-					usedNames.add(String.valueOf(typeName[0]));
+				addFirstToken(usedNames, field.type);
+			}
+		}
+		
+		// 4. Add extends and implements clauses.
+		addFirstToken(usedNames, td.superclass);
+		if (td.superInterfaces != null) {
+			for (TypeReference typeReference : td.superInterfaces) {
+				addFirstToken(usedNames, typeReference);
 			}
 		}
 		
 		return usedNames;
+	}
+
+	private void addFirstToken(java.util.Set<String> usedNames, TypeReference type) {
+		if (type == null) 
+			return;
+		// Add the first token, because only that can collide.
+		char[][] typeName = type.getTypeName();
+		if (typeName != null && typeName.length >= 1)
+			usedNames.add(String.valueOf(typeName[0]));
 	}
 	
 	private String generateNonclashingNameFor(String classGenericName, java.util.Set<String> typeParamStrings) {

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -1051,7 +1051,23 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			}
 		}
 		
+		// 4. Add extends and implements clauses.
+		addFirstToken(usedNames, Javac.getExtendsClause(td));
+		for (JCExpression impl : td.getImplementsClause()) {
+			addFirstToken(usedNames, impl);
+		}
+		
 		return usedNames;
+	}
+	
+	private void addFirstToken(java.util.Set<String> usedNames, JCTree type) {
+		if (type == null) 
+			return;
+		while (type instanceof JCFieldAccess && ((JCFieldAccess)type).selected != null) {
+			// Add the first token, because only that can collide.
+			type = ((JCFieldAccess)type).selected;
+		}
+		usedNames.add(type.toString());
 	}
 	
 	private String generateNonclashingNameFor(String classGenericName, java.util.HashSet<String> typeParamStrings) {

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -1063,6 +1063,9 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 	private void addFirstToken(java.util.Set<String> usedNames, JCTree type) {
 		if (type == null) 
 			return;
+		if (type instanceof JCTypeApply) {
+			type = ((JCTypeApply)type).clazz;
+		}
 		while (type instanceof JCFieldAccess && ((JCFieldAccess)type).selected != null) {
 			// Add the first token, because only that can collide.
 			type = ((JCFieldAccess)type).selected;

--- a/test/transform/resource/after-delombok/SuperBuilderNameClashes.java
+++ b/test/transform/resource/after-delombok/SuperBuilderNameClashes.java
@@ -125,13 +125,17 @@ public class SuperBuilderNameClashes {
 		}
 	}
 	interface B2 {
+		interface B4<X> {
+		}
 	}
-	public static class ExtendsClauseCollision extends B implements B2 {
+	interface B3<Y> {
+	}
+	public static class ExtendsClauseCollision extends B implements B2.B4<Object>, B3<Object> {
 		@java.lang.SuppressWarnings("all")
-		public static abstract class ExtendsClauseCollisionBuilder<C extends SuperBuilderNameClashes.ExtendsClauseCollision, B3 extends SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<C, B3>> extends B.BBuilder<C, B3> {
+		public static abstract class ExtendsClauseCollisionBuilder<C extends SuperBuilderNameClashes.ExtendsClauseCollision, B4 extends SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<C, B4>> extends B.BBuilder<C, B4> {
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
-			protected abstract B3 self();
+			protected abstract B4 self();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public abstract C build();

--- a/test/transform/resource/after-delombok/SuperBuilderNameClashes.java
+++ b/test/transform/resource/after-delombok/SuperBuilderNameClashes.java
@@ -124,4 +124,46 @@ public class SuperBuilderNameClashes {
 			return new SuperBuilderNameClashes.C.CBuilderImpl();
 		}
 	}
+	interface B2 {
+	}
+	public static class ExtendsClauseCollision extends B implements B2 {
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ExtendsClauseCollisionBuilder<C extends SuperBuilderNameClashes.ExtendsClauseCollision, B3 extends SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<C, B3>> extends B.BBuilder<C, B3> {
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B3 self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder(super=" + super.toString() + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ExtendsClauseCollisionBuilderImpl extends SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<SuperBuilderNameClashes.ExtendsClauseCollision, SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private ExtendsClauseCollisionBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public SuperBuilderNameClashes.ExtendsClauseCollision build() {
+				return new SuperBuilderNameClashes.ExtendsClauseCollision(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected ExtendsClauseCollision(final SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<?, ?> b) {
+			super(b);
+		}
+		@java.lang.SuppressWarnings("all")
+		public static SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<?, ?> builder() {
+			return new SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilderImpl();
+		}
+	}
 }

--- a/test/transform/resource/after-ecj/SuperBuilderNameClashes.java
+++ b/test/transform/resource/after-ecj/SuperBuilderNameClashes.java
@@ -101,6 +101,37 @@ public class SuperBuilderNameClashes {
       return new SuperBuilderNameClashes.C.CBuilderImpl();
     }
   }
+  interface B2 {
+  }
+  public static @lombok.experimental.SuperBuilder class ExtendsClauseCollision extends B implements B2 {
+    public static abstract @java.lang.SuppressWarnings("all") class ExtendsClauseCollisionBuilder<C extends SuperBuilderNameClashes.ExtendsClauseCollision, B3 extends SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<C, B3>> extends B.BBuilder<C, B3> {
+      public ExtendsClauseCollisionBuilder() {
+        super();
+      }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B3 self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (("SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder(super=" + super.toString()) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ExtendsClauseCollisionBuilderImpl extends SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<SuperBuilderNameClashes.ExtendsClauseCollision, SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilderImpl> {
+      private ExtendsClauseCollisionBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderNameClashes.ExtendsClauseCollision build() {
+        return new SuperBuilderNameClashes.ExtendsClauseCollision(this);
+      }
+    }
+    protected @java.lang.SuppressWarnings("all") ExtendsClauseCollision(final SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<?, ?> b) {
+      super(b);
+    }
+    public static @java.lang.SuppressWarnings("all") SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<?, ?> builder() {
+      return new SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilderImpl();
+    }
+  }
   public SuperBuilderNameClashes() {
     super();
   }

--- a/test/transform/resource/after-ecj/SuperBuilderNameClashes.java
+++ b/test/transform/resource/after-ecj/SuperBuilderNameClashes.java
@@ -102,13 +102,17 @@ public class SuperBuilderNameClashes {
     }
   }
   interface B2 {
+    interface B4<X> {
+    }
   }
-  public static @lombok.experimental.SuperBuilder class ExtendsClauseCollision extends B implements B2 {
-    public static abstract @java.lang.SuppressWarnings("all") class ExtendsClauseCollisionBuilder<C extends SuperBuilderNameClashes.ExtendsClauseCollision, B3 extends SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<C, B3>> extends B.BBuilder<C, B3> {
+  interface B3<Y> {
+  }
+  public static @lombok.experimental.SuperBuilder class ExtendsClauseCollision extends B implements B2.B4<Object>, B3<Object> {
+    public static abstract @java.lang.SuppressWarnings("all") class ExtendsClauseCollisionBuilder<C extends SuperBuilderNameClashes.ExtendsClauseCollision, B4 extends SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder<C, B4>> extends B.BBuilder<C, B4> {
       public ExtendsClauseCollisionBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B3 self();
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B4 self();
       public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (("SuperBuilderNameClashes.ExtendsClauseCollision.ExtendsClauseCollisionBuilder(super=" + super.toString()) + ")");

--- a/test/transform/resource/before/SuperBuilderNameClashes.java
+++ b/test/transform/resource/before/SuperBuilderNameClashes.java
@@ -14,4 +14,11 @@ public class SuperBuilderNameClashes {
 	public static class C {
 		C2 c2;
 	}
+	
+	interface B2 {
+	}
+	
+	@lombok.experimental.SuperBuilder
+	public static class ExtendsClauseCollision extends B implements B2 {
+	}
 }

--- a/test/transform/resource/before/SuperBuilderNameClashes.java
+++ b/test/transform/resource/before/SuperBuilderNameClashes.java
@@ -16,9 +16,14 @@ public class SuperBuilderNameClashes {
 	}
 	
 	interface B2 {
+		interface B4<X> {
+		}
+	}
+	
+	interface B3<Y> {
 	}
 	
 	@lombok.experimental.SuperBuilder
-	public static class ExtendsClauseCollision extends B implements B2 {
+	public static class ExtendsClauseCollision extends B implements B2.B4<Object>, B3<Object> {
 	}
 }


### PR DESCRIPTION
With this PR, `@SuperBuilder` checks for type argument name collisions also with `extends` and `implements` clauses. This fixes #3202.


For retrieving the `extends` clause in the javac handler, I had to use `Javac.getExtendsClause(classDecl))`, which does some tricks to get around access limitations for that method. When using `JCClassDecl.getImplementsClause()` this was not necessary at least in my setup (Java 11). I'm not sure if there might be access restrictions for that method (similar to the `getExtendsClause` method) in other Java version.
Does anyone know that? (No other handler uses that method, so there is no indication in the current sources...)