### PR TITLE
Fix SuperBuilder for fields named "build" or "self"

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -51,7 +51,6 @@ import org.eclipse.jdt.internal.compiler.ast.FieldDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.FieldReference;
 import org.eclipse.jdt.internal.compiler.ast.IfStatement;
 import org.eclipse.jdt.internal.compiler.ast.Initializer;
-import org.eclipse.jdt.internal.compiler.ast.MarkerAnnotation;
 import org.eclipse.jdt.internal.compiler.ast.MessageSend;
 import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.NullLiteral;
@@ -387,15 +386,15 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 			injectMethod(job.builderType, generateStaticFillValuesMethod(job, annInstance.setterPrefix()));
 		}
 		
-		// Generate abstract self() and build() methods in the abstract builder.
-		injectMethod(job.builderType, generateAbstractSelfMethod(job, superclassBuilderClass != null, builderGenericName));
-		job.setBuilderToAbstract();
-		injectMethod(job.builderType, generateAbstractBuildMethod(job, superclassBuilderClass != null, classGenericName));
-		
 		// Create the setter methods in the abstract builder.
 		for (BuilderFieldData bfd : job.builderFields) {
 			generateSetterMethodsForBuilder(job, bfd, builderGenericName, annInstance.setterPrefix());
 		}
+		
+		// Generate abstract self() and build() methods in the abstract builder.
+		injectMethod(job.builderType, generateAbstractSelfMethod(job, superclassBuilderClass != null, builderGenericName));
+		job.setBuilderToAbstract();
+		injectMethod(job.builderType, generateAbstractBuildMethod(job, superclassBuilderClass != null, classGenericName));
 		
 		// Create the toString() method for the abstract builder.
 		if (methodExists("toString", job.builderType, 0) == MemberExistsResult.NOT_EXISTS) {

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -336,6 +336,11 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			injectMethod(job.builderType, sfvm);
 		}
 		
+		// Create the setter methods in the abstract builder.
+		for (BuilderFieldData bfd : job.builderFields) {
+			generateSetterMethodsForBuilder(job, bfd, builderGenericName, annInstance.setterPrefix());
+		}
+		
 		// Generate abstract self() and build() methods in the abstract builder.
 		JCMethodDecl asm = generateAbstractSelfMethod(job, superclassBuilderClass != null, builderGenericName);
 		recursiveSetGeneratedBy(asm, annotationNode);
@@ -343,11 +348,6 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		JCMethodDecl abm = generateAbstractBuildMethod(job, superclassBuilderClass != null, classGenericName);
 		recursiveSetGeneratedBy(abm, annotationNode);
 		injectMethod(job.builderType, abm);
-		
-		// Create the setter methods in the abstract builder.
-		for (BuilderFieldData bfd : job.builderFields) {
-			generateSetterMethodsForBuilder(job, bfd, builderGenericName, annInstance.setterPrefix());
-		}
 		
 		// Create the toString() method for the abstract builder.
 		java.util.List<Included<JavacNode, ToString.Include>> fieldNodes = new ArrayList<Included<JavacNode, ToString.Include>>();

