### PR TITLE
Add Delombok option to keep full path within output directory

### DIFF
--- a/src/delombok/lombok/delombok/Delombok.java
+++ b/src/delombok/lombok/delombok/Delombok.java
@@ -97,6 +97,7 @@ public class Delombok {
 	private boolean verbose;
 	private boolean noCopy;
 	private boolean onlyChanged;
+	private boolean keepPathInTargetDirectory = false;
 	private boolean force = false;
 	private boolean disablePreview;
 	private String classpath, sourcepath, bootclasspath, modulepath;
@@ -168,6 +169,10 @@ public class Delombok {
 		@Description("By default lombok enables preview features if available (introduced in JDK 12). With this option, lombok won't do that.")
 		@FullName("disable-preview")
 		private boolean disablePreview;
+		
+		@Description("By default input files are delomboked directly to the target directory, which means files with the same name get overwritten. With this option, the target directory is kept as a prefix in the output file paths.")
+		@FullName("target-keep-path")
+		private boolean keepPathInTargetDirectory;
 		
 		private boolean help;
 	}
@@ -302,6 +307,7 @@ public class Delombok {
 			delombok.setOutputToStandardOut();
 		} else {
 			delombok.setOutput(new File(args.target));
+			if (args.keepPathInTargetDirectory) delombok.setKeepPathInTargetDirectory(true);
 		}
 		
 		if (args.classpath != null) delombok.setClasspath(args.classpath);
@@ -542,6 +548,10 @@ public class Delombok {
 	
 	public void setOnlyChanged(boolean onlyChanged) {
 		this.onlyChanged = onlyChanged;
+	}
+	
+	public void setKeepPathInTargetDirectory(boolean keepPathInTargetDirectory) {
+		this.keepPathInTargetDirectory = keepPathInTargetDirectory;
 	}
 	
 	public void setOutput(File dir) {
@@ -907,7 +917,9 @@ public class Delombok {
 		URI base = inBase.toURI();
 		URI relative = base.relativize(base.resolve(file));
 		File outFile;
-		if (relative.isAbsolute()) {
+		if (keepPathInTargetDirectory) {
+			outFile = new File(outBase, file.getPath().replace(":", ""));
+		} else if (relative.isAbsolute()) {
 			outFile = new File(outBase, new File(relative).getName());
 		} else {
 			outFile = new File(outBase, relative.getPath());


### PR DESCRIPTION
This PR introduces a new `--target-keep-path` flag for delombok. It should be used in combination with `--target`. The main goal is that individual files passed to delombok could be written to the output directory without accidentally overwriting each other.

As an example:
```
java -jar lombok.jar delombok X/A.java X/B.java Y/A.java -d out
```
produces two files in the `out` folder, `A.java` and `B.java`. Note that A.java that's processed earlier will be overwritten by the other file named the same.

On the other hand:
```
java -jar lombok.jar delombok X/A.java X/B.java Y/A.java -d out --target-keep-path
```
produces `out/[FULL_PATH_PREFIX]/X/A.java`, `out/[FULL_PATH_PREFIX]/X/B.java`, `out/[FULL_PATH_PREFIX]/Y/A.java`, where `[FULL_PATH_PREFIX]` is the full path of the parent folder of `X` and `Y`.