### PR TITLE
Cache ConfigurationFile.parent()

### DIFF
--- a/src/core/lombok/core/configuration/ConfigurationFile.java
+++ b/src/core/lombok/core/configuration/ConfigurationFile.java
@@ -110,7 +110,8 @@ public abstract class ConfigurationFile {
 	
 	private static class RegularConfigurationFile extends ConfigurationFile {
 		private final File file;
-		
+		private ConfigurationFile parent;
+
 		private RegularConfigurationFile(File file) {
 			super(file.getPath());
 			this.file = file;
@@ -173,8 +174,11 @@ public abstract class ConfigurationFile {
 		}
 
 		@Override ConfigurationFile parent() {
-			File parent = file.getParentFile().getParentFile();
-			return parent == null ? null : forDirectory(parent);
+			if (parent == null) {
+				File parentFile = file.getParentFile().getParentFile();
+				parent = parentFile == null ? null : forDirectory(parentFile);
+			}
+			return parent;
 		}
 		
 		private static String replaceEnvironmentVariables(String fileName) {


### PR DESCRIPTION
Hi,

looking up the parent of a ConfigurationFile is somewhat expensive and allocation "intense". Overall this makes up for 20% of all allocations during compilation. With the patch applied I can reduce this to 0.13%

**Before**
<img width="626" alt="image" src="https://user-images.githubusercontent.com/6304496/220628064-af76bbba-29a0-4d7b-9595-8751998d9aa1.png">

**After**
<img width="626" alt="image" src="https://user-images.githubusercontent.com/6304496/220628933-4701164c-793e-4dae-af3c-f19881c3839d.png">

Notice how the purple search highlights almost disappear from the latter screenshot.

I should note that the caching is somewhat suboptimal when no parent can be found because that would make the cache useless, but that's a) the minority of cases and b) should be happening even less with https://github.com/projectlombok/lombok/pull/3357 

Let me know what you think.
Cheers,
Christoph