### PR TITLE
fixes #3259: allow @ExtensionMethod on interfaces

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleExtensionMethod.java
+++ b/src/core/lombok/eclipse/handlers/HandleExtensionMethod.java
@@ -50,10 +50,10 @@ public class HandleExtensionMethod extends EclipseAnnotationHandler<ExtensionMet
 		int modifiers = typeDecl == null ? 0 : typeDecl.modifiers;
 		
 		boolean notAClass = (modifiers &
-				(ClassFileConstants.AccInterface | ClassFileConstants.AccAnnotation)) != 0;
+				(ClassFileConstants.AccAnnotation)) != 0;
 		
 		if (typeDecl == null || notAClass) {
-			annotationNode.addError("@ExtensionMethod is legal only on classes and enums.");
+			annotationNode.addError("@ExtensionMethod is legal only on classes and enums and interfaces.");
 			return;
 		}
 		

--- a/src/core/lombok/javac/handlers/HandleExtensionMethod.java
+++ b/src/core/lombok/javac/handlers/HandleExtensionMethod.java
@@ -73,10 +73,10 @@ public class HandleExtensionMethod extends JavacAnnotationHandler<ExtensionMetho
 		
 		deleteAnnotationIfNeccessary(annotationNode, ExtensionMethod.class);
 		JavacNode typeNode = annotationNode.up();
-		boolean isClassOrEnum = isClassOrEnum(typeNode);
+		boolean isClassOrEnumOrInterface = isClassOrEnumOrInterface(typeNode);
 		
-		if (!isClassOrEnum) {
-			annotationNode.addError("@ExtensionMethod can only be used on a class or an enum");
+		if (!isClassOrEnumOrInterface) {
+			annotationNode.addError("@ExtensionMethod can only be used on a class or an enum or an interface");
 			return;
 		}
 		

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -2069,6 +2069,10 @@ public class JavacHandlerUtil {
 		return isClassAndDoesNotHaveFlags(typeNode, Flags.INTERFACE | Flags.ANNOTATION | RECORD);
 	}
 	
+	public static boolean isClassOrEnumOrInterface(JavacNode typeNode) {
+		return isClassAndDoesNotHaveFlags(typeNode, Flags.ANNOTATION | RECORD);
+	}
+	
 	/**
 	 * Returns {@code true} if the provided node is an actual class, an enum or a record and not some other type declaration (so, not an annotation definition or interface).
 	 */


### PR DESCRIPTION
Simple change to allow `@ExtensionMethod` on interfaces, done for javac and Eclipse handlers. Using this without any problems for almost two months now. (fixes #3259)