### PR TITLE
Update VS Code page for Lombok support

### DIFF
--- a/website/templates/setup/vscode.html
+++ b/website/templates/setup/vscode.html
@@ -5,11 +5,11 @@
 		<p>
 			The <a href="https://code.visualstudio.com/">Microsoft Visual Studio Code</a> editor is compatible with lombok.
 		</p><p>
-			Add the <a href="https://marketplace.visualstudio.com/items?itemName=GabrielBB.vscode-lombok">vscode-lombok</a> plugin to your Visual Studio Code IDE to add lombok support.
+			The <a href="https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack">Extension Pack for Java</a> provides built-in support for Lombok.
 			<ul><li>
 				press <code>Ctrl + Shift + X</code> to open the extension manager.
 			</li><li>
-				Type <code>lombok</code> to find the plugin, and click <code>install</code>.
+				Type <code>java</code> to find the plugin, and click <code>install</code>.
 			</li><li>
 				Reload VS Code when asked.
 			</li></ul>


### PR DESCRIPTION
Per (https://devblogs.microsoft.com/java/java-on-visual-studio-code-update-july-2022/), the latest Extension for Pack has provided built-in support for Lombok.

In addition, the community-developed Lombok extension has entered a maintenance mode, the original author has moved on from the project. Microsoft is going to maintain the project from now on (The extension has been transferred to Microsoft)

Thanks1