### PR TITLE
Add @Generator annotation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,5 +54,6 @@ Till Brychcy <till.brychcy@mercateo.com>
 Victor Williams Stafusa da Silva <victorwssilva@gmail.com>
 Yonatan Sherwin <yonatansherwin@gmail.com>
 Yun Zhi Lin <yun@yunspace.com>
+Yoon Tae Min <storycraft@pancake.sh>
 
 By adding your name to this list, you grant full and irrevocable copyright and patent indemnity to Project Lombok and all use of Project Lombok in relation to all commits you add to Project Lombok, and you certify that you have the right to do so.

--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -651,6 +651,14 @@ public class ConfigurationKeys {
 	 */
 	public static final ConfigurationKey<FlagUsageType> FIELD_NAME_CONSTANTS_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.fieldNameConstants.flagUsage", "Emit a warning or error if @FieldNameConstants is used.") {};
 	
+	// ----- Generator -----
+	/**
+	 * lombok configuration: {@code lombok.generator.flagUsage} = {@code WARNING} | {@code ERROR}.
+	 * 
+	 * If set, <em>any</em> usage of {@code @Generator} results in a warning / error.
+	 */
+	public static final ConfigurationKey<FlagUsageType> GENERATOR_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.generator.flagUsage", "Emit a warning or error if @Generator is used.") {};
+	
 	/**
 	 * lombok configuration: {@code lombok.fieldNameConstants.innerTypeName} = &lt;String: AValidJavaTypeName&gt; (Default: {@code Fields}).
 	 * 

--- a/src/core/lombok/Lombok.java
+++ b/src/core/lombok/Lombok.java
@@ -21,6 +21,8 @@
  */
 package lombok;
 
+import java.util.Iterator;
+
 /**
  * Useful utility methods to manipulate lombok-generated code.
  */
@@ -81,5 +83,40 @@ public class Lombok {
 	public static <T> T checkNotNull(T value, String message) {
 		if (value == null) throw new NullPointerException(message);
 		return value;
+	}
+
+	/**
+	 * Stub class for {@code GeneratorPostTransformation}
+	 */
+	public static abstract class Generator<T> implements Iterable<T>, Iterator<T> {
+
+		protected abstract void advance();
+		
+		protected final void yieldThis(T target) {
+			throw new UnsupportedOperationException("Unimplemented method 'yieldThis'");
+		}
+
+		protected final void yieldAll(Iterable<T> target) {
+			throw new UnsupportedOperationException("Unimplemented method 'yieldAll'");
+		}
+		protected final void yieldAll(T[] target) {
+			throw new UnsupportedOperationException("Unimplemented method 'yieldAll'");
+		}
+
+		@Override public boolean hasNext() {
+			throw new UnsupportedOperationException("Unimplemented method 'hasNext'");
+		}
+
+		@Override public T next() {
+			throw new UnsupportedOperationException("Unimplemented method 'next'");
+		}
+
+		@Override public Iterator<T> iterator() {
+			throw new UnsupportedOperationException("Unimplemented method 'iterator'");
+		}
+
+		@Override public void remove() {
+			throw new UnsupportedOperationException("Unimplemented method 'remove'");
+		}
 	}
 }

--- a/src/core/lombok/bytecode/GeneratorPostTransformation.java
+++ b/src/core/lombok/bytecode/GeneratorPostTransformation.java
@@ -708,6 +708,10 @@ public class GeneratorPostTransformation implements PostCompilerTransformation {
         }
 
         @Override public BasicValue newValue(Type type) {
+            if (type == null) {
+                return BasicValue.UNINITIALIZED_VALUE;
+            } 
+
             return new BasicValue(type);
         }
     }

