### PR TITLE
Allow calling extension methods on `this` as receiver

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Christoph Dreis <christoph.dreis@freenet.de>
 DaveLaw <project.lombok@apconsult.de>
 Dave Brosius <dbrosius@mebigfatguy.com>
 Dawid Rusin <dawidrusin90@gmail.com>
+Demian Banakh <dembanakh01@gmail.com>
 Denis Stepanov <denis.stepanov@gmail.com>
 Emil Lundberg <emil@yubico.com>
 Enrique da Costa Cambio <enrique.dacostacambio@gmail.com>

--- a/src/core/lombok/javac/handlers/HandleExtensionMethod.java
+++ b/src/core/lombok/javac/handlers/HandleExtensionMethod.java
@@ -171,7 +171,8 @@ public class HandleExtensionMethod extends JavacAnnotationHandler<ExtensionMetho
 			JCExpression receiver = receiverOf(methodCall);
 			String methodName = methodNameOf(methodCall);
 			
-			if ("this".equals(receiver.toString()) || "this".equals(methodName) || "super".equals(methodName)) return;
+			if ("this".equals(receiver.toString()) && isImplicitReceiver(methodCall)) return;
+			if ("this".equals(methodName) || "super".equals(methodName)) return;
 			Map<JCTree, JCTree> resolution = new JavacResolution(methodCallNode.getContext()).resolveMethodMember(methodCallNode);
 			
 			JCTree resolvedMethodCall = resolution.get(methodCall);
@@ -223,6 +224,10 @@ public class HandleExtensionMethod extends JavacAnnotationHandler<ExtensionMetho
 			} else {
 				return ((JCFieldAccess) methodCall.meth).selected;
 			}
+		}
+		
+		private boolean isImplicitReceiver(final JCMethodInvocation methodCall) {
+			return methodCall.meth instanceof JCIdent;
 		}
 	}
 }

--- a/test/transform/resource/after-delombok/ExtensionMethodThis.java
+++ b/test/transform/resource/after-delombok/ExtensionMethodThis.java
@@ -1,0 +1,14 @@
+class ExtensionMethodThis {
+	public void test() {
+		ExtensionMethodThis.Extensions.hello(this);
+		hello();
+	}
+	
+	private void hello() {
+	}
+	
+	static class Extensions {
+		public static void hello(ExtensionMethodThis self) {	
+		}
+	}
+}

--- a/test/transform/resource/after-ecj/ExtensionMethodThis.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodThis.java
@@ -1,0 +1,19 @@
+import lombok.experimental.ExtensionMethod;
+@ExtensionMethod(ExtensionMethodThis.Extensions.class) class ExtensionMethodThis {
+  static class Extensions {
+    Extensions() {
+      super();
+    }
+    public static void hello(ExtensionMethodThis self) {
+    }
+  }
+  ExtensionMethodThis() {
+    super();
+  }
+  public void test() {
+    ExtensionMethodThis.Extensions.hello(this);
+    hello();
+  }
+  private void hello() {
+  }
+}

--- a/test/transform/resource/before/ExtensionMethodThis.java
+++ b/test/transform/resource/before/ExtensionMethodThis.java
@@ -1,0 +1,17 @@
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod(ExtensionMethodThis.Extensions.class)
+class ExtensionMethodThis {
+	public void test() {
+		this.hello();
+		hello();
+	}
+	
+	private void hello() {
+	}
+	
+	static class Extensions {
+		public static void hello(ExtensionMethodThis self) {
+		}
+	}
+}


### PR DESCRIPTION
Addresses #3334 

Currently in Javac, whenever the call receiver is `this`, it is not considered as a candidate for extension method call.
https://github.com/projectlombok/lombok/blob/8bb4dc5daa8792e718e88c596812f232a2b73e6e/src/core/lombok/javac/handlers/HandleExtensionMethod.java#L174

This PR makes the behaviour consistent with that of Eclipse's handler, I believe. In other words, explicit `this` call would be considered as a possible extension method call.