### PR TITLE
Use real type for enclosing class

### DIFF
--- a/src/core/lombok/javac/JavacResolution.java
+++ b/src/core/lombok/javac/JavacResolution.java
@@ -244,8 +244,15 @@ public class JavacResolution {
 	}
 	
 	private void attrib(JCTree tree, Env<AttrContext> env) {
-		if (env.enclClass.type == null) try {
-			env.enclClass.type = Type.noType;
+		try {
+			if (env.enclClass.type == null) {
+				if (env.enclClass.sym != null) {
+					env.enclClass.type = env.enclClass.sym.type;
+				}
+			}
+			if (env.enclClass.type == null) {
+				env.enclClass.type = Type.noType;
+			}
 		} catch (Throwable ignore) {
 			// This addresses issue #1553 which involves JDK9; if it doesn't exist, we probably don't need to set it.
 		}

--- a/test/transform/resource/after-delombok/ValSuperDefaultMethod.java
+++ b/test/transform/resource/after-delombok/ValSuperDefaultMethod.java
@@ -1,0 +1,12 @@
+// version :9
+class ValSuperDefaultMethod implements Default {
+	public void test() {
+		final java.lang.String a = "";
+		Default.super.method();
+	}
+}
+
+interface Default {
+	default void method() {
+	}
+}

--- a/test/transform/resource/after-ecj/ValSuperDefaultMethod.java
+++ b/test/transform/resource/after-ecj/ValSuperDefaultMethod.java
@@ -1,0 +1,14 @@
+import lombok.val;
+class ValSuperDefaultMethod implements Default {
+  ValSuperDefaultMethod() {
+    super();
+  }
+  public void test() {
+    final @val java.lang.String a = "";
+    Default.super.method();
+  }
+}
+interface Default {
+  default void method() {
+  }
+}

--- a/test/transform/resource/before/ValSuperDefaultMethod.java
+++ b/test/transform/resource/before/ValSuperDefaultMethod.java
@@ -1,0 +1,16 @@
+// version :9
+import lombok.val;
+
+class ValSuperDefaultMethod implements Default {
+	public void test() {
+		val a = "";
+		Default.super.method();
+	}
+	
+}
+
+interface Default {
+	default void method() {
+		
+	}
+}


### PR DESCRIPTION
This PR fixes #3242

Using `Type.noType` works as long as we do not need the parent class/interface. Lombok now uses the symbol type if it is available.