--- a/src/core/lombok/bytecode/GeneratorPostTransformation.java
+++ b/src/core/lombok/bytecode/GeneratorPostTransformation.java
@@ -1,0 +1,888 @@
+/*
+ * Copyright (C) 2023 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.bytecode;
+
+import static lombok.bytecode.AsmUtil.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import lombok.core.DiagnosticsReceiver;
+import lombok.core.PostCompilerTransformation;
+import lombok.spi.Provides;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.IincInsnNode;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.IntInsnNode;
+import org.objectweb.asm.tree.InvokeDynamicInsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.LookupSwitchInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MultiANewArrayInsnNode;
+import org.objectweb.asm.tree.TableSwitchInsnNode;
+import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicInterpreter;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
+
+@Provides
+public class GeneratorPostTransformation implements PostCompilerTransformation {
+    private static final String GENERATOR_ERR_RESUME_ON_FINISH = "Called next on finished generator";
+    private static final String GENERATOR_ERR_UNREACHABLE = "Unreachable generator state";
+
+	@Override public byte[] applyTransformations(byte[] original, String fileName, final DiagnosticsReceiver diagnostics) {
+		if (!"lombok/Lombok$Generator".equals(new ClassFileMetaData(original).getSuperClassName())) return null;
+
+		byte[] fixedByteCode = fixJSRInlining(original);
+		
+		ClassReader reader = new ClassReader(fixedByteCode);
+		ClassWriter writer = new ClassWriter(
+            reader,
+            ClassWriter.COMPUTE_MAXS
+        );
+
+        GeneratorClass generatorClass = initializeClass(Type.getType(Object.class), reader.getClassName(), writer, setupTable(reader));
+
+        reader.accept(transformClass(writer, reader.getClassName(), generatorClass), 0);
+
+        return writer.toByteArray();
+	}
+
+    private static boolean isYieldThis(int opcode, String className, String owner, String name) {
+        return opcode == Opcodes.INVOKEVIRTUAL && "yieldThis".equals(name) && owner.equals(className);
+    }
+
+    private static boolean isYieldAll(int opcode, String className, String owner, String name) {
+        return opcode == Opcodes.INVOKEVIRTUAL && "yieldAll".equals(name) && owner.equals(className);
+    }
+
+    private ClassVisitor transformClass(final ClassWriter writer, final String className, final GeneratorClass generatorClass) {
+        return new ClassVisitor(Opcodes.ASM7, writer) {
+            @Override public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+                access |= Opcodes.ACC_SYNTHETIC;
+                superName = Type.getInternalName(Object.class);
+                interfaces = new String[] {
+                    Type.getInternalName(Iterable.class),
+                    Type.getInternalName(Iterator.class)
+                };
+
+                super.visit(version, access, name, signature, superName, interfaces);
+
+                FieldNode stateNode = generatorClass.stateNode;
+                FieldNode resultNode = generatorClass.resultNode;
+                writer.visitField(stateNode.access, stateNode.name, stateNode.desc, stateNode.signature, stateNode.value);
+                writer.visitField(resultNode.access, resultNode.name, resultNode.desc, resultNode.signature, resultNode.value);
+        
+                visitIterator(writer);
+                visitHasNext(writer, className, resultNode);
+                visitNext(writer, className, resultNode);
+                visitRemove(writer);
+            }
+
+            @Override public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+                MethodVisitor visitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+
+                if ("<init>".equals(name)) {
+                    return new MethodVisitor(Opcodes.ASM7, visitor) {
+                        @Override public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+                            if (opcode == Opcodes.INVOKESPECIAL && "lombok/Lombok$Generator".equals(owner)) {
+                                owner = Type.getInternalName(Object.class);
+                            }
+
+                            super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                        }
+                    };
+                } else if ("advance".equals(name)) {
+                    return transformAdvance(writer, visitor, className, generatorClass);
+                }
+
+                return visitor;
+            }
+        };
+    }
+
+    private MethodVisitor transformAdvance(
+        final ClassWriter writer,
+        final MethodVisitor methodVisitor,
+        final String className,
+        final GeneratorClass generatorClass
+    ) {
+        final Frame<BasicValue> frame = new Frame<BasicValue>(65536, 65536);
+
+        MethodVisitor transformer = new MethodVisitor(Opcodes.ASM7, methodVisitor) {
+            private int index = 0;
+
+            private int tmpIndex = 0;
+            private Map<Integer, FieldNode> variableMap = new HashMap<Integer, FieldNode>();
+            
+            private void setState(int index) {
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                switch (index) {
+                    case 0: super.visitInsn(Opcodes.ICONST_0); break;
+                    case 1: super.visitInsn(Opcodes.ICONST_1); break;
+                    case 2: super.visitInsn(Opcodes.ICONST_2); break;
+                    case 3: super.visitInsn(Opcodes.ICONST_3); break;
+                    case 4: super.visitInsn(Opcodes.ICONST_4); break;
+                    case 5: super.visitInsn(Opcodes.ICONST_5); break;
+                    default: {
+                        if (index <= 0xff) {
+                            super.visitIntInsn(Opcodes.BIPUSH, index);
+                        } else if (index <= 0xffff) {
+                            super.visitIntInsn(Opcodes.SIPUSH, index);
+                        } else {
+                            super.visitLdcInsn(index);
+                        }
+                    }
+                }
+                
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, generatorClass.stateNode.name, generatorClass.stateNode.desc);
+            }
+
+            @Override public void visitCode() {
+                super.visitCode();
+
+                Label[] labels = generatorClass.table.toLabels();
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitFieldInsn(Opcodes.GETFIELD, className, generatorClass.stateNode.name, generatorClass.stateNode.desc);
+                super.visitTableSwitchInsn(0, labels.length - 1, generatorClass.table.defaultLabel, labels);
+                super.visitLabel(generatorClass.table.start);
+                super.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+            }
+
+            private Type getVariableType(int opcode, int varIndex) {
+                switch (opcode) {
+                    case Opcodes.ISTORE:
+                    case Opcodes.ILOAD: return Type.INT_TYPE;
+
+                    case Opcodes.FLOAD:
+                    case Opcodes.FSTORE: return Type.FLOAT_TYPE;
+
+                    case Opcodes.DLOAD:
+                    case Opcodes.DSTORE: return Type.DOUBLE_TYPE;
+
+                    case Opcodes.LLOAD:
+                    case Opcodes.LSTORE: return Type.LONG_TYPE;
+
+                    default: {
+                        BasicValue val = frame.getLocal(varIndex);
+                        if (val != null) {
+                            return val.getType();
+                        }
+
+                        return Type.getType(Object.class);
+                    }
+                }
+            }
+
+            private FieldNode createTempVariable(String descriptor) {
+                FieldNode node = new FieldNode(Opcodes.ACC_SYNTHETIC, "gen$" + tmpIndex++, descriptor, null, null);
+                writer.visitField(node.access, node.name, descriptor, null, null);
+                return node;
+            }
+
+            @Override public void visitVarInsn(int opcode, int varIndex) {
+                switch (opcode) {
+                    case Opcodes.ASTORE:
+                    case Opcodes.ISTORE:
+                    case Opcodes.LSTORE:
+                    case Opcodes.FSTORE:
+                    case Opcodes.DSTORE: {
+                        String descriptor = getVariableType(opcode, varIndex).getDescriptor();
+
+                        super.visitVarInsn(Opcodes.ALOAD, 0);
+
+                        FieldNode old = variableMap.get(varIndex);
+                        FieldNode node;
+                        if (old != null && descriptor.equals(old.desc)) {
+                            node = old;
+                        } else {
+                            if (old != null && Type.getType(old.desc).getSort() == Type.OBJECT) {
+                                super.visitInsn(Opcodes.DUP);
+                                super.visitInsn(Opcodes.ACONST_NULL);
+                                super.visitFieldInsn(Opcodes.PUTFIELD, className, old.name, old.desc);
+                            }
+
+                            node = createTempVariable(descriptor);
+                            variableMap.put(varIndex, node);
+                        }
+
+                        super.visitInsn(Opcodes.SWAP);
+                        super.visitFieldInsn(Opcodes.PUTFIELD, className, node.name, descriptor);
+                        return;
+                    }
+
+                    case Opcodes.ALOAD:
+                    case Opcodes.ILOAD:
+                    case Opcodes.LLOAD:
+                    case Opcodes.FLOAD:
+                    case Opcodes.DLOAD: {
+                        FieldNode node = variableMap.get(varIndex);
+                        if (node == null) {
+                            break;
+                        }
+
+                        super.visitVarInsn(Opcodes.ALOAD, 0);
+                        super.visitFieldInsn(Opcodes.GETFIELD, className, node.name, node.desc);
+                        return;
+                    }
+                }
+
+                super.visitVarInsn(opcode, varIndex);
+            }
+
+            @Override public void visitIincInsn(int varIndex, int increment) {
+                FieldNode node = variableMap.get(varIndex);
+                if (node == null) {
+                    super.visitIincInsn(varIndex, increment);
+                    return;
+                }
+
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitInsn(Opcodes.DUP);
+                super.visitFieldInsn(Opcodes.GETFIELD, className, node.name, node.desc);
+                switch (increment) {
+                    case -1: super.visitInsn(Opcodes.ICONST_M1); break;
+                    case 0: super.visitInsn(Opcodes.ICONST_0); break;
+                    case 1: super.visitInsn(Opcodes.ICONST_1); break;
+                    case 2: super.visitInsn(Opcodes.ICONST_2); break;
+                    case 3: super.visitInsn(Opcodes.ICONST_3); break;
+                    case 4: super.visitInsn(Opcodes.ICONST_4); break;
+                    case 5: super.visitInsn(Opcodes.ICONST_5); break;
+                    default: super.visitIntInsn(Opcodes.BIPUSH, increment); break;
+                }
+                super.visitInsn(Opcodes.IADD);
+
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, node.name, node.desc);
+            }
+
+            @Override public void visitFrame(int type, int numLocal, Object[] local, int numStack, Object[] stack) {
+                if (local != null) {
+                    // Remove all local variables
+                    if (type == Opcodes.F_FULL || type == Opcodes.F_NEW) {
+                        numLocal = 1;
+                    } else if (type == Opcodes.F_APPEND || type == Opcodes.F_CHOP) {
+                        numLocal = 0;
+                    }
+                }
+
+                super.visitFrame(type, numLocal, local, numStack, stack);
+            }
+
+            private void expandYieldThis() {
+                Label next = generatorClass.table.yields[index++];
+
+                // Assign next value (value already loaded by method invocation)
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, generatorClass.resultNode.name, generatorClass.resultNode.desc);
+                // Assign state
+                setState(index);
+                super.visitInsn(Opcodes.RETURN);
+
+                // Mark next
+                super.visitLabel(next);
+                super.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+            }
+
+            private void expandYieldAllIterable() {
+                Label next = generatorClass.table.yields[index++];
+
+                FieldNode iteratorNode = createTempVariable(Type.getDescriptor(Iterator.class));
+
+                // Create iterator (iterable already loaded by method invocation)
+                super.visitMethodInsn(
+                    Opcodes.INVOKEINTERFACE,
+                    Type.getInternalName(Iterable.class),
+                    "iterator",
+                    "()Ljava/util/Iterator;",
+                    true
+                );
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, iteratorNode.name, iteratorNode.desc);
+
+                // Mark next
+                setState(index);
+                super.visitLabel(next);
+                super.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+
+                // Jump to next on end
+                Label loopEnd = new Label();
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitFieldInsn(Opcodes.GETFIELD, className, iteratorNode.name, iteratorNode.desc);
+                super.visitMethodInsn(
+                    Opcodes.INVOKEINTERFACE,
+                    Type.getInternalName(Iterator.class),
+                    "hasNext",
+                    "()Z",
+                    true
+                );
+                super.visitJumpInsn(Opcodes.IFEQ, loopEnd);
+
+                // Assign next value
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitInsn(Opcodes.DUP);
+                super.visitFieldInsn(Opcodes.GETFIELD, className, iteratorNode.name, iteratorNode.desc);
+                super.visitMethodInsn(
+                    Opcodes.INVOKEINTERFACE,
+                    Type.getInternalName(Iterator.class),
+                    "next",
+                    "()Ljava/lang/Object;",
+                    true
+                );
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, generatorClass.resultNode.name, generatorClass.resultNode.desc);
+                super.visitInsn(Opcodes.RETURN);
+            
+                super.visitLabel(loopEnd);
+                super.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+
+                // Cleanup iterator
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitInsn(Opcodes.ACONST_NULL);
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, iteratorNode.name, iteratorNode.desc);
+            }
+
+            private void expandYieldAllArray() {
+                Label next = generatorClass.table.yields[index++];
+
+                FieldNode arrayNode = createTempVariable("[" + generatorClass.type.getDescriptor());
+                FieldNode lengthNode = createTempVariable(Type.INT_TYPE.getDescriptor());
+                FieldNode incrementNode = createTempVariable(Type.INT_TYPE.getDescriptor());
+                Label loopEnd = new Label();
+
+                // Initialize array
+                super.visitInsn(Opcodes.DUP2);
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, arrayNode.name, arrayNode.desc);
+
+                // Initialize length
+                super.visitInsn(Opcodes.ARRAYLENGTH);
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, lengthNode.name, lengthNode.desc);
+
+                // Initialize increment
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitInsn(Opcodes.ICONST_0);
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, incrementNode.name, incrementNode.desc);
+
+                // Mark next
+                setState(index);
+                super.visitLabel(next);
+                super.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+
+                // Check increment
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitFieldInsn(Opcodes.GETFIELD, className, incrementNode.name, incrementNode.desc);
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitFieldInsn(Opcodes.GETFIELD, className, lengthNode.name, lengthNode.desc);
+                super.visitJumpInsn(Opcodes.IF_ICMPGE, loopEnd);
+
+                // get value from array
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitInsn(Opcodes.DUP);
+                super.visitFieldInsn(Opcodes.GETFIELD, className, arrayNode.name, arrayNode.desc);
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitFieldInsn(Opcodes.GETFIELD, className, incrementNode.name, incrementNode.desc);
+                super.visitInsn(Opcodes.AALOAD);
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, generatorClass.resultNode.name, generatorClass.resultNode.desc);
+                
+                // add increment by 1 and return
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitInsn(Opcodes.DUP);
+                super.visitFieldInsn(Opcodes.GETFIELD, className, incrementNode.name, incrementNode.desc);
+                super.visitInsn(Opcodes.ICONST_1);
+                super.visitInsn(Opcodes.IADD);
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, incrementNode.name, incrementNode.desc);
+                super.visitInsn(Opcodes.RETURN);
+
+                super.visitLabel(loopEnd);
+                super.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+
+                // Cleanup array
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitInsn(Opcodes.ACONST_NULL);
+                super.visitFieldInsn(Opcodes.PUTFIELD, className, arrayNode.name, arrayNode.desc);
+            }
+
+            @Override public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+                if (isYieldThis(opcode, className, owner, name)) {
+                    expandYieldThis();
+                    return;
+                } else if (isYieldAll(opcode, className, owner, name)) {
+                    Type[] arguments = Type.getArgumentTypes(descriptor);
+                    if (arguments[0].getSort() != Type.ARRAY) {
+                        expandYieldAllIterable();
+                    } else {
+                        expandYieldAllArray();
+                    }
+                    return;
+                }
+
+                super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+            }
+
+            @Override public void visitInsn(int opcode) {
+                switch(opcode) {
+                    // Mark generator finished on return
+                    case Opcodes.IRETURN:
+                    case Opcodes.FRETURN:
+                    case Opcodes.ARETURN:
+                    case Opcodes.LRETURN:
+                    case Opcodes.DRETURN:
+                    case Opcodes.RETURN: {
+                        setState(generatorClass.table.getFinishState());
+                        break;
+                    }
+
+                    default: break;
+                }
+
+                super.visitInsn(opcode);
+            }
+
+            @Override public void visitMaxs(int maxStack, int maxLocals) {
+                Label finish = new Label();
+                super.visitLabel(finish);
+                super.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+                setState(generatorClass.table.getFinishState());
+    
+                super.visitLabel(generatorClass.table.end);
+                super.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+                super.visitInsn(Opcodes.RETURN);
+
+                Label exceptionCleanup = new Label();
+                super.visitLabel(exceptionCleanup);
+                super.visitFrame(Opcodes.F_SAME1, 0, null, 1, new Object[] {"java/lang/Throwable"});
+                setState(generatorClass.table.getFinishState());
+                super.visitInsn(Opcodes.ATHROW);
+
+                super.visitTryCatchBlock(generatorClass.table.start, finish, exceptionCleanup, null);
+
+                // Default case
+                super.visitLabel(generatorClass.table.defaultLabel);
+                super.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+                super.visitTypeInsn(Opcodes.NEW, "java/lang/RuntimeException");
+                super.visitInsn(Opcodes.DUP);
+                super.visitLdcInsn(GENERATOR_ERR_UNREACHABLE);
+                super.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/RuntimeException", "<init>", "(Ljava/lang/String;)V", false);
+                super.visitInsn(Opcodes.ATHROW);
+
+                super.visitMaxs(maxStack, maxLocals);
+            }
+        };
+        
+        return new FrameTracker(Opcodes.ASM7, frame, transformer);
+    }
+
+    private GeneratorClass initializeClass(
+        Type type,
+        String className,
+        ClassWriter writer,
+        GeneratorTable table
+    ) {
+        FieldNode stateNode = new FieldNode(Opcodes.ACC_SYNTHETIC, "$state", "I", null, null);
+        FieldNode resultNode = new FieldNode(Opcodes.ACC_SYNTHETIC, "$result", type.getDescriptor(), null, null);
+
+        return new GeneratorClass(type, stateNode, resultNode, table);
+    }
+
+    private void visitIterator(ClassVisitor classVisitor) {
+        MethodVisitor visitor = classVisitor.visitMethod(
+            Opcodes.ACC_PUBLIC,
+            "iterator",
+            "()" + Type.getDescriptor(Iterator.class),
+            null,
+            null
+        );
+        visitor.visitCode();
+        visitor.visitVarInsn(Opcodes.ALOAD, 0);
+        visitor.visitInsn(Opcodes.ARETURN);
+        visitor.visitMaxs(1, 1);
+        visitor.visitEnd();
+    }
+
+    private void visitHasNext(ClassVisitor classVisitor, String className, FieldNode resultNode) {
+        MethodVisitor visitor = classVisitor.visitMethod(
+            Opcodes.ACC_PUBLIC,
+            "hasNext",
+            "()Z",
+            null,
+            null
+        );
+        Label advanceEnd = new Label();
+        visitor.visitCode();
+
+        visitor.visitVarInsn(Opcodes.ALOAD, 0);
+        visitor.visitFieldInsn(Opcodes.GETFIELD, className, resultNode.name, resultNode.desc);
+        visitor.visitJumpInsn(Opcodes.IFNONNULL, advanceEnd);
+
+        visitor.visitVarInsn(Opcodes.ALOAD, 0);
+        visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, "advance", "()V", false);
+
+        visitor.visitLabel(advanceEnd);
+        visitor.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+        visitor.visitVarInsn(Opcodes.ALOAD, 0);
+        visitor.visitFieldInsn(Opcodes.GETFIELD, className, resultNode.name, resultNode.desc);
+
+        Label hasNextReturnFalse = new Label();
+        visitor.visitJumpInsn(Opcodes.IFNULL, hasNextReturnFalse);
+
+        visitor.visitInsn(Opcodes.ICONST_1);
+        visitor.visitInsn(Opcodes.IRETURN);
+
+        visitor.visitLabel(hasNextReturnFalse);
+        visitor.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+        visitor.visitInsn(Opcodes.ICONST_0);
+        visitor.visitInsn(Opcodes.IRETURN);
+
+        visitor.visitMaxs(2, 1);
+        visitor.visitEnd();
+    }
+    
+    private void visitNext(ClassVisitor classVisitor, String className, FieldNode resultNode) {
+        MethodVisitor visitor = classVisitor.visitMethod(
+            Opcodes.ACC_PUBLIC,
+            "next",
+            "()Ljava/lang/Object;",
+            null,
+            null
+        );
+        visitor.visitCode();
+        Label checkEnd = new Label();
+        
+        visitor.visitVarInsn(Opcodes.ALOAD, 0);
+        visitor.visitFieldInsn(Opcodes.GETFIELD, className, resultNode.name, resultNode.desc);
+        visitor.visitJumpInsn(Opcodes.IFNONNULL, checkEnd);
+        
+        visitor.visitVarInsn(Opcodes.ALOAD, 0);
+        visitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, className, "advance", "()V", false);
+        visitor.visitVarInsn(Opcodes.ALOAD, 0);
+        visitor.visitFieldInsn(Opcodes.GETFIELD, className, resultNode.name, resultNode.desc);
+        visitor.visitJumpInsn(Opcodes.IFNONNULL, checkEnd);
+
+        String exceptionClass = Type.getInternalName(NoSuchElementException.class);
+        visitor.visitTypeInsn(Opcodes.NEW, exceptionClass);
+        visitor.visitInsn(Opcodes.DUP);
+        visitor.visitLdcInsn(GENERATOR_ERR_RESUME_ON_FINISH);
+        visitor.visitMethodInsn(Opcodes.INVOKESPECIAL, exceptionClass, "<init>", "(Ljava/lang/String;)V", false);
+        visitor.visitInsn(Opcodes.ATHROW);
+
+        visitor.visitLabel(checkEnd);
+        visitor.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+        visitor.visitVarInsn(Opcodes.ALOAD, 0);
+        visitor.visitFieldInsn(Opcodes.GETFIELD, className, resultNode.name, resultNode.desc);
+        visitor.visitVarInsn(Opcodes.ALOAD, 0);
+        visitor.visitInsn(Opcodes.ACONST_NULL);
+        visitor.visitFieldInsn(Opcodes.PUTFIELD, className, resultNode.name, resultNode.desc);
+        visitor.visitInsn(Opcodes.ARETURN);
+
+        visitor.visitMaxs(3, 1);
+        visitor.visitEnd();
+    }
+
+    private void visitRemove(ClassVisitor classVisitor) {
+        MethodVisitor visitor = classVisitor.visitMethod(
+            Opcodes.ACC_PUBLIC,
+            "remove",
+            "()V",
+            null,
+            null
+        );
+        visitor.visitCode();
+
+        String exceptionClass = Type.getInternalName(UnsupportedOperationException.class);
+        visitor.visitTypeInsn(Opcodes.NEW, exceptionClass);
+        visitor.visitInsn(Opcodes.DUP);
+        visitor.visitLdcInsn("remove");
+        visitor.visitMethodInsn(Opcodes.INVOKESPECIAL, exceptionClass, "<init>", "(Ljava/lang/String;)V", false);
+        visitor.visitInsn(Opcodes.ATHROW);
+
+        visitor.visitMaxs(3, 1);
+        visitor.visitEnd();
+    }
+
+    private GeneratorTable setupTable(ClassReader reader) {
+        final String className = reader.getClassName();
+        final List<Label> yields = new ArrayList<Label>();
+
+        reader.accept(new ClassVisitor(Opcodes.ASM7) {
+            @Override public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+                if ("advance".equals(name)) {
+                    return new MethodVisitor(Opcodes.ASM7) {
+                        @Override public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+                            if (isYieldThis(opcode, className, owner, name) || isYieldAll(opcode, className, owner, name)) {
+                                yields.add(new Label());
+                            }
+                        }
+                    };
+                }
+
+                return null;
+            }
+        }, ClassReader.SKIP_FRAMES);
+
+        return new GeneratorTable(
+            new Label(),
+            yields.toArray(new Label[0]),
+            new Label(),
+            new Label()
+        );
+    }
+
+    private static class GeneratorClass {
+        public final Type type;
+        public final FieldNode stateNode;
+        public final FieldNode resultNode;
+        public final GeneratorTable table;
+
+        public GeneratorClass(Type type, FieldNode stateNode, FieldNode resultNode, GeneratorTable table) {
+            this.type = type;
+            this.stateNode = stateNode;
+            this.resultNode = resultNode;
+            this.table = table;
+        }
+    }
+
+    private static class GeneratorTable {
+        public final Label start;
+        public final Label[] yields;
+        public final Label end;
+        public final Label defaultLabel;
+
+        public GeneratorTable(Label start, Label[] yields, Label end, Label defaultLabel) {
+            this.start = start;
+            this.yields = yields;
+            this.end = end;
+            this.defaultLabel = defaultLabel;
+        }
+
+        public Label[] toLabels() {
+            Label[] arr = new Label[yields.length + 2];
+            arr[0] = start;
+            System.arraycopy(yields, 0, arr, 1, yields.length);
+            arr[arr.length - 1] = end;
+
+            return arr;
+        }
+
+        public int getFinishState() {
+            return yields.length + 1;
+        }
+    }
+
+    private static class RawInterpreter extends BasicInterpreter {
+        public RawInterpreter() {
+            super(Opcodes.ASM7);
+        }
+
+        @Override public BasicValue newValue(Type type) {
+            return new BasicValue(type);
+        }
+    }
+
+    private static class FrameTracker extends MethodVisitor {
+        private final RawInterpreter interpreter;
+        public final Frame<BasicValue> frame;
+
+        protected FrameTracker(int api, Frame<BasicValue> frame, MethodVisitor methodVisitor) {
+            super(api, methodVisitor);
+            this.interpreter = new RawInterpreter();
+            this.frame = frame;
+        }
+
+        private void updateFrame(AbstractInsnNode node) {
+            try {
+                frame.execute(node, interpreter);
+            } catch (AnalyzerException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private LabelNode[] intoLabelNodes(Label[] labels) {
+            LabelNode[] labelNodes = new LabelNode[labels.length];
+            for (int i = 0; i < labels.length; i++) {
+                labelNodes[i] = new LabelNode(labels[i]);
+            }
+            return labelNodes;
+        }
+
+        @Override public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
+            updateFrame(new FieldInsnNode(opcode, owner, name, descriptor));
+            super.visitFieldInsn(opcode, owner, name, descriptor);
+        }
+
+        private Type[] intoTypes(Object[] frameTypes) {
+            List<Type> list = new ArrayList<Type>(frameTypes.length);
+            for (Object frameType : frameTypes) {
+                if (frameType == null) {
+                    break;
+                } else if (frameType == Opcodes.TOP) {
+                    continue;
+                } if (frameType == Opcodes.INTEGER) {
+                    list.add(Type.INT_TYPE);
+                } else if (frameType == Opcodes.LONG) {
+                    list.add(Type.LONG_TYPE);
+                } else if (frameType == Opcodes.FLOAT) {
+                    list.add(Type.FLOAT_TYPE);
+                } else if (frameType == Opcodes.DOUBLE) {
+                    list.add(Type.DOUBLE_TYPE);
+                } else if (frameType instanceof String) {
+                    list.add(Type.getObjectType((String) frameType));
+                }
+            }
+
+            return list.toArray(new Type[0]);
+        }
+
+        private void updateStack(int numStack, Type[] stack) {
+            frame.clearStack();
+            for (int i = 0; i < numStack; i++) {
+                frame.push(interpreter.newValue(stack[i]));
+            }
+        }
+
+        private void updateLocal(int numLocal, Type[] local) {
+            for (int i = 0; i < numLocal; i++) {
+                frame.setLocal(i, interpreter.newValue(local[i]));
+            }
+        }
+
+        @Override public void visitFrame(int type, int numLocal, Object[] local, int numStack, Object[] stack) {
+            switch (type) {
+                case Opcodes.F_NEW:
+                case Opcodes.F_FULL: {
+                    updateStack(numStack, intoTypes(stack));
+                    updateLocal(numLocal, intoTypes(local));
+                    break;
+                }
+
+                case Opcodes.F_SAME1: {
+                    frame.clearStack();
+                    frame.push(interpreter.newValue(intoTypes(stack)[0]));
+                    break;
+                }
+
+                case Opcodes.F_CHOP: {
+                    frame.clearStack();
+                    int start = local.length - 1;
+
+                    for (int i = 0; i < numLocal; i++) {
+                        frame.setLocal(start - i, null);
+                    }
+                    break;
+                }
+                case Opcodes.F_APPEND: {
+                    frame.clearStack();
+                    int start = local.length;
+
+                    Type[] localTypes = intoTypes(local);
+                    for (int i = 0; i < numLocal; i++) {
+                        frame.setLocal(start + i, interpreter.newValue(localTypes[i]));
+                    }
+                    break;
+                }
+
+                case Opcodes.F_SAME: {
+                    frame.clearStack();
+                    break;
+                }
+
+                default: break;
+            }
+
+            super.visitFrame(type, numLocal, local, numStack, stack);
+        }
+
+        @Override public void visitIincInsn(int varIndex, int increment) {
+            updateFrame(new IincInsnNode(varIndex, increment));
+            super.visitIincInsn(varIndex, increment);
+        }
+
+        @Override public void visitInsn(int opcode) {
+            updateFrame(new InsnNode(opcode));
+            super.visitInsn(opcode);
+        }
+
+        @Override public void visitIntInsn(int opcode, int operand) {
+            updateFrame(new IntInsnNode(opcode, operand));
+            super.visitIntInsn(opcode, operand);
+        }
+
+        @Override public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
+            updateFrame(new InvokeDynamicInsnNode(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments));
+            super.visitInvokeDynamicInsn(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+        }
+
+        @Override public void visitJumpInsn(int opcode, Label label) {
+            updateFrame(new JumpInsnNode(opcode, new LabelNode(label)));
+            super.visitJumpInsn(opcode, label);
+        }
+
+        @Override public void visitLdcInsn(Object value) {
+            updateFrame(new LdcInsnNode(value));
+            super.visitLdcInsn(value);
+        }
+
+        @Override public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
+            updateFrame(new LookupSwitchInsnNode(new LabelNode(dflt), keys, intoLabelNodes(labels)));
+            super.visitLookupSwitchInsn(dflt, keys, labels);
+        }
+
+        @Override public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+            updateFrame(new MethodInsnNode(opcode, owner, name, descriptor, isInterface));
+            super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+        }
+
+        @Override public void visitMultiANewArrayInsn(String descriptor, int numDimensions) {
+            updateFrame(new MultiANewArrayInsnNode(descriptor, numDimensions));
+            super.visitMultiANewArrayInsn(descriptor, numDimensions);
+        }
+
+        @Override public void visitTableSwitchInsn(int min, int max, Label dflt, Label... labels) {
+            updateFrame(new TableSwitchInsnNode(min, max, new LabelNode(dflt), intoLabelNodes(labels)));
+            super.visitTableSwitchInsn(min, max, dflt, labels);
+        }
+
+        @Override public void visitTypeInsn(int opcode, String type) {
+            updateFrame(new TypeInsnNode(opcode, type));
+            super.visitTypeInsn(opcode, type);
+        }
+
+        @Override public void visitVarInsn(int opcode, int varIndex) {
+            updateFrame(new VarInsnNode(opcode, varIndex));
+            super.visitVarInsn(opcode, varIndex);
+        }
+    }
+}

--- a/src/core/lombok/bytecode/GeneratorPostTransformation.java
+++ b/src/core/lombok/bytecode/GeneratorPostTransformation.java
@@ -749,7 +749,7 @@ public class GeneratorPostTransformation implements PostCompilerTransformation {
                 if (frameType == null) {
                     break;
                 } else if (frameType == Opcodes.TOP) {
-                    continue;
+                    list.add(null);
                 } if (frameType == Opcodes.INTEGER) {
                     list.add(Type.INT_TYPE);
                 } else if (frameType == Opcodes.LONG) {

--- a/src/core/lombok/eclipse/handlers/HandleGenerator.java
+++ b/src/core/lombok/eclipse/handlers/HandleGenerator.java
@@ -27,6 +27,7 @@ import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
 
 import lombok.ConfigurationKeys;
 import lombok.core.AnnotationValues;
+import lombok.core.HandlerPriority;
 import lombok.core.AST.Kind;
 import lombok.eclipse.DeferUntilPostDiet;
 import lombok.eclipse.EclipseAnnotationHandler;
@@ -64,6 +65,7 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 
 @Provides
 @DeferUntilPostDiet
+@HandlerPriority(65536) // 2^16; Handler wraps entire method body, so it must be last.
 public class HandleGenerator extends EclipseAnnotationHandler<Generator> {
 	public void handle(AnnotationValues<Generator> annotation, Annotation ast, EclipseNode annotationNode) {
 		handleExperimentalFlagUsage(annotationNode, ConfigurationKeys.GENERATOR_FLAG_USAGE, "@Generator");

--- a/src/core/lombok/eclipse/handlers/HandleGenerator.java
+++ b/src/core/lombok/eclipse/handlers/HandleGenerator.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (C) 2023 The Project Lombok Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.eclipse.handlers;
+
+import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.eclipse.Eclipse.*;
+import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
+
+import lombok.ConfigurationKeys;
+import lombok.core.AnnotationValues;
+import lombok.core.AST.Kind;
+import lombok.eclipse.DeferUntilPostDiet;
+import lombok.eclipse.EclipseAnnotationHandler;
+import lombok.eclipse.EclipseNode;
+import lombok.experimental.Generator;
+import lombok.spi.Provides;
+
+import org.eclipse.jdt.internal.compiler.ASTVisitor;
+import org.eclipse.jdt.internal.compiler.CompilationResult;
+import org.eclipse.jdt.internal.compiler.ast.ASTNode;
+import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.AllocationExpression;
+import org.eclipse.jdt.internal.compiler.ast.Annotation;
+import org.eclipse.jdt.internal.compiler.ast.Expression;
+import org.eclipse.jdt.internal.compiler.ast.FieldReference;
+import org.eclipse.jdt.internal.compiler.ast.MessageSend;
+import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.ParameterizedQualifiedTypeReference;
+import org.eclipse.jdt.internal.compiler.ast.QualifiedSuperReference;
+import org.eclipse.jdt.internal.compiler.ast.QualifiedThisReference;
+import org.eclipse.jdt.internal.compiler.ast.ReturnStatement;
+import org.eclipse.jdt.internal.compiler.ast.SingleTypeReference;
+import org.eclipse.jdt.internal.compiler.ast.Statement;
+import org.eclipse.jdt.internal.compiler.ast.SuperReference;
+import org.eclipse.jdt.internal.compiler.ast.SynchronizedStatement;
+import org.eclipse.jdt.internal.compiler.ast.ThisReference;
+import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.TypeReference;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
+import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
+import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
+import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
+
+@Provides
+@DeferUntilPostDiet
+public class HandleGenerator extends EclipseAnnotationHandler<Generator> {
+	public void handle(AnnotationValues<Generator> annotation, Annotation ast, EclipseNode annotationNode) {
+		handleExperimentalFlagUsage(annotationNode, ConfigurationKeys.GENERATOR_FLAG_USAGE, "@Generator");
+
+        EclipseNode methodNode = annotationNode.up();
+        if (methodNode.getKind() != Kind.METHOD) {
+            annotationNode.addError("@Generator can only be applied to method");
+            return;
+        }
+
+        intoGeneratorMethod(ast, methodNode);
+
+		methodNode.rebuild();
+	}
+
+	private static TypeReference extractIteratorType(TypeReference typeReference) {
+		TypeReference[][] typeArguments = typeReference.getTypeArguments();
+
+		if (typeArguments.length > 0) {
+			TypeReference[] lastArguments = typeArguments[typeArguments.length - 1];
+			if (lastArguments.length > 0) {
+				return lastArguments[0];
+			}
+		}
+
+		return generateQualifiedTypeRef(typeReference, TypeConstants.JAVA_LANG_OBJECT);
+	}
+
+	private static void checkMethod(final EclipseNode node, final String innerClassName) {
+		MethodDeclaration methodDecl = (MethodDeclaration) node.get();
+
+        if (methodDecl.thrownExceptions != null && methodDecl.thrownExceptions.length > 0) {
+            node.addWarning("throws in generator method does nothing");
+        }
+
+        if ((methodDecl.modifiers & ClassFileConstants.AccSynchronized) != 0) {
+            node.addError("Generator method cannot be synchronized");
+        }
+
+		methodDecl.traverse(new ASTVisitor() {
+			private int synchronizedDepth = 0;
+
+			@Override public boolean visit(MessageSend messageSend, BlockScope scope) {
+				String name = new String(messageSend.selector);
+				if (
+					synchronizedDepth > 0
+					&& messageSend.receiverIsImplicitThis()
+					&& ("yieldThis".equals(name) || "yieldAll".equals(name))
+					&& messageSend.arguments != null
+					&& messageSend.arguments.length == 1
+				) {
+					node.addError(
+						"Cannot yield inside synchronized block",
+						messageSend.sourceStart,
+						messageSend.sourceEnd
+					);
+				}
+
+				if (
+					messageSend.receiverIsImplicitThis()
+					&& "advance".equals(name)
+					&& (messageSend.arguments == null || messageSend.arguments.length == 0)
+				) {
+					node.addError(
+						"Cannot call advance method directly in generater method",
+						messageSend.sourceStart,
+						messageSend.sourceEnd
+					);
+				}
+
+				return super.visit(messageSend, scope);
+			}
+
+			// Ignore local class
+			@Override public boolean visit(TypeDeclaration localTypeDeclaration, BlockScope scope) {
+				return false;
+			}
+
+			private void checkClassName(ASTNode targetNode, String token) {
+				if (innerClassName.equals(token)) {
+					node.addError(
+						innerClassName + " is used internally in generater method",
+						targetNode.sourceStart,
+						targetNode.sourceEnd
+					);
+				}
+			}
+
+			@Override public boolean visit(SingleTypeReference singleTypeReference, BlockScope scope) {
+				checkClassName(singleTypeReference, new String(singleTypeReference.token));
+
+				return super.visit(singleTypeReference, scope);
+			}
+
+			@Override public boolean visit(SynchronizedStatement synchronizedStatement, BlockScope scope) {
+				synchronizedDepth++;
+				return super.visit(synchronizedStatement, scope);
+			}
+
+			@Override public void endVisit(SynchronizedStatement synchronizedStatement, BlockScope scope) {
+				synchronizedDepth--;
+				super.endVisit(synchronizedStatement, scope);
+			}
+		}, (ClassScope) null);
+	}
+
+	private static void intoGeneratorMethod(ASTNode ast, EclipseNode sourceMethod) {
+		MethodDeclaration methodDecl = (MethodDeclaration) sourceMethod.get();
+		TypeDeclaration typeDecl = (TypeDeclaration) sourceMethod.up().get();
+
+		String className = "__Generator";
+
+		checkMethod(sourceMethod, className);
+
+		TypeDeclaration generatorClass = createGeneratorClass(
+			ast,
+			new SingleTypeReference(typeDecl.name, 0),
+			methodDecl.compilationResult,
+			className,
+			extractIteratorType(methodDecl.returnType),
+			methodDecl.statements
+		);
+
+		AllocationExpression newExpr = new AllocationExpression();
+		newExpr.type = new SingleTypeReference(generatorClass.name, 0);
+
+		ReturnStatement returnStatement = new ReturnStatement(newExpr, 0, 0);
+		returnStatement.traverse(new SetGeneratedByVisitor(ast), null);
+
+		methodDecl.statements = new Statement[] {
+			generatorClass,
+			returnStatement
+		};
+		methodDecl.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
+	}
+
+	private static TypeDeclaration createGeneratorClass(
+		ASTNode ast,
+		TypeReference classType,
+		CompilationResult result,
+		String name,
+		TypeReference type,
+		Statement[] statements
+	) {
+		TypeDeclaration innerClass = new TypeDeclaration(result);
+		innerClass.name = name.toCharArray();
+
+		innerClass.modifiers |= ClassFileConstants.AccFinal;
+		innerClass.superclass = new ParameterizedQualifiedTypeReference(
+			new char[][] { "lombok".toCharArray(), "Lombok".toCharArray(), "Generator".toCharArray() },
+			new TypeReference[][] { null, null, new TypeReference[] { copyType(type) } },
+			0,
+			new long[3]
+		);
+
+		innerClass.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
+
+		MethodDeclaration advanceMethod = new MethodDeclaration(result);
+		advanceMethod.modifiers = ClassFileConstants.AccProtected;
+		advanceMethod.returnType = TypeReference.baseTypeReference(TypeIds.T_void, 0);
+		advanceMethod.annotations = null;
+		advanceMethod.arguments = null;
+		advanceMethod.selector = "advance".toCharArray();
+		advanceMethod.binding = null;
+		advanceMethod.thrownExceptions = null;
+		advanceMethod.typeParameters = null;
+
+		innerClass.methods = new AbstractMethodDeclaration[] {
+			innerClass.createDefaultConstructor(false, false),
+			advanceMethod
+		};
+
+		innerClass.traverse(new SetGeneratedByVisitor(ast), (ClassScope) null);
+
+		remapThisSuper(classType, statements);
+		advanceMethod.statements = statements;
+
+		return innerClass;
+	}
+
+	private static void remapThisSuper(final TypeReference classType, Statement[] statements) {
+		ASTVisitor remapper = new ASTVisitor() {
+			private Expression updateReceiver(ASTNode node, Expression expression) {
+				Class<?> clazz = expression.getClass();
+
+				if (clazz == SuperReference.class) {
+					return new QualifiedSuperReference(
+						copyType(classType, node),
+						node.sourceStart,
+						node.sourceEnd
+					);
+				} else if (clazz == ThisReference.class && !expression.isImplicitThis()) {
+					return new QualifiedThisReference(
+						copyType(classType, node),
+						node.sourceStart,
+						node.sourceEnd
+					);
+				}
+
+				return null;
+			}
+
+			@Override public boolean visit(MessageSend messageSend, BlockScope scope) {
+				Expression updated = updateReceiver(messageSend, messageSend.receiver);
+				if (updated != null) {
+					messageSend.receiver = updated;
+				}
+
+				return super.visit(messageSend, scope);
+			}
+
+			@Override public boolean visit(FieldReference fieldReference, BlockScope scope) {
+				Expression updated = updateReceiver(fieldReference, fieldReference.receiver);
+				if (updated != null) {
+					fieldReference.receiver = updated;
+				}
+
+				return super.visit(fieldReference, scope);
+			}
+		};
+
+		for (Statement statement : statements) {
+			statement.traverse(remapper, null);
+		}
+	}
+}

--- a/src/core/lombok/experimental/Generator.java
+++ b/src/core/lombok/experimental/Generator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.experimental;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The {@code Generator} annotation allows user to write iterator easily.
+ * <p>
+ * By adding {@code @Generator} to method, user can use {@code yieldThis} or {@code yieldAll}
+ * to suspend execution and yield values to iterator.
+ * <p>
+ * The method's return type must be one of {@code java.lang.Iterable} or {@code java.util.Iterator}
+ * as it will return iterator (or iterable returning self as iterator).
+ * <p>
+ * Example
+ * <pre>
+ * &#64;Generator
+ * public Iterable&lt;Integer&gt; range(int from, int to) {
+ *  for (int i = from; i < to; i++) {
+ *      yieldThis(i);
+ *  }
+ * }
+ * </pre>
+ * Calling {@code range(0, 10)} will create iterator returning from 0 to 9.
+ * <p>
+ * Example code will be expanded like below
+ * <pre>
+ * public Iterable&lt;Integer&gt; range(int from, int to) {
+ *  class __Generator extends lombok.Lombok.Generator&lt;Integer&gt; {
+ *      protected void advance() {
+ *          for (int i = from; i < to; i++) {
+ *              yieldThis(i);
+ *          }
+ *      }
+ *  }
+ *  return new __Generator();
+ * </pre>
+ * Note: Class extending {@code lombok.Lombok.Generator} is transformed in bytecode level into state machine after compiled.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Generator {}

--- a/src/core/lombok/javac/handlers/HandleGenerator.java
+++ b/src/core/lombok/javac/handlers/HandleGenerator.java
@@ -171,7 +171,7 @@ public class HandleGenerator extends JavacAnnotationHandler<Generator> {
             block,
             null
         );
-        bodyBuffer.add(advanceDecl);
+        bodyBuffer.append(advanceDecl);
 
         return treeMaker.ClassDef(
             treeMaker.Modifiers(Flags.FINAL),

--- a/src/core/lombok/javac/handlers/HandleGenerator.java
+++ b/src/core/lombok/javac/handlers/HandleGenerator.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2023 The Project Lombok Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.javac.handlers;
+
+import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.javac.Javac.*;
+import static lombok.javac.handlers.JavacHandlerUtil.*;
+
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.ListBuffer;
+
+import lombok.ConfigurationKeys;
+import lombok.core.AnnotationValues;
+import lombok.core.AST.Kind;
+import lombok.experimental.Generator;
+import lombok.javac.JavacAST;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.javac.JavacTreeMaker;
+
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.TreeScanner;
+import com.sun.tools.javac.tree.JCTree.*;
+import lombok.spi.Provides;
+
+@Provides
+public class HandleGenerator extends JavacAnnotationHandler<Generator> {
+    @Override public void handle(AnnotationValues<Generator> annotation, JCAnnotation ast, JavacNode annotationNode) {
+        handleExperimentalFlagUsage(annotationNode, ConfigurationKeys.GENERATOR_FLAG_USAGE, "@Generator");
+        deleteAnnotationIfNeccessary(annotationNode, Generator.class);
+
+        JavacNode methodNode = annotationNode.up();
+        if (methodNode.getKind() != Kind.METHOD) {
+            annotationNode.addError("@Generator can only be applied to method");
+            return;
+        }
+
+        intoGeneratorMethod(methodNode);
+        recursiveSetGeneratedBy(methodNode.get(), annotationNode);
+        methodNode.rebuild();
+    }
+
+    private static JCExpression extractIteratorType(JavacNode node, JCExpression type) {
+        if (type instanceof JCTypeApply) {
+            return ((JCTypeApply) type).arguments.head;
+        }
+
+        return genJavaLangTypeRef(node, "Object");
+    }
+
+    private static void checkMethod(final JavacNode node, final String innerClassName) {
+        JCMethodDecl methodDecl = (JCMethodDecl) node.get();
+
+        if (!methodDecl.thrown.isEmpty()) {
+            node.addWarning("throws in generator method does nothing", methodDecl.pos());
+        }
+
+        if ((methodDecl.mods.flags & Flags.SYNCHRONIZED) != 0) {
+            node.addError("Generator method cannot be synchronized", methodDecl.pos());
+        }
+
+        methodDecl.accept(new TreeScanner() {
+            private int synchronizedDepth = 0;
+
+            @Override public void visitSynchronized(JCSynchronized arg0) {
+                synchronizedDepth++;
+                super.visitSynchronized(arg0);
+                synchronizedDepth--;
+            }
+
+            // Ignore inner class
+            @Override public void visitClassDef(JCClassDecl arg0) {}
+
+            @Override public void visitIdent(JCIdent arg0) {
+                if (innerClassName.equals(arg0.name.toString())) {
+                    node.addError(innerClassName + " is used internally in generater method", arg0.pos());
+                }
+
+                super.visitIdent(arg0);
+            }
+
+            @Override public void visitApply(JCMethodInvocation arg0) {
+                String name = arg0.meth.toString();
+                if (synchronizedDepth > 0 && ("yieldThis".equals(name) || "yieldAll".equals(name))) {
+                    node.addError("Cannot yield inside synchronized block", arg0.pos());
+                }
+
+                if (arg0.meth instanceof JCIdent && "advance".equals(name) && arg0.args.isEmpty()) {
+                    node.addError("Cannot call advance method directly in generater method", arg0.pos());
+                }
+
+                super.visitApply(arg0);
+            }
+        });
+    }
+
+    public static void intoGeneratorMethod(JavacNode sourceMethod) {
+        JCMethodDecl methodDecl = (JCMethodDecl) sourceMethod.get();
+        JCClassDecl classDecl = (JCClassDecl) sourceMethod.up().get();
+        JavacAST ast = sourceMethod.getAst();
+        JavacTreeMaker treeMaker = ast.getTreeMaker();
+
+        String className = "__Generator";
+
+        checkMethod(sourceMethod, className);
+
+        JCClassDecl generatorDecl = createGeneratorClass(
+            sourceMethod,
+            treeMaker.Ident(classDecl.name),
+            className,
+            extractIteratorType(sourceMethod, methodDecl.restype),
+            methodDecl.body
+        );
+
+        JCBlock methodBody = treeMaker.Block(0, List.of(
+            generatorDecl,
+            treeMaker.Return(
+                treeMaker.NewClass(
+                    (JCExpression) null,
+                    List.<JCExpression>nil(),
+                    treeMaker.Ident(generatorDecl.name),
+                    List.<JCExpression>nil(),
+                    (JCClassDecl) null
+                )
+            )
+        ));
+
+        methodDecl.body = methodBody;
+    }
+
+    public static JCClassDecl createGeneratorClass(
+        JavacNode node,
+        JCExpression classExpr,
+        String name,
+        JCExpression type,
+        JCBlock block
+    ) {
+        JavacAST ast = node.getAst();
+        JavacTreeMaker treeMaker = ast.getTreeMaker();
+
+        ListBuffer<JCTree> bodyBuffer = new ListBuffer<JCTree>();
+
+        remapThisSuper(ast, classExpr, block);
+        JCMethodDecl advanceDecl = treeMaker.MethodDef(
+            treeMaker.Modifiers(Flags.PROTECTED),
+            ast.toName("advance"),
+            treeMaker.TypeIdent(CTC_VOID),
+            List.<JCTypeParameter>nil(),
+            List.<JCVariableDecl>nil(),
+            List.<JCExpression>nil(),
+            block,
+            null
+        );
+        bodyBuffer.add(advanceDecl);
+
+        return treeMaker.ClassDef(
+            treeMaker.Modifiers(Flags.FINAL),
+            ast.toName(name),
+            List.<JCTypeParameter>nil(),
+            treeMaker.TypeApply(chainDots(node, "lombok", "Lombok", "Generator"), List.of(type)),
+            List.<JCExpression>nil(),
+            bodyBuffer.toList()
+        );
+    }
+
+    /**
+     * Remap this, super selection to select outer class
+     */
+    private static <T extends JCTree> void remapThisSuper(final JavacAST ast, final JCExpression classExpr, T tree) {
+        tree.accept(new TreeScanner() {
+            @Override public void visitSelect(JCFieldAccess arg0) {
+                if (arg0.selected instanceof JCIdent) {
+                    String selected = arg0.selected.toString();
+                    if ("this".equals(selected) || "super".equals(selected)) {
+                        JavacTreeMaker treeMaker = ast.getTreeMaker().at(arg0.pos);
+                        arg0.selected = treeMaker.Select(classExpr, ((JCIdent) arg0.selected).name);
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/core/lombok/javac/handlers/HandleGenerator.java
+++ b/src/core/lombok/javac/handlers/HandleGenerator.java
@@ -30,6 +30,7 @@ import com.sun.tools.javac.util.ListBuffer;
 
 import lombok.ConfigurationKeys;
 import lombok.core.AnnotationValues;
+import lombok.core.HandlerPriority;
 import lombok.core.AST.Kind;
 import lombok.experimental.Generator;
 import lombok.javac.JavacAST;
@@ -44,6 +45,7 @@ import com.sun.tools.javac.tree.JCTree.*;
 import lombok.spi.Provides;
 
 @Provides
+@HandlerPriority(65536) // 2^16; Handler wraps entire method body, so it must be last.
 public class HandleGenerator extends JavacAnnotationHandler<Generator> {
     @Override public void handle(AnnotationValues<Generator> annotation, JCAnnotation ast, JavacNode annotationNode) {
         handleExperimentalFlagUsage(annotationNode, ConfigurationKeys.GENERATOR_FLAG_USAGE, "@Generator");

--- a/test/transform/resource/after-delombok/GeneratorSuper.java
+++ b/test/transform/resource/after-delombok/GeneratorSuper.java
@@ -1,0 +1,15 @@
+public class GeneratorSuper extends SuperClass {
+    public Iterable<Integer> yieldSuperField() {
+
+        final class __Generator extends lombok.Lombok.Generator<Integer> {
+            protected void advance() {
+                yieldThis(GeneratorSuper.super.variable);
+            }
+        }
+        return new __Generator();
+    }
+}
+
+class SuperClass {
+    int variable;
+}

--- a/test/transform/resource/after-delombok/GeneratorThis.java
+++ b/test/transform/resource/after-delombok/GeneratorThis.java
@@ -1,0 +1,13 @@
+public class GeneratorThis {
+    int variable = 2;
+
+    public Iterable<Integer> yieldThisField() {
+
+        final class __Generator extends lombok.Lombok.Generator<Integer> {
+            protected void advance() {
+                yieldThis(GeneratorThis.this.variable);
+            }
+        }
+        return new __Generator();
+    }
+}

--- a/test/transform/resource/after-ecj/GeneratorSuper.java
+++ b/test/transform/resource/after-ecj/GeneratorSuper.java
@@ -1,0 +1,22 @@
+public class GeneratorSuper extends SuperClass {
+  public GeneratorSuper() {
+    super();
+  }
+  public @lombok.experimental.Generator Iterable<Integer> yieldSuperField() {
+    final class __Generator extends lombok.Lombok.Generator<Integer> {
+      __Generator() {
+      }
+      protected void advance() {
+        yieldThis(GeneratorSuper.super.variable);
+      }
+    }
+    return new __Generator();
+  }
+}
+
+class SuperClass {
+  int variable;
+  SuperClass() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/GeneratorThis.java
+++ b/test/transform/resource/after-ecj/GeneratorThis.java
@@ -1,0 +1,16 @@
+public class GeneratorThis {
+  int variable = 2;
+  public GeneratorThis() {
+    super();
+  }
+  public @lombok.experimental.Generator Iterable<Integer> yieldThisField() {
+    final class __Generator extends lombok.Lombok.Generator<Integer> {
+      __Generator() {
+      }
+      protected void advance() {
+        yieldThis(GeneratorThis.this.variable);
+      }
+    }
+    return new __Generator();
+  }
+}

--- a/test/transform/resource/before/GeneratorSuper.java
+++ b/test/transform/resource/before/GeneratorSuper.java
@@ -1,0 +1,10 @@
+public class GeneratorSuper extends SuperClass {
+    @lombok.experimental.Generator
+    public Iterable<Integer> yieldSuperField() {
+        yieldThis(super.variable);
+    }
+}
+
+class SuperClass {
+    int variable;
+}

--- a/test/transform/resource/before/GeneratorThis.java
+++ b/test/transform/resource/before/GeneratorThis.java
@@ -1,0 +1,8 @@
+public class GeneratorThis {
+    int variable = 2;
+
+    @lombok.experimental.Generator
+    public Iterable<Integer> yieldThisField() {
+        yieldThis(this.variable);
+    }
+}

--- a/website/templates/features/experimental/Generator.html
+++ b/website/templates/features/experimental/Generator.html
@@ -1,0 +1,44 @@
+<#import "../_features.html" as f>
+
+<@f.scaffold title="@Generator" logline="Iterate, execute, and yield. Finally creating iterator became easy.">
+	<@f.history>
+		<p>
+			<code>@Generator</code> was introduced as experimental feature in lombok v0.18.27.
+		</p>
+	</@f.history>
+	
+	<@f.experimental>
+		<ul>
+			<li>
+				Unstable feature. This feature is not tested extensively and needs more experiment.
+			</li>
+		</ul>
+	</@f.experimental>
+
+	<@f.overview>
+		<p>
+			Generator, also known as Sequence is a form of iterator which can be yielded and resumed later.  Their context(variable declarations) will be saved for future resumption.
+		</p><p>
+			By default method annotated with <code>@Generator</code> will not be run immediately on called. Instead the method returns <code>Iterator</code>(or <code>Iterable</code>). By calling <code>next</code> method of iterator it will be executed until next <code>yieldThis</code> statement is met, which is the next value of iterator, or with <code>yieldAll</code> statement, delegates to another iterable object. The <code>next</code> or <code>hasNext</code> method will resume iterator and buffer next yielded value if there is no buffered value. Additionally the <code>next</code> method will return buffered value and remove it.
+		</p><p>
+			All statements containing control flow change statements including <code>yieldThis</code>, <code>yieldAll</code>, <code>return</code>, <code>break</code>, <code>continue</code> and <code>throw</code> will be transformed.<br />
+			All local variables will be captured as a field. Captured objects can be garbage collected just like local variables.
+		</p>
+	</@f.overview>
+
+	<@f.snippets name="experimental/Generator" />
+
+	<@f.confKeys>
+		<dt>
+			<code>lombok.generator.flagUsage</code> = [<code>warning</code> | <code>error</code>] (default: not set)
+		</dt><dd>
+			Lombok will flag any usage of <code>@Generator</code> as a warning or error if configured.
+		</dd>
+	</@f.confKeys>
+
+	<@f.smallPrint>
+		<p>
+			When using <code>yieldAll</code> statement, using primitive type array is impossible to use due to limitation.
+		</p>
+	</@f.smallPrint>
+</@f.scaffold>

--- a/website/templates/features/experimental/index.html
+++ b/website/templates/features/experimental/index.html
@@ -75,6 +75,10 @@
 			<@main.feature title="@StandardException" href="StandardException">
 				Standard.. Exceptional? This is not just an oxymoron, it's convenient!
 			</@main.feature>
+			
+			<@main.feature title="@Generator" href="Generator">
+				Iterate, execute, and yield. Finally creating iterator became easy.
+			</@main.feature>
 		</div>
 
 		<@f.confKeys>

--- a/website/usageExamples/experimental/GeneratorExample_post.jpage
+++ b/website/usageExamples/experimental/GeneratorExample_post.jpage
@@ -1,0 +1,28 @@
+import lombok.experimental.Generator;
+
+public class GeneratorExample {
+	@Generator
+	public Iterable<Integer> range(int from, int to) {
+		class __Generator extends lombok.Lombok.Generator<Integer> {
+			protected void advance() {
+				for (int i = from; i < to; i++) {
+					yieldThis(i);
+				}
+			}
+		}
+		return new __Generator();
+	}
+
+	@SafeVarargs
+	@Generator
+	public final <T> Iterable<T> join(Iterable<T>... iters) {
+		class __Generator extends lombok.Lombok.Generator<T> {
+			protected void advance() {
+				for (Iterable<T> iter : iters) {
+					yieldAll(iter);
+				}
+			}
+		}
+		return new __Generator();
+	}
+}

--- a/website/usageExamples/experimental/GeneratorExample_pre.jpage
+++ b/website/usageExamples/experimental/GeneratorExample_pre.jpage
@@ -1,0 +1,18 @@
+import lombok.experimental.Generator;
+
+public class GeneratorExample {
+	@Generator
+	public Iterable<Integer> range(int from, int to) {
+		for (int i = from; i < to; i++) {
+			yieldThis(i);
+		}
+	}
+
+	@SafeVarargs
+	@Generator
+	public final <T> Iterable<T> join(Iterable<T>... iters) {
+		for (Iterable<T> iter : iters) {
+			yieldAll(iter);
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces `@Generator` annotation.

`@Generator` annotation converts normal method into generator(lazily evaluated iterator). It provides a easy way to create custom iterators. Creating iterators by hand are very hard and complex.

Using `@Generator` annotation, user can suspend execution and yield values to iterator using `yieldThis` or `yieldAll` statement. The method must return `Iterable` or `Iterator`.

This PR closes #560 (Same functionality)

## Transformation steps
1. The code in method annotated with `@Generator` is wrapped with internal local class `__Generator` by handler. The `__Generator` class extends `lombok.Lombok.Generator` which is stub class implementing `Iterable`, `Iterator`. The stub class also have blank `yieldThis`, `yieldAll` method declaration.
2. Classes extending `lombok.Lombok.Generator` class is transformed in post compiler phase using bytecode manipulation. The transformer remove stub class, capture every local variable into field, and transform `yieldThis`, `yieldAll` statements. Efficiently transforms into state machine.

## Code example
Method `range` yields number from `from` to `to`, and method `join` delegates multiple iterables by order.

With Lombok
```java
import lombok.experimental.Generator;

public class GeneratorExample {
    @Generator
    public Iterable<Integer> range(int from, int to) {
        for (int i = from; i < to; i++) {
            yieldThis(i);
        }
    }

    @SafeVarargs
    @Generator
    public final <T> Iterable<T> join(Iterable<T>... iters) {
        for (Iterable<T> iter : iters) {
            yieldAll(iter);
        }
    }
}
```

Generated code by Lombok handler
```java
public class GeneratorExample {
    public Iterable<Integer> range(int from, int to) {
        class __Generator extends lombok.Lombok.Generator<Integer> {
            protected void advance() {
                for (int i = from; i < to; i++) {
                    yieldThis(i);
                }
            }
        }
        return new __Generator();
    }

    @SafeVarargs
    public final <T> Iterable<T> join(Iterable<T>... iters) {
        class __Generator extends lombok.Lombok.Generator<T> {
            protected void advance() {
                for (Iterable<T> iter : iters) {
                    yieldAll(iter);
                }
            }
        }
        return new __Generator();
    }
}
```

After bytecode manipulation, cannot be decompiled into java code.
