### PR TITLE
Reset erasure_field of symbol

### DIFF
--- a/src/core/lombok/javac/handlers/HandleUtilityClass.java
+++ b/src/core/lombok/javac/handlers/HandleUtilityClass.java
@@ -128,8 +128,11 @@ public class HandleUtilityClass extends JavacAnnotationHandler<UtilityClass> {
 				JCClassDecl innerClassDecl = (JCClassDecl) element.get();
 				innerClassDecl.mods.flags |= Flags.STATIC;
 				ClassSymbol innerClassSymbol = innerClassDecl.sym;
-				if (innerClassSymbol != null && innerClassSymbol.type instanceof ClassType) {
-					((ClassType) innerClassSymbol.type).setEnclosingType(Type.noType);
+				if (innerClassSymbol != null) {
+					if (innerClassSymbol.type instanceof ClassType) {
+						((ClassType) innerClassSymbol.type).setEnclosingType(Type.noType);
+					}
+					innerClassSymbol.erasure_field = null;
 				}
 			}
 		}

--- a/src/stubs/com/sun/tools/javac/code/Symbol.java
+++ b/src/stubs/com/sun/tools/javac/code/Symbol.java
@@ -25,6 +25,7 @@ public abstract class Symbol implements Element {
 	public Type type;
 	public Name name;
 	public Symbol owner;
+	public Type erasure_field;
 
 	public long flags() { return 0; }
 	public boolean isStatic() { return false; }

--- a/test/transform/resource/after-delombok/UtilityClassGeneric.java
+++ b/test/transform/resource/after-delombok/UtilityClassGeneric.java
@@ -1,0 +1,21 @@
+final class UtilityClassGeneric {
+	static <T> T convertValue(Class<T> toValueType) {
+		return null;
+	}
+
+	static DTO convert(Object json) {
+		return convertValue(DTO.class);
+	}
+
+	static Object convert(DTO dto) {
+		return null;
+	}
+
+	static class DTO {
+	}
+
+	@java.lang.SuppressWarnings("all")
+	private UtilityClassGeneric() {
+		throw new java.lang.UnsupportedOperationException("This is a utility class and cannot be instantiated");
+	}
+}

--- a/test/transform/resource/after-ecj/UtilityClassGeneric.java
+++ b/test/transform/resource/after-ecj/UtilityClassGeneric.java
@@ -1,0 +1,21 @@
+import lombok.experimental.UtilityClass;
+final @UtilityClass class UtilityClassGeneric {
+  static class DTO {
+    DTO() {
+      super();
+    }
+  }
+  static <T>T convertValue(Class<T> toValueType) {
+    return null;
+  }
+  static DTO convert(Object json) {
+    return convertValue(DTO.class);
+  }
+  static Object convert(DTO dto) {
+    return null;
+  }
+  private @java.lang.SuppressWarnings("all") UtilityClassGeneric() {
+    super();
+    throw new java.lang.UnsupportedOperationException("This is a utility class and cannot be instantiated");
+  }
+}

--- a/test/transform/resource/before/UtilityClassGeneric.java
+++ b/test/transform/resource/before/UtilityClassGeneric.java
@@ -1,0 +1,18 @@
+import lombok.experimental.UtilityClass;
+@UtilityClass
+class UtilityClassGeneric {
+	<T> T convertValue(Class<T> toValueType) {
+		return null;
+	}
+	
+	DTO convert(Object json) {
+		return convertValue(DTO.class);
+	}
+	
+	Object convert(DTO dto) {
+		return null;
+	}
+	
+	class DTO {
+	}
+}


### PR DESCRIPTION
This PR fixes #3274

`erasure_field` is part of the Symbol class since JDK6, should be safe to add it to the stubs.