### PR TITLE
Find references for extension methods

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -918,6 +918,13 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 			.request(StackRequest.THIS)
 			.wrapMethod(new Hook(PATCH_EXTENSIONMETHOD_COMPLETIONPROPOSAL_PORTAL, "getJavaCompletionProposals", I_JAVA_COMPLETION_PROPOSAL_SIG, "java.lang.Object[]", "java.lang.Object"))
 			.build());
+		
+		sm.addScriptIfWitness(OSGI_TYPES, ScriptBuilder.wrapReturnValue()
+			.target(new MethodTarget("org.eclipse.jdt.core.search.SearchPattern", "createPattern", "org.eclipse.jdt.core.search.SearchPattern", "org.eclipse.jdt.core.IJavaElement", "int", "int"))
+			.wrapMethod(new Hook(PATCH_EXTENSIONMETHOD, "modifyMethodPattern", "java.lang.Object", "java.lang.Object"))
+			.cast()
+			.request(StackRequest.RETURN_VALUE)
+			.build());
 	}
 
 	private static void patchNullCheck(ScriptManager sm) {

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
@@ -43,6 +43,7 @@ import lombok.eclipse.handlers.EclipseHandlerUtil;
 import lombok.experimental.ExtensionMethod;
 import lombok.permit.Permit;
 
+import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
 import org.eclipse.jdt.internal.compiler.ast.ClassLiteralAccess;
@@ -66,6 +67,7 @@ import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
+import org.eclipse.jdt.internal.core.search.matching.MethodPattern;
 
 public class PatchExtensionMethod {
 	static class Extension {
@@ -377,6 +379,17 @@ public class PatchExtensionMethod {
 		
 		MessageSend_postponedErrors.clear(methodCall);
 		return resolvedType;
+	}
+	
+	public static SearchPattern modifyMethodPattern(SearchPattern original) {
+		if (original != null && original instanceof MethodPattern) {
+			MethodPattern methodPattern = (MethodPattern) original;
+			if (methodPattern.parameterCount > 0) {
+				methodPattern.varargs = true;
+			}
+		}
+		
+		return original;
 	}
 
 	private static boolean requiresPolyBinding(Expression argument) {

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -335,6 +335,7 @@ final class PatchFixesHider {
 		private static final Method ERROR_NO_METHOD_FOR;
 		private static final Method INVALID_METHOD, INVALID_METHOD2;
 		private static final Method NON_STATIC_ACCESS_TO_STATIC_METHOD;
+		private static final Method MODIFY_METHOD_PATTERN;
 		
 		static {
 			Class<?> shadowed = Util.shadowLoadClass("lombok.eclipse.agent.PatchExtensionMethod");
@@ -343,6 +344,7 @@ final class PatchFixesHider {
 			INVALID_METHOD = Util.findMethod(shadowed, "invalidMethod", PROBLEM_REPORTER_SIG, MESSAGE_SEND_SIG, METHOD_BINDING_SIG);
 			INVALID_METHOD2 = Util.findMethod(shadowed, "invalidMethod", PROBLEM_REPORTER_SIG, MESSAGE_SEND_SIG, METHOD_BINDING_SIG, SCOPE_SIG);
 			NON_STATIC_ACCESS_TO_STATIC_METHOD = Util.findMethod(shadowed, "nonStaticAccessToStaticMethod", PROBLEM_REPORTER_SIG, AST_NODE_SIG, METHOD_BINDING_SIG, MESSAGE_SEND_SIG);
+			MODIFY_METHOD_PATTERN = Util.findMethod(shadowed, "modifyMethodPattern", "org.eclipse.jdt.core.search.SearchPattern");
 		}
 		
 		public static Object resolveType(Object resolvedType, Object methodCall, Object scope) {
@@ -363,6 +365,10 @@ final class PatchFixesHider {
 		
 		public static void nonStaticAccessToStaticMethod(Object problemReporter, Object location, Object method, Object messageSend) {
 			Util.invokeMethod(NON_STATIC_ACCESS_TO_STATIC_METHOD, problemReporter, location, method, messageSend);
+		}
+		
+		public static Object modifyMethodPattern(Object original) {
+			return Util.invokeMethod(MODIFY_METHOD_PATTERN, original);
 		}
 	}
 	

--- a/test/eclipse/resource/findreferences/extensionMethod/Extension.java
+++ b/test/eclipse/resource/findreferences/extensionMethod/Extension.java
@@ -1,0 +1,15 @@
+package pkg;
+
+public static class Extension {
+	public static String test(String s) {
+		return s;
+	}
+	
+	public static String test(String s, int i) {
+		return s;
+	}
+	
+	public static String test(String s, String... s2) {
+		return s;
+	}
+}

--- a/test/eclipse/resource/findreferences/extensionMethod/Usage.java
+++ b/test/eclipse/resource/findreferences/extensionMethod/Usage.java
@@ -1,0 +1,13 @@
+package pkg;
+
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod(Extension.class)
+public class Usage {
+	public void test() {
+		private String string;
+		string.test();
+		string.test("a");
+		string.test(1);
+	}
+}

--- a/test/eclipse/resource/rename/extensionMethod/after/Extension.java
+++ b/test/eclipse/resource/rename/extensionMethod/after/Extension.java
@@ -1,0 +1,15 @@
+package pkg;
+
+public static class Extension {
+	public static String newTest(String s) {
+		return s;
+	}
+	
+	public static String test(String s, int i) {
+		return s;
+	}
+	
+	public static String test(String s, String... s2) {
+		return s;
+	}
+}

--- a/test/eclipse/resource/rename/extensionMethod/after/Usage.java
+++ b/test/eclipse/resource/rename/extensionMethod/after/Usage.java
@@ -1,0 +1,13 @@
+package pkg;
+
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod(Extension.class)
+public class Usage {
+	public void test() {
+		private String string;
+		string.newTest();
+		string.test("a");
+		string.test(1);
+	}
+}

--- a/test/eclipse/resource/rename/extensionMethod/before/Extension.java
+++ b/test/eclipse/resource/rename/extensionMethod/before/Extension.java
@@ -1,0 +1,15 @@
+package pkg;
+
+public static class Extension {
+	public static String test(String s) {
+		return s;
+	}
+	
+	public static String test(String s, int i) {
+		return s;
+	}
+	
+	public static String test(String s, String... s2) {
+		return s;
+	}
+}

--- a/test/eclipse/resource/rename/extensionMethod/before/Usage.java
+++ b/test/eclipse/resource/rename/extensionMethod/before/Usage.java
@@ -1,0 +1,13 @@
+package pkg;
+
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod(Extension.class)
+public class Usage {
+	public void test() {
+		private String string;
+		string.test();
+		string.test("a");
+		string.test(1);
+	}
+}

--- a/test/eclipse/src/lombok/eclipse/EclipseTests.java
+++ b/test/eclipse/src/lombok/eclipse/EclipseTests.java
@@ -8,9 +8,10 @@ import lombok.eclipse.cleanup.CleanupTest;
 import lombok.eclipse.edit.SelectTest;
 import lombok.eclipse.refactoring.ExtractInterfaceTest;
 import lombok.eclipse.refactoring.RenameTest;
+import lombok.eclipse.references.FindReferencesTest;
 
 @RunWith(Suite.class)
-@SuiteClasses({ExtractInterfaceTest.class, RenameTest.class, SelectTest.class, CleanupTest.class})
+@SuiteClasses({ExtractInterfaceTest.class, RenameTest.class, SelectTest.class, CleanupTest.class, FindReferencesTest.class})
 public class EclipseTests {
 	
 }

--- a/test/eclipse/src/lombok/eclipse/SetupBeforeAfterTest.java
+++ b/test/eclipse/src/lombok/eclipse/SetupBeforeAfterTest.java
@@ -32,7 +32,7 @@ public class SetupBeforeAfterTest extends SetupTest {
 	protected void succeeded(Description description) {
 		try {
 			compareWithAfter();
-		} catch (Throwable e) {
+		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/test/eclipse/src/lombok/eclipse/refactoring/RenameTest.java
+++ b/test/eclipse/src/lombok/eclipse/refactoring/RenameTest.java
@@ -4,8 +4,11 @@ import static lombok.eclipse.RefactoringUtils.performRefactoring;
 
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.internal.corext.refactoring.rename.RenameFieldProcessor;
+import org.eclipse.jdt.internal.corext.refactoring.rename.RenameMethodProcessor;
+import org.eclipse.jdt.internal.corext.refactoring.rename.RenameNonVirtualMethodProcessor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -67,5 +70,17 @@ public class RenameTest {
 		renameFieldProcessor.setNewElementName("newString");
 		
 		performRefactoring(renameFieldProcessor);
+	}
+	
+	@Test
+	public void extensionMethod() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("Extension.java");
+		IType type = cu.findPrimaryType();
+		IMethod method = type.getMethods()[0];
+		
+		RenameMethodProcessor renameMethodProcessor = new RenameNonVirtualMethodProcessor(method);
+		renameMethodProcessor.setNewElementName("newTest");
+		
+		performRefactoring(renameMethodProcessor);
 	}
 }

--- a/test/eclipse/src/lombok/eclipse/references/FindReferencesTest.java
+++ b/test/eclipse/src/lombok/eclipse/references/FindReferencesTest.java
@@ -1,0 +1,56 @@
+package lombok.eclipse.references;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.internal.corext.refactoring.CollectingSearchRequestor;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import lombok.eclipse.EclipseRunner;
+import lombok.eclipse.SetupSingleFileTest;
+
+@RunWith(EclipseRunner.class)
+public class FindReferencesTest {
+	
+	@Rule
+	public SetupSingleFileTest setup = new SetupSingleFileTest();
+	
+	@Test
+	public void extensionMethod() throws Exception {
+		ICompilationUnit extensionCu = setup.getPackageFragment().getCompilationUnit("Extension.java");
+		IType type = extensionCu.findPrimaryType();
+		List<SearchMatch> firstResult = searchInProject(type.getMethods()[0]);
+		assertEquals(firstResult.size(), 2);
+		
+		ICompilationUnit usageCu = setup.getPackageFragment().getCompilationUnit("Usage.java");
+		List<SearchMatch> secondResult = searchInProject(usageCu.codeSelect(170, 0)[0]);
+		assertEquals(secondResult.size(), 2);
+	}
+
+	private List<SearchMatch> searchInProject(IJavaElement element) throws CoreException, JavaModelException {
+		CollectingSearchRequestor requestor = new CollectingSearchRequestor();
+		SearchEngine engine = new SearchEngine();
+		engine.search(
+			SearchPattern.createPattern(element, IJavaSearchConstants.ALL_OCCURRENCES, SearchPattern.R_EXACT_MATCH), 
+			new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, 
+			SearchEngine.createJavaSearchScope(new IJavaElement[] { setup.getJavaProject() }), 
+			requestor, 
+			null
+		);
+		
+		return requestor.getResults();
+	}
+}


### PR DESCRIPTION
This PR fixes #3373

To find references eclipse uses an index that is based on method parameters. A extension method definition always has one parameter more than the reference. To find all matching methods the patch modifies the search pattern to always assume varargs. The search logic removes non-matching methods in a later step.

There might be some unintended side effects...