### PR TITLE
Convert short array initializers to long version

### DIFF
--- a/test/transform/resource/after-delombok/BuilderDefaultsArray.java
+++ b/test/transform/resource/after-delombok/BuilderDefaultsArray.java
@@ -1,0 +1,79 @@
+import lombok.Value;
+
+public class BuilderDefaultsArray {
+	int[] x;
+	java.lang.String[][] y;
+
+	@java.lang.SuppressWarnings("all")
+	private static int[] $default$x() {
+		return new int[] {1, 2};
+	}
+
+	@java.lang.SuppressWarnings("all")
+	private static java.lang.String[][] $default$y() {
+		return new java.lang.String[][] {};
+	}
+
+	@java.lang.SuppressWarnings("all")
+	BuilderDefaultsArray(final int[] x, final java.lang.String[][] y) {
+		this.x = x;
+		this.y = y;
+	}
+
+
+	@java.lang.SuppressWarnings("all")
+	public static class BuilderDefaultsArrayBuilder {
+		@java.lang.SuppressWarnings("all")
+		private boolean x$set;
+		@java.lang.SuppressWarnings("all")
+		private int[] x$value;
+		@java.lang.SuppressWarnings("all")
+		private boolean y$set;
+		@java.lang.SuppressWarnings("all")
+		private java.lang.String[][] y$value;
+
+		@java.lang.SuppressWarnings("all")
+		BuilderDefaultsArrayBuilder() {
+		}
+
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public BuilderDefaultsArray.BuilderDefaultsArrayBuilder x(final int[] x) {
+			this.x$value = x;
+			x$set = true;
+			return this;
+		}
+
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public BuilderDefaultsArray.BuilderDefaultsArrayBuilder y(final java.lang.String[][] y) {
+			this.y$value = y;
+			y$set = true;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public BuilderDefaultsArray build() {
+			int[] x$value = this.x$value;
+			if (!this.x$set) x$value = BuilderDefaultsArray.$default$x();
+			java.lang.String[][] y$value = this.y$value;
+			if (!this.y$set) y$value = BuilderDefaultsArray.$default$y();
+			return new BuilderDefaultsArray(x$value, y$value);
+		}
+
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "BuilderDefaultsArray.BuilderDefaultsArrayBuilder(x$value=" + java.util.Arrays.toString(this.x$value) + ", y$value=" + java.util.Arrays.deepToString(this.y$value) + ")";
+		}
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public static BuilderDefaultsArray.BuilderDefaultsArrayBuilder builder() {
+		return new BuilderDefaultsArray.BuilderDefaultsArrayBuilder();
+	}
+}

--- a/test/transform/resource/after-ecj/BuilderDefaultsArray.java
+++ b/test/transform/resource/after-ecj/BuilderDefaultsArray.java
@@ -1,0 +1,57 @@
+import lombok.Builder;
+import lombok.Value;
+public @Builder class BuilderDefaultsArray {
+  public static @java.lang.SuppressWarnings("all") class BuilderDefaultsArrayBuilder {
+    private @java.lang.SuppressWarnings("all") int[] x$value;
+    private @java.lang.SuppressWarnings("all") boolean x$set;
+    private @java.lang.SuppressWarnings("all") java.lang.String[][] y$value;
+    private @java.lang.SuppressWarnings("all") boolean y$set;
+    @java.lang.SuppressWarnings("all") BuilderDefaultsArrayBuilder() {
+      super();
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") BuilderDefaultsArray.BuilderDefaultsArrayBuilder x(final int[] x) {
+      this.x$value = x;
+      x$set = true;
+      return this;
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") BuilderDefaultsArray.BuilderDefaultsArrayBuilder y(final java.lang.String[][] y) {
+      this.y$value = y;
+      y$set = true;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderDefaultsArray build() {
+      int[] x$value = this.x$value;
+      if ((! this.x$set))
+          x$value = BuilderDefaultsArray.$default$x();
+      java.lang.String[][] y$value = this.y$value;
+      if ((! this.y$set))
+          y$value = BuilderDefaultsArray.$default$y();
+      return new BuilderDefaultsArray(x$value, y$value);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (((("BuilderDefaultsArray.BuilderDefaultsArrayBuilder(x$value=" + java.util.Arrays.toString(this.x$value)) + ", y$value=") + java.util.Arrays.deepToString(this.y$value)) + ")");
+    }
+  }
+  @Builder.Default int[] x;
+  @Builder.Default java.lang.String[][] y;
+  private static @java.lang.SuppressWarnings("all") int[] $default$x() {
+    return new int[]{1, 2};
+  }
+  private static @java.lang.SuppressWarnings("all") java.lang.String[][] $default$y() {
+    return new java.lang.String[][]{};
+  }
+  @java.lang.SuppressWarnings("all") BuilderDefaultsArray(final int[] x, final java.lang.String[][] y) {
+    super();
+    this.x = x;
+    this.y = y;
+  }
+  public static @java.lang.SuppressWarnings("all") BuilderDefaultsArray.BuilderDefaultsArrayBuilder builder() {
+    return new BuilderDefaultsArray.BuilderDefaultsArrayBuilder();
+  }
+}

--- a/test/transform/resource/before/BuilderDefaultsArray.java
+++ b/test/transform/resource/before/BuilderDefaultsArray.java
@@ -1,0 +1,11 @@
+import lombok.Builder;
+import lombok.Value;
+
+@Builder
+public class BuilderDefaultsArray {
+	@Builder.Default
+	int[] x = {1,2};
+	
+	@Builder.Default
+	java.lang.String[][] y = {};
+}


### PR DESCRIPTION
This PR fixes #3306

It also includes changes for `javac`. Even if it worked there I think that the generated code should be valid.