### PR TITLE
Inject fields after generated record fields

### DIFF
--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -1998,7 +1998,7 @@ public class EclipseHandlerUtil {
 			int index = 0;
 			for (; index < size; index++) {
 				FieldDeclaration f = newArray[index];
-				if (isEnumConstant(f) || isGenerated(f)) continue;
+				if (isEnumConstant(f) || isGenerated(f) || isRecordField(f)) continue;
 				break;
 			}
 			System.arraycopy(newArray, index, newArray, index + 1, size - index);
@@ -2758,6 +2758,13 @@ public class EclipseHandlerUtil {
 	 */
 	public static boolean isRecordField(EclipseNode fieldNode) {
 		return fieldNode.getKind() == Kind.FIELD && (((FieldDeclaration) fieldNode.get()).modifiers & AccRecord) != 0;
+	}
+	
+	/**
+	 * Returns {@code true} If the provided node is a field declaration, and represents a field in a {@code record} declaration.
+	 */
+	public static boolean isRecordField(FieldDeclaration fieldDeclaration) {
+		return (fieldDeclaration.modifiers & AccRecord) != 0;
 	}
 	
 	/**

--- a/test/transform/resource/after-ecj/LoggerFloggerRecord.java
+++ b/test/transform/resource/after-ecj/LoggerFloggerRecord.java
@@ -1,9 +1,9 @@
 // version 19:
 import lombok.extern.flogger.Flogger;
 class LoggerFloggerRecord {
-  public @Flogger record Inner(com log) {
-    private static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+  public @Flogger record Inner(String x) {
 /* Implicit */    private final String x;
+    private static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
     <clinit>() {
     }
     public Inner(String x) {

--- a/test/transform/resource/after-ecj/LoggerSlf4jOnRecord.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4jOnRecord.java
@@ -1,9 +1,9 @@
 // version 14:
 import lombok.extern.slf4j.Slf4j;
-public @Slf4j record LoggerSlf4jOnRecord(org log, String a) {
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jOnRecord.class);
+public @Slf4j record LoggerSlf4jOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
+  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jOnRecord.class);
   <clinit>() {
   }
   public LoggerSlf4jOnRecord(String a, String b) {

--- a/test/transform/resource/after-ecj/SynchronizedInRecord.java
+++ b/test/transform/resource/after-ecj/SynchronizedInRecord.java
@@ -1,8 +1,8 @@
 import lombok.Synchronized;
-public record SynchronizedInRecord(java $lock, String a) {
-  private final java.lang.Object $lock = new java.lang.Object[0];
+public record SynchronizedInRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
+  private final java.lang.Object $lock = new java.lang.Object[0];
   public SynchronizedInRecord(String a, String b) {
     super();
     .a = a;


### PR DESCRIPTION
This PR fixes #3327.

Eclipse expects that a record starts with the generated fields. As far as I know this only affects the string output.