--- a/test/transform/resource/after-delombok/BuilderCustomName.java
+++ b/test/transform/resource/after-delombok/BuilderCustomName.java
@@ -5,10 +5,6 @@ class BuilderCustomName<T> {
 	public static abstract class SimpleTestBuilder<T, C extends BuilderCustomName<T>, B extends BuilderCustomName.SimpleTestBuilder<T, C, B>> {
 		@java.lang.SuppressWarnings("all")
 		private int field;
-		@java.lang.SuppressWarnings("all")
-		protected abstract B self();
-		@java.lang.SuppressWarnings("all")
-		public abstract C build();
 		/**
 		 * @return {@code this}.
 		 */
@@ -17,6 +13,10 @@ class BuilderCustomName<T> {
 			this.field = field;
 			return self();
 		}
+		@java.lang.SuppressWarnings("all")
+		protected abstract B self();
+		@java.lang.SuppressWarnings("all")
+		public abstract C build();
 		@java.lang.Override
 		@java.lang.SuppressWarnings("all")
 		public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/CheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-delombok/CheckerFrameworkSuperBuilder.java
@@ -23,12 +23,6 @@ class CheckerFrameworkSuperBuilder {
 			private int z;
 			@java.lang.SuppressWarnings("all")
 			private java.util.ArrayList<String> names;
-			@org.checkerframework.dataflow.qual.Pure
-			@java.lang.SuppressWarnings("all")
-			protected abstract @org.checkerframework.common.returnsreceiver.qual.This B self();
-			@org.checkerframework.dataflow.qual.SideEffectFree
-			@java.lang.SuppressWarnings("all")
-			public abstract C build(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilder<C, B> this);
 			/**
 			 * @return {@code this}.
 			 */
@@ -74,6 +68,12 @@ class CheckerFrameworkSuperBuilder {
 				if (this.names != null) this.names.clear();
 				return self();
 			}
+			@org.checkerframework.dataflow.qual.Pure
+			@java.lang.SuppressWarnings("all")
+			protected abstract @org.checkerframework.common.returnsreceiver.qual.This B self();
+			@org.checkerframework.dataflow.qual.SideEffectFree
+			@java.lang.SuppressWarnings("all")
+			public abstract C build(CheckerFrameworkSuperBuilder.Parent.@org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilder<C, B> this);
 			@org.checkerframework.dataflow.qual.SideEffectFree
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
@@ -140,14 +140,6 @@ class CheckerFrameworkSuperBuilder {
 			private int a$value;
 			@java.lang.SuppressWarnings("all")
 			private int b;
-			@java.lang.Override
-			@org.checkerframework.dataflow.qual.Pure
-			@java.lang.SuppressWarnings("all")
-			protected abstract @org.checkerframework.common.returnsreceiver.qual.This B self();
-			@org.checkerframework.dataflow.qual.SideEffectFree
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilder<C, B> this);
 			/**
 			 * @return {@code this}.
 			 */
@@ -165,6 +157,14 @@ class CheckerFrameworkSuperBuilder {
 				this.b = b;
 				return self();
 			}
+			@java.lang.Override
+			@org.checkerframework.dataflow.qual.Pure
+			@java.lang.SuppressWarnings("all")
+			protected abstract @org.checkerframework.common.returnsreceiver.qual.This B self();
+			@org.checkerframework.dataflow.qual.SideEffectFree
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build(CheckerFrameworkSuperBuilder.ZChild.@org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilder<C, B> this);
 			@org.checkerframework.dataflow.qual.SideEffectFree
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")

--- a/test/transform/resource/after-delombok/ConstructorsWithSuperBuilderDefaults.java
+++ b/test/transform/resource/after-delombok/ConstructorsWithSuperBuilderDefaults.java
@@ -17,12 +17,6 @@ class ConstructorsWithSuperBuilderDefaults {
 		@java.lang.SuppressWarnings("all")
 		private int y;
 
-		@java.lang.SuppressWarnings("all")
-		protected abstract B self();
-
-		@java.lang.SuppressWarnings("all")
-		public abstract C build();
-
 		/**
 		 * @return {@code this}.
 		 */
@@ -41,6 +35,12 @@ class ConstructorsWithSuperBuilderDefaults {
 			this.y = y;
 			return self();
 		}
+
+		@java.lang.SuppressWarnings("all")
+		protected abstract B self();
+
+		@java.lang.SuppressWarnings("all")
+		public abstract C build();
 
 		@java.lang.Override
 		@java.lang.SuppressWarnings("all")

--- a/test/transform/resource/after-delombok/JacksonizedSuperBuilderSimple.java
+++ b/test/transform/resource/after-delombok/JacksonizedSuperBuilderSimple.java
@@ -8,10 +8,6 @@ public class JacksonizedSuperBuilderSimple {
 		public static abstract class ParentBuilder<C extends JacksonizedSuperBuilderSimple.Parent, B extends JacksonizedSuperBuilderSimple.Parent.ParentBuilder<C, B>> {
 			@java.lang.SuppressWarnings("all")
 			private int field1;
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -20,6 +16,10 @@ public class JacksonizedSuperBuilderSimple {
 				this.field1 = field1;
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/JacksonizedSuperBuilderWithJsonDeserialize.java
+++ b/test/transform/resource/after-delombok/JacksonizedSuperBuilderWithJsonDeserialize.java
@@ -6,10 +6,6 @@ public class JacksonizedSuperBuilderWithJsonDeserialize {
 	public static abstract class JacksonizedSuperBuilderWithJsonDeserializeBuilder<C extends JacksonizedSuperBuilderWithJsonDeserialize, B extends JacksonizedSuperBuilderWithJsonDeserialize.JacksonizedSuperBuilderWithJsonDeserializeBuilder<C, B>> {
 		@java.lang.SuppressWarnings("all")
 		private int field1;
-		@java.lang.SuppressWarnings("all")
-		protected abstract B self();
-		@java.lang.SuppressWarnings("all")
-		public abstract C build();
 		/**
 		 * @return {@code this}.
 		 */
@@ -18,6 +14,10 @@ public class JacksonizedSuperBuilderWithJsonDeserialize {
 			this.field1 = field1;
 			return self();
 		}
+		@java.lang.SuppressWarnings("all")
+		protected abstract B self();
+		@java.lang.SuppressWarnings("all")
+		public abstract C build();
 		@java.lang.Override
 		@java.lang.SuppressWarnings("all")
 		public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/NullAnnotatedCheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-delombok/NullAnnotatedCheckerFrameworkSuperBuilder.java
@@ -29,12 +29,6 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
 			@java.lang.SuppressWarnings("all")
 			private java.util.ArrayList<String> names;
 
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
-
 			/**
 			 * @return {@code this}.
 			 */
@@ -91,6 +85,12 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
 				if (this.names != null) this.names.clear();
 				return self();
 			}
+
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
@@ -165,14 +165,6 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
 			@java.lang.SuppressWarnings("all")
 			private int b;
 
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
-
 			/**
 			 * @return {@code this}.
 			 */
@@ -193,6 +185,14 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
 				this.b = b;
 				return self();
 			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")

--- a/test/transform/resource/after-delombok/SuperBuilderAbstract.java
+++ b/test/transform/resource/after-delombok/SuperBuilderAbstract.java
@@ -5,10 +5,6 @@ public class SuperBuilderAbstract {
 		public static abstract class ParentBuilder<C extends SuperBuilderAbstract.Parent, B extends SuperBuilderAbstract.Parent.ParentBuilder<C, B>> {
 			@java.lang.SuppressWarnings("all")
 			private int parentField;
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -17,6 +13,10 @@ public class SuperBuilderAbstract {
 				this.parentField = parentField;
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -54,12 +54,6 @@ public class SuperBuilderAbstract {
 		public static abstract class ChildBuilder<C extends SuperBuilderAbstract.Child, B extends SuperBuilderAbstract.Child.ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
 			@java.lang.SuppressWarnings("all")
 			private double childField;
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -68,6 +62,12 @@ public class SuperBuilderAbstract {
 				this.childField = childField;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -86,12 +86,6 @@ public class SuperBuilderAbstract {
 		public static abstract class GrandChildBuilder<C extends SuperBuilderAbstract.GrandChild, B extends SuperBuilderAbstract.GrandChild.GrandChildBuilder<C, B>> extends Child.ChildBuilder<C, B> {
 			@java.lang.SuppressWarnings("all")
 			private String grandChildField;
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -100,6 +94,12 @@ public class SuperBuilderAbstract {
 				this.grandChildField = grandChildField;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderAbstractToBuilder.java
+++ b/test/transform/resource/after-delombok/SuperBuilderAbstractToBuilder.java
@@ -14,10 +14,6 @@ public class SuperBuilderAbstractToBuilder {
 			private static void $fillValuesFromInstanceIntoBuilder(final SuperBuilderAbstractToBuilder.Parent instance, final SuperBuilderAbstractToBuilder.Parent.ParentBuilder<?, ?> b) {
 				b.parentField(instance.parentField);
 			}
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -26,6 +22,10 @@ public class SuperBuilderAbstractToBuilder {
 				this.parentField = parentField;
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -78,12 +78,6 @@ public class SuperBuilderAbstractToBuilder {
 			private static void $fillValuesFromInstanceIntoBuilder(final SuperBuilderAbstractToBuilder.Child instance, final SuperBuilderAbstractToBuilder.Child.ChildBuilder<?, ?> b) {
 				b.childField(instance.childField);
 			}
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -92,6 +86,12 @@ public class SuperBuilderAbstractToBuilder {
 				this.childField = childField;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -121,12 +121,6 @@ public class SuperBuilderAbstractToBuilder {
 			private static void $fillValuesFromInstanceIntoBuilder(final SuperBuilderAbstractToBuilder.GrandChild instance, final SuperBuilderAbstractToBuilder.GrandChild.GrandChildBuilder<?, ?> b) {
 				b.grandChildField(instance.grandChildField);
 			}
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -135,6 +129,12 @@ public class SuperBuilderAbstractToBuilder {
 				this.grandChildField = grandChildField;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderBasic.java
+++ b/test/transform/resource/after-delombok/SuperBuilderBasic.java
@@ -9,10 +9,6 @@ public class SuperBuilderBasic {
 			private int field1;
 			@java.lang.SuppressWarnings("all")
 			private java.util.ArrayList<String> items;
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -41,6 +37,10 @@ public class SuperBuilderBasic {
 				if (this.items != null) this.items.clear();
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -90,12 +90,6 @@ public class SuperBuilderBasic {
 		public static abstract class ChildBuilder<C extends SuperBuilderBasic.Child, B extends SuperBuilderBasic.Child.ChildBuilder<C, B>> extends SuperBuilderBasic.Parent.ParentBuilder<C, B> {
 			@java.lang.SuppressWarnings("all")
 			private double field3;
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -104,6 +98,12 @@ public class SuperBuilderBasic {
 				this.field3 = field3;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderBasicToBuilder.java
+++ b/test/transform/resource/after-delombok/SuperBuilderBasicToBuilder.java
@@ -37,10 +37,6 @@ public class SuperBuilderBasicToBuilder {
 				b.obtainViaStaticMethod(SuperBuilderBasicToBuilder.Parent.staticMethod(instance));
 				b.items(instance.items == null ? java.util.Collections.<String>emptyList() : instance.items);
 			}
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -93,6 +89,10 @@ public class SuperBuilderBasicToBuilder {
 				if (this.items != null) this.items.clear();
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -160,12 +160,6 @@ public class SuperBuilderBasicToBuilder {
 			private static void $fillValuesFromInstanceIntoBuilder(final SuperBuilderBasicToBuilder.Child instance, final SuperBuilderBasicToBuilder.Child.ChildBuilder<?, ?> b) {
 				b.field3(instance.field3);
 			}
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -174,6 +168,12 @@ public class SuperBuilderBasicToBuilder {
 				this.field3 = field3;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderCustomized.java
+++ b/test/transform/resource/after-delombok/SuperBuilderCustomized.java
@@ -71,12 +71,6 @@ public class SuperBuilderCustomized {
 		public static abstract class ChildBuilder<C extends SuperBuilderCustomized.Child, B extends SuperBuilderCustomized.Child.ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
 			@java.lang.SuppressWarnings("all")
 			private double field2;
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -85,6 +79,12 @@ public class SuperBuilderCustomized {
 				this.field2 = field2;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderInitializer.java
+++ b/test/transform/resource/after-delombok/SuperBuilderInitializer.java
@@ -19,12 +19,6 @@ class SuperBuilderInitializer {
 			@java.lang.SuppressWarnings("all")
 			private String world;
 
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
-
 			/**
 			 * @return {@code this}.
 			 */
@@ -33,6 +27,12 @@ class SuperBuilderInitializer {
 				this.world = world;
 				return self();
 			}
+
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")

--- a/test/transform/resource/after-delombok/SuperBuilderNameClashes.java
+++ b/test/transform/resource/after-delombok/SuperBuilderNameClashes.java
@@ -81,10 +81,6 @@ public class SuperBuilderNameClashes {
 		public static abstract class CBuilder<C3 extends SuperBuilderNameClashes.C, B extends SuperBuilderNameClashes.C.CBuilder<C3, B>> {
 			@java.lang.SuppressWarnings("all")
 			private C2 c2;
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C3 build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -93,6 +89,10 @@ public class SuperBuilderNameClashes {
 				this.c2 = c2;
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C3 build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderSingularAnnotatedTypes.java
+++ b/test/transform/resource/after-delombok/SuperBuilderSingularAnnotatedTypes.java
@@ -19,10 +19,6 @@ class SuperBuilderSingularAnnotatedTypes {
 		@java.lang.SuppressWarnings("all")
 		private java.util.ArrayList<@MyAnnotation @NonNull Integer> bars$value;
 		@java.lang.SuppressWarnings("all")
-		protected abstract B self();
-		@java.lang.SuppressWarnings("all")
-		public abstract C build();
-		@java.lang.SuppressWarnings("all")
 		public B foo(@MyAnnotation @NonNull final String foo) {
 			if (foo == null) {
 				throw new java.lang.NullPointerException("foo is marked non-null but is null");
@@ -84,6 +80,10 @@ class SuperBuilderSingularAnnotatedTypes {
 			}
 			return self();
 		}
+		@java.lang.SuppressWarnings("all")
+		protected abstract B self();
+		@java.lang.SuppressWarnings("all")
+		public abstract C build();
 		@java.lang.Override
 		@java.lang.SuppressWarnings("all")
 		public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderSingularCustomized.java
+++ b/test/transform/resource/after-delombok/SuperBuilderSingularCustomized.java
@@ -8,10 +8,6 @@ class SuperBuilderSingularCustomized {
 			return self();
 		}
 		@java.lang.SuppressWarnings("all")
-		protected abstract B self();
-		@java.lang.SuppressWarnings("all")
-		public abstract C build();
-		@java.lang.SuppressWarnings("all")
 		public B foo(final String foo) {
 			if (this.foos == null) this.foos = new java.util.ArrayList<String>();
 			this.foos.add(foo);
@@ -31,6 +27,10 @@ class SuperBuilderSingularCustomized {
 			if (this.foos != null) this.foos.clear();
 			return self();
 		}
+		@java.lang.SuppressWarnings("all")
+		protected abstract B self();
+		@java.lang.SuppressWarnings("all")
+		public abstract C build();
 		@java.lang.Override
 		@java.lang.SuppressWarnings("all")
 		public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderSingularToBuilderGuava.java
+++ b/test/transform/resource/after-delombok/SuperBuilderSingularToBuilderGuava.java
@@ -32,10 +32,6 @@ public class SuperBuilderSingularToBuilderGuava {
 				b.users(instance.users == null ? com.google.common.collect.ImmutableTable.<Number, Number, String>of() : instance.users);
 			}
 			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
-			@java.lang.SuppressWarnings("all")
 			public B card(final T card) {
 				if (this.cards == null) this.cards = com.google.common.collect.ImmutableList.builder();
 				this.cards.add(card);
@@ -135,6 +131,10 @@ public class SuperBuilderSingularToBuilderGuava {
 				this.users = null;
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -196,12 +196,6 @@ public class SuperBuilderSingularToBuilderGuava {
 			private static <T> void $fillValuesFromInstanceIntoBuilder(final SuperBuilderSingularToBuilderGuava.Child<T> instance, final SuperBuilderSingularToBuilderGuava.Child.ChildBuilder<T, ?, ?> b) {
 				b.field3(instance.field3);
 			}
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -210,6 +204,12 @@ public class SuperBuilderSingularToBuilderGuava {
 				this.field3 = field3;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithCustomBuilderMethod.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithCustomBuilderMethod.java
@@ -10,10 +10,6 @@ public class SuperBuilderWithCustomBuilderMethod {
 			private A field1;
 			@java.lang.SuppressWarnings("all")
 			private java.util.ArrayList<String> items;
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -42,6 +38,10 @@ public class SuperBuilderWithCustomBuilderMethod {
 				if (this.items != null) this.items.clear();
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -94,12 +94,6 @@ public class SuperBuilderWithCustomBuilderMethod {
 		public static abstract class ChildBuilder<A, C extends SuperBuilderWithCustomBuilderMethod.Child<A>, B extends SuperBuilderWithCustomBuilderMethod.Child.ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
 			@java.lang.SuppressWarnings("all")
 			private double field3;
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -108,6 +102,12 @@ public class SuperBuilderWithCustomBuilderMethod {
 				this.field3 = field3;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithDefaults.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithDefaults.java
@@ -21,10 +21,6 @@ public class SuperBuilderWithDefaults {
 			private boolean numberField$set;
 			@java.lang.SuppressWarnings("all")
 			private N numberField$value;
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -43,6 +39,10 @@ public class SuperBuilderWithDefaults {
 				numberField$set = true;
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -89,12 +89,6 @@ public class SuperBuilderWithDefaults {
 			private boolean doubleField$set;
 			@java.lang.SuppressWarnings("all")
 			private double doubleField$value;
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -104,6 +98,12 @@ public class SuperBuilderWithDefaults {
 				doubleField$set = true;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithDefaultsAndTargetTyping.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithDefaultsAndTargetTyping.java
@@ -18,12 +18,6 @@ public class SuperBuilderWithDefaultsAndTargetTyping {
 			@java.lang.SuppressWarnings("all")
 			private String foo$value;
 
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
-
 			/**
 			 * @return {@code this}.
 			 */
@@ -33,6 +27,12 @@ public class SuperBuilderWithDefaultsAndTargetTyping {
 				foo$set = true;
 				return self();
 			}
+
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
@@ -90,14 +90,6 @@ public class SuperBuilderWithDefaultsAndTargetTyping {
 			@java.lang.SuppressWarnings("all")
 			private String foo$value;
 
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
-
 			/**
 			 * @return {@code this}.
 			 */
@@ -107,6 +99,14 @@ public class SuperBuilderWithDefaultsAndTargetTyping {
 				foo$set = true;
 				return self();
 			}
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenerics.java
@@ -9,10 +9,6 @@ public class SuperBuilderWithGenerics {
 			private A field1;
 			@java.lang.SuppressWarnings("all")
 			private java.util.ArrayList<String> items;
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -41,6 +37,10 @@ public class SuperBuilderWithGenerics {
 				if (this.items != null) this.items.clear();
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -90,12 +90,6 @@ public class SuperBuilderWithGenerics {
 		public static abstract class ChildBuilder<A, C extends SuperBuilderWithGenerics.Child<A>, B extends SuperBuilderWithGenerics.Child.ChildBuilder<A, C, B>> extends Parent.ParentBuilder<A, C, B> {
 			@java.lang.SuppressWarnings("all")
 			private double field3;
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -104,6 +98,12 @@ public class SuperBuilderWithGenerics {
 				this.field3 = field3;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenerics2.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenerics2.java
@@ -9,10 +9,6 @@ public class SuperBuilderWithGenerics2 {
 			private A field1;
 			@java.lang.SuppressWarnings("all")
 			private java.util.ArrayList<String> items;
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -41,6 +37,10 @@ public class SuperBuilderWithGenerics2 {
 				if (this.items != null) this.items.clear();
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -90,12 +90,6 @@ public class SuperBuilderWithGenerics2 {
 		public static abstract class ChildBuilder<A, C extends SuperBuilderWithGenerics2.Child<A>, B extends SuperBuilderWithGenerics2.Child.ChildBuilder<A, C, B>> extends Parent.ParentBuilder<String, C, B> {
 			@java.lang.SuppressWarnings("all")
 			private A field3;
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -104,6 +98,12 @@ public class SuperBuilderWithGenerics2 {
 				this.field3 = field3;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenerics3.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenerics3.java
@@ -6,10 +6,6 @@ public class SuperBuilderWithGenerics3 {
 		public static abstract class ParentBuilder<A, C extends SuperBuilderWithGenerics3.Parent<A>, B extends SuperBuilderWithGenerics3.Parent.ParentBuilder<A, C, B>> {
 			@java.lang.SuppressWarnings("all")
 			private String str;
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -18,6 +14,10 @@ public class SuperBuilderWithGenerics3 {
 				this.str = str;
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -57,12 +57,6 @@ public class SuperBuilderWithGenerics3 {
 		public static abstract class ChildBuilder<C extends SuperBuilderWithGenerics3.Child, B extends SuperBuilderWithGenerics3.Child.ChildBuilder<C, B>> extends Parent.ParentBuilder<Child.SomeInnerStaticClass, C, B> {
 			@java.lang.SuppressWarnings("all")
 			private double field3;
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -71,6 +65,12 @@ public class SuperBuilderWithGenerics3 {
 				this.field3 = field3;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithGenericsAndToBuilder.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithGenericsAndToBuilder.java
@@ -21,10 +21,6 @@ public class SuperBuilderWithGenericsAndToBuilder {
 				b.field1(instance.field1);
 				b.items(instance.items == null ? java.util.Collections.<Integer, String>emptyMap() : instance.items);
 			}
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -66,6 +62,10 @@ public class SuperBuilderWithGenericsAndToBuilder {
 				}
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -132,12 +132,6 @@ public class SuperBuilderWithGenericsAndToBuilder {
 			private static <A> void $fillValuesFromInstanceIntoBuilder(final SuperBuilderWithGenericsAndToBuilder.Child<A> instance, final SuperBuilderWithGenericsAndToBuilder.Child.ChildBuilder<A, ?, ?> b) {
 				b.field3(instance.field3);
 			}
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -146,6 +140,12 @@ public class SuperBuilderWithGenericsAndToBuilder {
 				this.field3 = field3;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithNonNull.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithNonNull.java
@@ -14,10 +14,6 @@ public class SuperBuilderWithNonNull {
 			private boolean nonNullParentField$set;
 			@java.lang.SuppressWarnings("all")
 			private String nonNullParentField$value;
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -30,6 +26,10 @@ public class SuperBuilderWithNonNull {
 				nonNullParentField$set = true;
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -72,12 +72,6 @@ public class SuperBuilderWithNonNull {
 		public static abstract class ChildBuilder<C extends SuperBuilderWithNonNull.Child, B extends SuperBuilderWithNonNull.Child.ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
 			@java.lang.SuppressWarnings("all")
 			private String nonNullChildField;
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -89,6 +83,12 @@ public class SuperBuilderWithNonNull {
 				this.nonNullChildField = nonNullChildField;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithOverloadedGeneratedMethods.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithOverloadedGeneratedMethods.java
@@ -1,0 +1,106 @@
+public class SuperBuilderWithOverloadedGeneratedMethods {
+	public static class Parent {
+		int self;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ParentBuilder<C extends SuperBuilderWithOverloadedGeneratedMethods.Parent, B extends SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilder<C, B>> {
+			@java.lang.SuppressWarnings("all")
+			private int self;
+			/**
+			 * @return {@code this}.
+			 */
+			@java.lang.SuppressWarnings("all")
+			public B self(final int self) {
+				this.self = self;
+				return self();
+			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilder(self=" + this.self + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ParentBuilderImpl extends SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilder<SuperBuilderWithOverloadedGeneratedMethods.Parent, SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private ParentBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public SuperBuilderWithOverloadedGeneratedMethods.Parent build() {
+				return new SuperBuilderWithOverloadedGeneratedMethods.Parent(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Parent(final SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilder<?, ?> b) {
+			this.self = b.self;
+		}
+		@java.lang.SuppressWarnings("all")
+		public static SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilder<?, ?> builder() {
+			return new SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilderImpl();
+		}
+	}
+	public static class Child extends Parent {
+		double build;
+		@java.lang.SuppressWarnings("all")
+		public static abstract class ChildBuilder<C extends SuperBuilderWithOverloadedGeneratedMethods.Child, B extends SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
+			@java.lang.SuppressWarnings("all")
+			private double build;
+			/**
+			 * @return {@code this}.
+			 */
+			@java.lang.SuppressWarnings("all")
+			public B build(final double build) {
+				this.build = build;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public java.lang.String toString() {
+				return "SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilder(super=" + super.toString() + ", build=" + this.build + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		private static final class ChildBuilderImpl extends SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilder<SuperBuilderWithOverloadedGeneratedMethods.Child, SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			private ChildBuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public SuperBuilderWithOverloadedGeneratedMethods.Child build() {
+				return new SuperBuilderWithOverloadedGeneratedMethods.Child(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		protected Child(final SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilder<?, ?> b) {
+			super(b);
+			this.build = b.build;
+		}
+		@java.lang.SuppressWarnings("all")
+		public static SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilder<?, ?> builder() {
+			return new SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilderImpl();
+		}
+	}
+	public static void test() {
+		Child x = Child.builder().build(0.0).self(5).build();
+	}
+}

--- a/test/transform/resource/after-delombok/SuperBuilderWithPrefixes.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithPrefixes.java
@@ -10,10 +10,6 @@ class SuperBuilderWithPrefixes {
 		private int otherField;
 		@java.lang.SuppressWarnings("all")
 		private java.util.ArrayList<String> items;
-		@java.lang.SuppressWarnings("all")
-		protected abstract B self();
-		@java.lang.SuppressWarnings("all")
-		public abstract C build();
 		/**
 		 * @return {@code this}.
 		 */
@@ -50,6 +46,10 @@ class SuperBuilderWithPrefixes {
 			if (this.items != null) this.items.clear();
 			return self();
 		}
+		@java.lang.SuppressWarnings("all")
+		protected abstract B self();
+		@java.lang.SuppressWarnings("all")
+		public abstract C build();
 		@java.lang.Override
 		@java.lang.SuppressWarnings("all")
 		public java.lang.String toString() {

--- a/test/transform/resource/after-delombok/SuperBuilderWithSetterPrefix.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithSetterPrefix.java
@@ -37,10 +37,6 @@ public class SuperBuilderWithSetterPrefix {
 				b.withObtainViaStaticMethod(SuperBuilderWithSetterPrefix.Parent.staticMethod(instance));
 				b.withItems(instance.items == null ? java.util.Collections.<String>emptyList() : instance.items);
 			}
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -93,6 +89,10 @@ public class SuperBuilderWithSetterPrefix {
 				if (this.items != null) this.items.clear();
 				return self();
 			}
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {
@@ -160,12 +160,6 @@ public class SuperBuilderWithSetterPrefix {
 			private static void $fillValuesFromInstanceIntoBuilder(final SuperBuilderWithSetterPrefix.Child instance, final SuperBuilderWithSetterPrefix.Child.ChildBuilder<?, ?> b) {
 				b.setField3(instance.field3);
 			}
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			protected abstract B self();
-			@java.lang.Override
-			@java.lang.SuppressWarnings("all")
-			public abstract C build();
 			/**
 			 * @return {@code this}.
 			 */
@@ -174,6 +168,12 @@ public class SuperBuilderWithSetterPrefix {
 				this.field3 = field3;
 				return self();
 			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			public abstract C build();
 			@java.lang.Override
 			@java.lang.SuppressWarnings("all")
 			public java.lang.String toString() {

--- a/test/transform/resource/after-ecj/BuilderCustomName.java
+++ b/test/transform/resource/after-ecj/BuilderCustomName.java
@@ -5,8 +5,6 @@ import java.util.List;
     public SimpleTestBuilder() {
       super();
     }
-    protected abstract @java.lang.SuppressWarnings("all") B self();
-    public abstract @java.lang.SuppressWarnings("all") C build();
     /**
      * @return {@code this}.
      */
@@ -14,6 +12,8 @@ import java.util.List;
       this.field = field;
       return self();
     }
+    protected abstract @java.lang.SuppressWarnings("all") B self();
+    public abstract @java.lang.SuppressWarnings("all") C build();
     public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
       return (("BuilderCustomName.SimpleTestBuilder(field=" + this.field) + ")");
     }

--- a/test/transform/resource/after-ecj/CheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-ecj/CheckerFrameworkSuperBuilder.java
@@ -11,8 +11,6 @@ class CheckerFrameworkSuperBuilder {
       public ParentBuilder() {
         super();
       }
-      protected abstract @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B self();
-      public abstract @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilder<C, B> this);
       /**
        * @return {@code this}.
        */
@@ -56,6 +54,8 @@ class CheckerFrameworkSuperBuilder {
             this.names.clear();
         return self();
       }
+      protected abstract @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B self();
+      public abstract @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(CheckerFrameworkSuperBuilder.Parent. @org.checkerframework.checker.calledmethods.qual.CalledMethods({"y", "z"}) ParentBuilder<C, B> this);
       public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((((((("CheckerFrameworkSuperBuilder.Parent.ParentBuilder(x$value=" + this.x$value) + ", y=") + this.y) + ", z=") + this.z) + ", names=") + this.names) + ")");
       }
@@ -111,8 +111,6 @@ class CheckerFrameworkSuperBuilder {
       public ZChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B self();
-      public abstract @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(CheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilder<C, B> this);
       /**
        * @return {@code this}.
        */
@@ -128,6 +126,8 @@ class CheckerFrameworkSuperBuilder {
         this.b = b;
         return self();
       }
+      protected abstract @java.lang.Override @org.checkerframework.dataflow.qual.Pure @java.lang.SuppressWarnings("all") @org.checkerframework.common.returnsreceiver.qual.This B self();
+      public abstract @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") C build(CheckerFrameworkSuperBuilder.ZChild. @org.checkerframework.checker.calledmethods.qual.CalledMethods("b") ZChildBuilder<C, B> this);
       public @java.lang.Override @org.checkerframework.dataflow.qual.SideEffectFree @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((((("CheckerFrameworkSuperBuilder.ZChild.ZChildBuilder(super=" + super.toString()) + ", a$value=") + this.a$value) + ", b=") + this.b) + ")");
       }

--- a/test/transform/resource/after-ecj/ConstructorsWithSuperBuilderDefaults.java
+++ b/test/transform/resource/after-ecj/ConstructorsWithSuperBuilderDefaults.java
@@ -10,8 +10,6 @@ import lombok.Builder;
     public ConstructorsWithSuperBuilderDefaultsBuilder() {
       super();
     }
-    protected abstract @java.lang.SuppressWarnings("all") B self();
-    public abstract @java.lang.SuppressWarnings("all") C build();
     /**
      * @return {@code this}.
      */
@@ -27,6 +25,8 @@ import lombok.Builder;
       this.y = y;
       return self();
     }
+    protected abstract @java.lang.SuppressWarnings("all") B self();
+    public abstract @java.lang.SuppressWarnings("all") C build();
     public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
       return (((("ConstructorsWithSuperBuilderDefaults.ConstructorsWithSuperBuilderDefaultsBuilder(x$value=" + this.x$value) + ", y=") + this.y) + ")");
     }

--- a/test/transform/resource/after-ecj/JacksonizedSuperBuilderSimple.java
+++ b/test/transform/resource/after-ecj/JacksonizedSuperBuilderSimple.java
@@ -5,8 +5,6 @@ public class JacksonizedSuperBuilderSimple {
       public ParentBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -14,6 +12,8 @@ public class JacksonizedSuperBuilderSimple {
         this.field1 = field1;
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (("JacksonizedSuperBuilderSimple.Parent.ParentBuilder(field1=" + this.field1) + ")");
       }

--- a/test/transform/resource/after-ecj/JacksonizedSuperBuilderWithJsonDeserialize.java
+++ b/test/transform/resource/after-ecj/JacksonizedSuperBuilderWithJsonDeserialize.java
@@ -4,8 +4,6 @@ public @lombok.extern.jackson.Jacksonized @lombok.experimental.SuperBuilder @com
     public JacksonizedSuperBuilderWithJsonDeserializeBuilder() {
       super();
     }
-    protected abstract @java.lang.SuppressWarnings("all") B self();
-    public abstract @java.lang.SuppressWarnings("all") C build();
     /**
      * @return {@code this}.
      */
@@ -13,6 +11,8 @@ public @lombok.extern.jackson.Jacksonized @lombok.experimental.SuperBuilder @com
       this.field1 = field1;
       return self();
     }
+    protected abstract @java.lang.SuppressWarnings("all") B self();
+    public abstract @java.lang.SuppressWarnings("all") C build();
     public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
       return (("JacksonizedSuperBuilderWithJsonDeserialize.JacksonizedSuperBuilderWithJsonDeserializeBuilder(field1=" + this.field1) + ")");
     }

--- a/test/transform/resource/after-ecj/NullAnnotatedCheckerFrameworkSuperBuilder.java
+++ b/test/transform/resource/after-ecj/NullAnnotatedCheckerFrameworkSuperBuilder.java
@@ -11,8 +11,6 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
       public ParentBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -56,6 +54,8 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
             this.names.clear();
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.@org.checkerframework.checker.nullness.qual.NonNull String toString() {
         return (((((((("NullAnnotatedCheckerFrameworkSuperBuilder.Parent.ParentBuilder(x$value=" + this.x$value) + ", y=") + this.y) + ", z=") + this.z) + ", names=") + this.names) + ")");
       }
@@ -111,8 +111,6 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
       public ZChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -128,6 +126,8 @@ class NullAnnotatedCheckerFrameworkSuperBuilder {
         this.b = b;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.@org.checkerframework.checker.nullness.qual.NonNull String toString() {
         return (((((("NullAnnotatedCheckerFrameworkSuperBuilder.ZChild.ZChildBuilder(super=" + super.toString()) + ", a$value=") + this.a$value) + ", b=") + this.b) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderAbstract.java
+++ b/test/transform/resource/after-ecj/SuperBuilderAbstract.java
@@ -5,8 +5,6 @@ public class SuperBuilderAbstract {
       public ParentBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -14,6 +12,8 @@ public class SuperBuilderAbstract {
         this.parentField = parentField;
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (("SuperBuilderAbstract.Parent.ParentBuilder(parentField=" + this.parentField) + ")");
       }
@@ -44,8 +44,6 @@ public class SuperBuilderAbstract {
       public ChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -53,6 +51,8 @@ public class SuperBuilderAbstract {
         this.childField = childField;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderAbstract.Child.ChildBuilder(super=" + super.toString()) + ", childField=") + this.childField) + ")");
       }
@@ -69,8 +69,6 @@ public class SuperBuilderAbstract {
       public GrandChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -78,6 +76,8 @@ public class SuperBuilderAbstract {
         this.grandChildField = grandChildField;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderAbstract.GrandChild.GrandChildBuilder(super=" + super.toString()) + ", grandChildField=") + this.grandChildField) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderAbstractToBuilder.java
+++ b/test/transform/resource/after-ecj/SuperBuilderAbstractToBuilder.java
@@ -12,8 +12,6 @@ public class SuperBuilderAbstractToBuilder {
       private static @java.lang.SuppressWarnings("all") void $fillValuesFromInstanceIntoBuilder(final SuperBuilderAbstractToBuilder.Parent instance, final SuperBuilderAbstractToBuilder.Parent.ParentBuilder<?, ?> b) {
         b.parentField(instance.parentField);
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -21,6 +19,8 @@ public class SuperBuilderAbstractToBuilder {
         this.parentField = parentField;
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (("SuperBuilderAbstractToBuilder.Parent.ParentBuilder(parentField=" + this.parentField) + ")");
       }
@@ -62,8 +62,6 @@ public class SuperBuilderAbstractToBuilder {
       private static @java.lang.SuppressWarnings("all") void $fillValuesFromInstanceIntoBuilder(final SuperBuilderAbstractToBuilder.Child instance, final SuperBuilderAbstractToBuilder.Child.ChildBuilder<?, ?> b) {
         b.childField(instance.childField);
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -71,6 +69,8 @@ public class SuperBuilderAbstractToBuilder {
         this.childField = childField;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderAbstractToBuilder.Child.ChildBuilder(super=" + super.toString()) + ", childField=") + this.childField) + ")");
       }
@@ -95,8 +95,6 @@ public class SuperBuilderAbstractToBuilder {
       private static @java.lang.SuppressWarnings("all") void $fillValuesFromInstanceIntoBuilder(final SuperBuilderAbstractToBuilder.GrandChild instance, final SuperBuilderAbstractToBuilder.GrandChild.GrandChildBuilder<?, ?> b) {
         b.grandChildField(instance.grandChildField);
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -104,6 +102,8 @@ public class SuperBuilderAbstractToBuilder {
         this.grandChildField = grandChildField;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderAbstractToBuilder.GrandChild.GrandChildBuilder(super=" + super.toString()) + ", grandChildField=") + this.grandChildField) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderBasic.java
+++ b/test/transform/resource/after-ecj/SuperBuilderBasic.java
@@ -7,8 +7,6 @@ public class SuperBuilderBasic {
       public ParentBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -37,6 +35,8 @@ public class SuperBuilderBasic {
             this.items.clear();
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderBasic.Parent.ParentBuilder(field1=" + this.field1) + ", items=") + this.items) + ")");
       }
@@ -80,8 +80,6 @@ public class SuperBuilderBasic {
       public ChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -89,6 +87,8 @@ public class SuperBuilderBasic {
         this.field3 = field3;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderBasic.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderBasicToBuilder.java
+++ b/test/transform/resource/after-ecj/SuperBuilderBasicToBuilder.java
@@ -21,8 +21,6 @@ public class SuperBuilderBasicToBuilder {
         b.obtainViaStaticMethod(SuperBuilderBasicToBuilder.Parent.staticMethod(instance));
         b.items(((instance.items == null) ? java.util.Collections.<String>emptyList() : instance.items));
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -72,6 +70,8 @@ public class SuperBuilderBasicToBuilder {
             this.items.clear();
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((((((((("SuperBuilderBasicToBuilder.Parent.ParentBuilder(field1=" + this.field1) + ", obtainViaField=") + this.obtainViaField) + ", obtainViaMethod=") + this.obtainViaMethod) + ", obtainViaStaticMethod=") + this.obtainViaStaticMethod) + ", items=") + this.items) + ")");
       }
@@ -138,8 +138,6 @@ public class SuperBuilderBasicToBuilder {
       private static @java.lang.SuppressWarnings("all") void $fillValuesFromInstanceIntoBuilder(final SuperBuilderBasicToBuilder.Child instance, final SuperBuilderBasicToBuilder.Child.ChildBuilder<?, ?> b) {
         b.field3(instance.field3);
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -147,6 +145,8 @@ public class SuperBuilderBasicToBuilder {
         this.field3 = field3;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderBasicToBuilder.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderCustomized.java
+++ b/test/transform/resource/after-ecj/SuperBuilderCustomized.java
@@ -60,8 +60,6 @@ public class SuperBuilderCustomized {
       public ChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -69,6 +67,8 @@ public class SuperBuilderCustomized {
         this.field2 = field2;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderCustomized.Child.ChildBuilder(super=" + super.toString()) + ", field2=") + this.field2) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderInitializer.java
+++ b/test/transform/resource/after-ecj/SuperBuilderInitializer.java
@@ -6,8 +6,6 @@ class SuperBuilderInitializer {
       public OneBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -15,6 +13,8 @@ class SuperBuilderInitializer {
         this.world = world;
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (("SuperBuilderInitializer.One.OneBuilder(world=" + this.world) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderNameClashes.java
+++ b/test/transform/resource/after-ecj/SuperBuilderNameClashes.java
@@ -68,8 +68,6 @@ public class SuperBuilderNameClashes {
       public CBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C3 build();
       /**
        * @return {@code this}.
        */
@@ -77,6 +75,8 @@ public class SuperBuilderNameClashes {
         this.c2 = c2;
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C3 build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (("SuperBuilderNameClashes.C.CBuilder(c2=" + this.c2) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderSingularAnnotatedTypes.java
+++ b/test/transform/resource/after-ecj/SuperBuilderSingularAnnotatedTypes.java
@@ -14,8 +14,6 @@ import lombok.Singular;
     public SuperBuilderSingularAnnotatedTypesBuilder() {
       super();
     }
-    protected abstract @java.lang.SuppressWarnings("all") B self();
-    public abstract @java.lang.SuppressWarnings("all") C build();
     public @java.lang.SuppressWarnings("all") B foo(final @MyAnnotation @NonNull String foo) {
       if ((foo == null))
           {
@@ -84,6 +82,8 @@ import lombok.Singular;
           }
       return self();
     }
+    protected abstract @java.lang.SuppressWarnings("all") B self();
+    public abstract @java.lang.SuppressWarnings("all") C build();
     public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
       return (((((("SuperBuilderSingularAnnotatedTypes.SuperBuilderSingularAnnotatedTypesBuilder(foos=" + this.foos) + ", bars$key=") + this.bars$key) + ", bars$value=") + this.bars$value) + ")");
     }

--- a/test/transform/resource/after-ecj/SuperBuilderSingularCustomized.java
+++ b/test/transform/resource/after-ecj/SuperBuilderSingularCustomized.java
@@ -8,8 +8,6 @@ import java.util.Set;
     public B custom(final String value) {
       return self();
     }
-    protected abstract @java.lang.SuppressWarnings("all") B self();
-    public abstract @java.lang.SuppressWarnings("all") C build();
     public @java.lang.SuppressWarnings("all") B foo(final String foo) {
       if ((this.foos == null))
           this.foos = new java.util.ArrayList<String>();
@@ -31,6 +29,8 @@ import java.util.Set;
           this.foos.clear();
       return self();
     }
+    protected abstract @java.lang.SuppressWarnings("all") B self();
+    public abstract @java.lang.SuppressWarnings("all") C build();
     public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
       return (("SuperBuilderSingularCustomized.SuperBuilderSingularCustomizedBuilder(foos=" + this.foos) + ")");
     }

--- a/test/transform/resource/after-ecj/SuperBuilderSingularToBuilderGuava.java
+++ b/test/transform/resource/after-ecj/SuperBuilderSingularToBuilderGuava.java
@@ -20,8 +20,6 @@ public class SuperBuilderSingularToBuilderGuava {
         b.passes(((instance.passes == null) ? com.google.common.collect.ImmutableSortedSet.<String>of() : instance.passes));
         b.users(((instance.users == null) ? com.google.common.collect.ImmutableTable.<Number, Number, String>of() : instance.users));
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.SuppressWarnings("all") B card(final T card) {
         if ((this.cards == null))
             this.cards = com.google.common.collect.ImmutableList.builder();
@@ -122,6 +120,8 @@ public class SuperBuilderSingularToBuilderGuava {
         this.users = null;
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((((((((("SuperBuilderSingularToBuilderGuava.Parent.ParentBuilder(cards=" + this.cards) + ", frogs=") + this.frogs) + ", rawSet=") + this.rawSet) + ", passes=") + this.passes) + ", users=") + this.users) + ")");
       }
@@ -176,8 +176,6 @@ public class SuperBuilderSingularToBuilderGuava {
       private static @java.lang.SuppressWarnings("all") <T>void $fillValuesFromInstanceIntoBuilder(final SuperBuilderSingularToBuilderGuava.Child<T> instance, final SuperBuilderSingularToBuilderGuava.Child.ChildBuilder<T, ?, ?> b) {
         b.field3(instance.field3);
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -185,6 +183,8 @@ public class SuperBuilderSingularToBuilderGuava {
         this.field3 = field3;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderSingularToBuilderGuava.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderWithCustomBuilderMethod.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithCustomBuilderMethod.java
@@ -7,8 +7,6 @@ public class SuperBuilderWithCustomBuilderMethod {
       public ParentBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -37,6 +35,8 @@ public class SuperBuilderWithCustomBuilderMethod {
             this.items.clear();
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithCustomBuilderMethod.Parent.ParentBuilder(field1=" + this.field1) + ", items=") + this.items) + ")");
       }
@@ -80,8 +80,6 @@ public class SuperBuilderWithCustomBuilderMethod {
       public ChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -89,6 +87,8 @@ public class SuperBuilderWithCustomBuilderMethod {
         this.field3 = field3;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithCustomBuilderMethod.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderWithDefaults.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithDefaults.java
@@ -9,8 +9,6 @@ public class SuperBuilderWithDefaults {
       public ParentBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -27,6 +25,8 @@ public class SuperBuilderWithDefaults {
         numberField$set = true;
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithDefaults.Parent.ParentBuilder(millis$value=" + this.millis$value) + ", numberField$value=") + this.numberField$value) + ")");
       }
@@ -72,8 +72,6 @@ public class SuperBuilderWithDefaults {
       public ChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -82,6 +80,8 @@ public class SuperBuilderWithDefaults {
         doubleField$set = true;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithDefaults.Child.ChildBuilder(super=" + super.toString()) + ", doubleField$value=") + this.doubleField$value) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderWithDefaultsAndTargetTyping.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithDefaultsAndTargetTyping.java
@@ -8,8 +8,6 @@ public class SuperBuilderWithDefaultsAndTargetTyping {
       public ParentBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -18,6 +16,8 @@ public class SuperBuilderWithDefaultsAndTargetTyping {
         foo$set = true;
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (("SuperBuilderWithDefaultsAndTargetTyping.Parent.ParentBuilder(foo$value=" + this.foo$value) + ")");
       }
@@ -55,8 +55,6 @@ public class SuperBuilderWithDefaultsAndTargetTyping {
       public ChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -65,6 +63,8 @@ public class SuperBuilderWithDefaultsAndTargetTyping {
         foo$set = true;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithDefaultsAndTargetTyping.Child.ChildBuilder(super=" + super.toString()) + ", foo$value=") + this.foo$value) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenerics.java
@@ -7,8 +7,6 @@ public class SuperBuilderWithGenerics {
       public ParentBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -37,6 +35,8 @@ public class SuperBuilderWithGenerics {
             this.items.clear();
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithGenerics.Parent.ParentBuilder(field1=" + this.field1) + ", items=") + this.items) + ")");
       }
@@ -80,8 +80,6 @@ public class SuperBuilderWithGenerics {
       public ChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -89,6 +87,8 @@ public class SuperBuilderWithGenerics {
         this.field3 = field3;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithGenerics.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenerics2.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenerics2.java
@@ -7,8 +7,6 @@ public class SuperBuilderWithGenerics2 {
       public ParentBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -37,6 +35,8 @@ public class SuperBuilderWithGenerics2 {
             this.items.clear();
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithGenerics2.Parent.ParentBuilder(field1=" + this.field1) + ", items=") + this.items) + ")");
       }
@@ -80,8 +80,6 @@ public class SuperBuilderWithGenerics2 {
       public ChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -89,6 +87,8 @@ public class SuperBuilderWithGenerics2 {
         this.field3 = field3;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithGenerics2.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenerics3.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenerics3.java
@@ -6,8 +6,6 @@ public class SuperBuilderWithGenerics3 {
       public ParentBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -15,6 +13,8 @@ public class SuperBuilderWithGenerics3 {
         this.str = str;
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (("SuperBuilderWithGenerics3.Parent.ParentBuilder(str=" + this.str) + ")");
       }
@@ -50,8 +50,6 @@ public class SuperBuilderWithGenerics3 {
       public ChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -59,6 +57,8 @@ public class SuperBuilderWithGenerics3 {
         this.field3 = field3;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithGenerics3.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderWithGenericsAndToBuilder.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithGenericsAndToBuilder.java
@@ -16,8 +16,6 @@ public class SuperBuilderWithGenericsAndToBuilder {
         b.field1(instance.field1);
         b.items(((instance.items == null) ? java.util.Collections.<Integer, String>emptyMap() : instance.items));
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -60,6 +58,8 @@ public class SuperBuilderWithGenericsAndToBuilder {
             }
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((((("SuperBuilderWithGenericsAndToBuilder.Parent.ParentBuilder(field1=" + this.field1) + ", items$key=") + this.items$key) + ", items$value=") + this.items$value) + ")");
       }
@@ -117,8 +117,6 @@ public class SuperBuilderWithGenericsAndToBuilder {
       private static @java.lang.SuppressWarnings("all") <A>void $fillValuesFromInstanceIntoBuilder(final SuperBuilderWithGenericsAndToBuilder.Child<A> instance, final SuperBuilderWithGenericsAndToBuilder.Child.ChildBuilder<A, ?, ?> b) {
         b.field3(instance.field3);
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -126,6 +124,8 @@ public class SuperBuilderWithGenericsAndToBuilder {
         this.field3 = field3;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithGenericsAndToBuilder.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderWithNonNull.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithNonNull.java
@@ -7,8 +7,6 @@ public class SuperBuilderWithNonNull {
       public ParentBuilder() {
         super();
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -21,6 +19,8 @@ public class SuperBuilderWithNonNull {
         nonNullParentField$set = true;
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (("SuperBuilderWithNonNull.Parent.ParentBuilder(nonNullParentField$value=" + this.nonNullParentField$value) + ")");
       }
@@ -61,8 +61,6 @@ public class SuperBuilderWithNonNull {
       public ChildBuilder() {
         super();
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -74,6 +72,8 @@ public class SuperBuilderWithNonNull {
         this.nonNullChildField = nonNullChildField;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithNonNull.Child.ChildBuilder(super=" + super.toString()) + ", nonNullChildField=") + this.nonNullChildField) + ")");
       }

--- a/test/transform/resource/after-ecj/SuperBuilderWithOverloadedGeneratedMethods.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithOverloadedGeneratedMethods.java
@@ -1,0 +1,86 @@
+public class SuperBuilderWithOverloadedGeneratedMethods {
+  public static @lombok.experimental.SuperBuilder class Parent {
+    public static abstract @java.lang.SuppressWarnings("all") class ParentBuilder<C extends SuperBuilderWithOverloadedGeneratedMethods.Parent, B extends SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilder<C, B>> {
+      private @java.lang.SuppressWarnings("all") int self;
+      public ParentBuilder() {
+        super();
+      }
+      /**
+       * @return {@code this}.
+       */
+      public @java.lang.SuppressWarnings("all") B self(final int self) {
+        this.self = self;
+        return self();
+      }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (("SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilder(self=" + this.self) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ParentBuilderImpl extends SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilder<SuperBuilderWithOverloadedGeneratedMethods.Parent, SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilderImpl> {
+      private ParentBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderWithOverloadedGeneratedMethods.Parent build() {
+        return new SuperBuilderWithOverloadedGeneratedMethods.Parent(this);
+      }
+    }
+    int self;
+    protected @java.lang.SuppressWarnings("all") Parent(final SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilder<?, ?> b) {
+      super();
+      this.self = b.self;
+    }
+    public static @java.lang.SuppressWarnings("all") SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilder<?, ?> builder() {
+      return new SuperBuilderWithOverloadedGeneratedMethods.Parent.ParentBuilderImpl();
+    }
+  }
+  public static @lombok.experimental.SuperBuilder class Child extends Parent {
+    public static abstract @java.lang.SuppressWarnings("all") class ChildBuilder<C extends SuperBuilderWithOverloadedGeneratedMethods.Child, B extends SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilder<C, B>> extends Parent.ParentBuilder<C, B> {
+      private @java.lang.SuppressWarnings("all") double build;
+      public ChildBuilder() {
+        super();
+      }
+      /**
+       * @return {@code this}.
+       */
+      public @java.lang.SuppressWarnings("all") B build(final double build) {
+        this.build = build;
+        return self();
+      }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+        return (((("SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilder(super=" + super.toString()) + ", build=") + this.build) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") class ChildBuilderImpl extends SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilder<SuperBuilderWithOverloadedGeneratedMethods.Child, SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilderImpl> {
+      private ChildBuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") SuperBuilderWithOverloadedGeneratedMethods.Child build() {
+        return new SuperBuilderWithOverloadedGeneratedMethods.Child(this);
+      }
+    }
+    double build;
+    protected @java.lang.SuppressWarnings("all") Child(final SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilder<?, ?> b) {
+      super(b);
+      this.build = b.build;
+    }
+    public static @java.lang.SuppressWarnings("all") SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilder<?, ?> builder() {
+      return new SuperBuilderWithOverloadedGeneratedMethods.Child.ChildBuilderImpl();
+    }
+  }
+  public SuperBuilderWithOverloadedGeneratedMethods() {
+    super();
+  }
+  public static void test() {
+    Child x = Child.builder().build(0.0).self(5).build();
+  }
+}

--- a/test/transform/resource/after-ecj/SuperBuilderWithPrefixes.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithPrefixes.java
@@ -6,8 +6,6 @@
     public SuperBuilderWithPrefixesBuilder() {
       super();
     }
-    protected abstract @java.lang.SuppressWarnings("all") B self();
-    public abstract @java.lang.SuppressWarnings("all") C build();
     /**
      * @return {@code this}.
      */
@@ -43,6 +41,8 @@
           this.items.clear();
       return self();
     }
+    protected abstract @java.lang.SuppressWarnings("all") B self();
+    public abstract @java.lang.SuppressWarnings("all") C build();
     public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
       return (((((("SuperBuilderWithPrefixes.SuperBuilderWithPrefixesBuilder(field=" + this.field) + ", otherField=") + this.otherField) + ", items=") + this.items) + ")");
     }

--- a/test/transform/resource/after-ecj/SuperBuilderWithSetterPrefix.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithSetterPrefix.java
@@ -21,8 +21,6 @@ public class SuperBuilderWithSetterPrefix {
         b.withObtainViaStaticMethod(SuperBuilderWithSetterPrefix.Parent.staticMethod(instance));
         b.withItems(((instance.items == null) ? java.util.Collections.<String>emptyList() : instance.items));
       }
-      protected abstract @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -72,6 +70,8 @@ public class SuperBuilderWithSetterPrefix {
             this.items.clear();
         return self();
       }
+      protected abstract @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((((((((("SuperBuilderWithSetterPrefix.Parent.ParentBuilder(field1=" + this.field1) + ", obtainViaField=") + this.obtainViaField) + ", obtainViaMethod=") + this.obtainViaMethod) + ", obtainViaStaticMethod=") + this.obtainViaStaticMethod) + ", items=") + this.items) + ")");
       }
@@ -138,8 +138,6 @@ public class SuperBuilderWithSetterPrefix {
       private static @java.lang.SuppressWarnings("all") void $fillValuesFromInstanceIntoBuilder(final SuperBuilderWithSetterPrefix.Child instance, final SuperBuilderWithSetterPrefix.Child.ChildBuilder<?, ?> b) {
         b.setField3(instance.field3);
       }
-      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
-      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       /**
        * @return {@code this}.
        */
@@ -147,6 +145,8 @@ public class SuperBuilderWithSetterPrefix {
         this.field3 = field3;
         return self();
       }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") C build();
       public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
         return (((("SuperBuilderWithSetterPrefix.Child.ChildBuilder(super=" + super.toString()) + ", field3=") + this.field3) + ")");
       }

--- a/test/transform/resource/before/SuperBuilderWithOverloadedGeneratedMethods.java
+++ b/test/transform/resource/before/SuperBuilderWithOverloadedGeneratedMethods.java
@@ -1,0 +1,15 @@
+public class SuperBuilderWithOverloadedGeneratedMethods {
+	@lombok.experimental.SuperBuilder
+	public static class Parent {
+		int self;
+	}
+	
+	@lombok.experimental.SuperBuilder
+	public static class Child extends Parent {
+		double build;
+	}
+	
+	public static void test() {
+		Child x = Child.builder().build(0.0).self(5).build();
+	}
+}


### PR DESCRIPTION
This PR changes the order of the generated methods in the abstract builder class for `@SuperBuilder`.
The methods `abstract B self()` and `abstract C build()` are now generated after all setter methods. Generating them later avoids triggering the existing-methods check on setters with fields named "build" or "self".

This fixes #3230.
 