### PR TITLE
Introduce `--source` argument for Delombok

### DIFF
--- a/src/delombok/lombok/delombok/Delombok.java
+++ b/src/delombok/lombok/delombok/Delombok.java
@@ -99,7 +99,7 @@ public class Delombok {
 	private boolean onlyChanged;
 	private boolean force = false;
 	private boolean disablePreview;
-	private String classpath, sourcepath, bootclasspath, modulepath;
+	private String classpath, sourcepath, bootclasspath, modulepath, source;
 	private LinkedHashMap<File, File> fileToBase = new LinkedHashMap<File, File>();
 	private List<File> filesToParse = new ArrayList<File>();
 	private Map<String, String> formatPrefs = new HashMap<String, String>();
@@ -153,6 +153,9 @@ public class Delombok {
 		@Description("Module path (analogous to javac --module-path option)")
 		@FullName("module-path")
 		private String modulepath;
+		
+		@Description("Source version (analogous to javac -source option)")
+		private String source;
 		
 		@Description("Files to delombok. Provide either a file, or a directory. If you use a directory, all files in it (recursive) are delombok-ed")
 		@Sequential
@@ -308,6 +311,7 @@ public class Delombok {
 		if (args.sourcepath != null) delombok.setSourcepath(args.sourcepath);
 		if (args.bootclasspath != null) delombok.setBootclasspath(args.bootclasspath);
 		if (args.modulepath != null) delombok.setModulepath(args.modulepath);
+		if (args.source != null) delombok.setSource(args.source);
 		
 		try {
 			for (String in : args.input) {
@@ -560,6 +564,10 @@ public class Delombok {
 		this.modulepath = modulepath;
 	}
 	
+	public void setSource(String source) {
+		this.source = source;
+	}
+	
 	public void addDirectory(File base) throws IOException {
 		addDirectory0(false, base, "", 0);
 	}
@@ -682,6 +690,7 @@ public class Delombok {
 		if (classpath != null) options.putJavacOption("CLASSPATH", unpackClasspath(classpath));
 		if (sourcepath != null) options.putJavacOption("SOURCEPATH", sourcepath);
 		if (bootclasspath != null) options.putJavacOption("BOOTCLASSPATH", unpackClasspath(bootclasspath));
+		if (source != null) options.putJavacOption("SOURCE", source);
 		options.setFormatPreferences(new FormatPreferences(formatPrefs));
 		options.put("compilePolicy", "check");
 		
@@ -699,6 +708,10 @@ public class Delombok {
 			if (bootclasspath != null) {
 				argsList.add("--boot-class-path");
 				argsList.add(options.get("--boot-class-path"));
+			}
+			if (source != null) {
+				argsList.add("-source");
+				argsList.add(options.get("-source"));
 			}
 			if (charset != null) {
 				argsList.add("-encoding");

--- a/src/delombok/lombok/delombok/Delombok.java
+++ b/src/delombok/lombok/delombok/Delombok.java
@@ -711,7 +711,11 @@ public class Delombok {
 			}
 			if (source != null) {
 				argsList.add("-source");
-				argsList.add(options.get("-source"));
+				if (Javac.getJavaCompilerVersion() < 12) {
+					argsList.add(options.get("-source"));
+				} else {
+					argsList.add(options.get("--source"));
+				}
 			}
 			if (charset != null) {
 				argsList.add("-encoding");


### PR DESCRIPTION
This PR introduces the a optional `--source` argument for Delombok. By specifying `--source=X`, the generated output conforms to Java version X. `val x = 1;` is Delomboked to `final var x = 1;` or `final int x = 1;` depending on the JVM executing Delombok. Specifying `--source=1.8` results in the latter `final int x = 1;` variant even on JVM above version 9.

Fixes https://github.com/projectlombok/lombok/issues/3025.
