### PR TITLE
Avoid looking up parent if bubbling stopped

### DIFF
--- a/src/core/lombok/core/configuration/BubblingConfigurationResolver.java
+++ b/src/core/lombok/core/configuration/BubblingConfigurationResolver.java
@@ -82,7 +82,7 @@ public class BubblingConfigurationResolver implements ConfigurationResolver {
 					return (T) result.getValue();
 				}
 			}
-			currentLevel = currentLevel.parent();
+			currentLevel = stopBubbling ? null : currentLevel.parent();
 		}
 		
 		if (!isList) return null;


### PR DESCRIPTION
Hi,

looking up the parent of a `ConfigurationFile` is somewhat expensive and allocation "intense".

<img width="626" alt="image" src="https://user-images.githubusercontent.com/6304496/220626205-c6778451-8025-4e0b-9935-51ebebc6da21.png">

Overall it makes up for ~20% of allocations. While I have a different PR coming up that caches the result of `ConfigurationFile.parent` I wanted to split this from this PR, because I think it's actually wrong to lookup the parent if the bubbling stopped and should be imho discussed separately.

Let me know what you think.
Cheers,
Christoph
