### PR TITLE
Prevent repeated expensive creation of error logger

### DIFF
--- a/src/core/lombok/javac/JavacAST.java
+++ b/src/core/lombok/javac/JavacAST.java
@@ -77,7 +77,6 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 	private final JavacTreeMaker treeMaker;
 	private final Symtab symtab;
 	private final JavacTypes javacTypes;
-	private final Log log;
 	private final ErrorLog errorLogger;
 	private final Context context;
 	private static final URI NOT_CALCULATED_MARKER = URI.create("https://projectlombok.org/not/calculated");
@@ -86,16 +85,16 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 	/**
 	 * Creates a new JavacAST of the provided Compilation Unit.
 	 * 
-	 * @param messager A Messager for warning and error reporting.
+	 * @param errorLog A logger for warning and error reporting.
 	 * @param context A Context object for interfacing with the compiler.
 	 * @param top The compilation unit, which serves as the top level node in the tree to be built.
+	 * @param cleanup The registry for cleanup tasks.
 	 */
-	public JavacAST(Messager messager, Context context, JCCompilationUnit top, CleanupRegistry cleanup) {
+	public JavacAST(ErrorLog errorLog, Context context, JCCompilationUnit top, CleanupRegistry cleanup) {
 		super(sourceName(top), PackageName.getPackageName(top), new JavacImportList(top), statementTypes());
 		setTop(buildCompilationUnit(top));
 		this.context = context;
-		this.log = Log.instance(context);
-		this.errorLogger = ErrorLog.create(messager, log);
+		this.errorLogger = errorLog;
 		this.elements = JavacElements.instance(context);
 		this.treeMaker = new JavacTreeMaker(TreeMaker.instance(context));
 		this.symtab = Symtab.instance(context);
@@ -545,7 +544,7 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 		JCCompilationUnit top = (JCCompilationUnit) top().get();
 		newSource = top.sourcefile;
 		if (newSource != null) {
-			oldSource = log.useSource(newSource);
+			oldSource = errorLogger.useSource(newSource);
 			if (pos == null) pos = astObject.pos();
 		}
 		if (pos != null && node != null && attemptToRemoveErrorsInRange) {
@@ -568,7 +567,7 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 				break;
 			}
 		} finally {
-			if (newSource != null) log.useSource(oldSource);
+			if (newSource != null) errorLogger.useSource(oldSource);
 		}
 	}
 
@@ -619,6 +618,10 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 			this.warningCount = warningCount;
 		}
 
+		final JavaFileObject useSource(JavaFileObject file) {
+			return log.useSource(file);
+		}
+
 		final void error(DiagnosticPosition pos, String message) {
 			increment(errorCount);
 			error1(pos, message);
@@ -649,12 +652,13 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 			}
 		}
 		
-		static ErrorLog create(Messager messager, Log log) {
+		static ErrorLog create(Messager messager, Context context) {
 			Field errorCount; try {
 				errorCount = Permit.getField(messager.getClass(), "errorCount");
 			} catch (Throwable t) {
 				errorCount = null;
 			}
+			Log log = Log.instance(context);
 			boolean hasMultipleErrors = false;
 			for (Field field : log.getClass().getFields()) {
 				if (field.getName().equals("multipleErrors")) {

--- a/src/core/lombok/javac/JavacTransformer.java
+++ b/src/core/lombok/javac/JavacTransformer.java
@@ -57,9 +57,13 @@ public class JavacTransformer {
 	}
 	
 	public void transform(long priority, Context context, List<JCCompilationUnit> compilationUnits, CleanupRegistry cleanup) {
+		if (compilationUnits.isEmpty()) {
+			return;
+		}
+		JavacAST.ErrorLog errorLog = JavacAST.ErrorLog.create(messager, context);
 		for (JCCompilationUnit unit : compilationUnits) {
 			if (!Boolean.TRUE.equals(LombokConfiguration.read(ConfigurationKeys.LOMBOK_DISABLE, JavacAST.getAbsoluteFileLocation(unit)))) {
-				JavacAST ast = new JavacAST(messager, context, unit, cleanup);
+				JavacAST ast = new JavacAST(errorLog, context, unit, cleanup);
 				ast.traverse(new AnnotationVisitor(priority));
 				handlers.callASTVisitors(ast, priority);
 				if (ast.isChanged()) LombokOptions.markChanged(context, (JCCompilationUnit) ast.top().get());


### PR DESCRIPTION
Hi,

I've noticed that the creation of the error logger is quite intense.

<img width="653" alt="image" src="https://user-images.githubusercontent.com/6304496/220901967-ed93542d-3b39-4cd3-ab41-2c1574025998.png">

The idea of this PR is to avoid the creation of the error logger repeatedly for every compilation unit. It's same throughout anyhow. By that, we can avoid the reflective overhead and avoid the corresponding repeated expensive exceptions that are caused by JDK 11 having a few things available on the parent `AbstractLogger` rather than directly in `Log`. The stuff still currently still works because the lookup on the parent classes is successful (if you're asking yourself if there is a problem underneath why those methods are created in the first place). But the ones on `Log` cause the exceptions (that are silently caught).

Let me know what you think.
Cheers,
Christoph