### PR TITLE
Remove eclipse specific classes in ExtensionMethod patch signatures

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
@@ -43,7 +43,6 @@ import lombok.eclipse.handlers.EclipseHandlerUtil;
 import lombok.experimental.ExtensionMethod;
 import lombok.permit.Permit;
 
-import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
 import org.eclipse.jdt.internal.compiler.ast.ClassLiteralAccess;
@@ -381,7 +380,7 @@ public class PatchExtensionMethod {
 		return resolvedType;
 	}
 	
-	public static SearchPattern modifyMethodPattern(SearchPattern original) {
+	public static Object modifyMethodPattern(Object original) {
 		if (original != null && original instanceof MethodPattern) {
 			MethodPattern methodPattern = (MethodPattern) original;
 			if (methodPattern.parameterCount > 0) {

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -353,7 +353,7 @@ final class PatchFixesHider {
 			INVALID_METHOD = Util.findMethod(shadowed, "invalidMethod", PROBLEM_REPORTER_SIG, MESSAGE_SEND_SIG, METHOD_BINDING_SIG);
 			INVALID_METHOD2 = Util.findMethod(shadowed, "invalidMethod", PROBLEM_REPORTER_SIG, MESSAGE_SEND_SIG, METHOD_BINDING_SIG, SCOPE_SIG);
 			NON_STATIC_ACCESS_TO_STATIC_METHOD = Util.findMethod(shadowed, "nonStaticAccessToStaticMethod", PROBLEM_REPORTER_SIG, AST_NODE_SIG, METHOD_BINDING_SIG, MESSAGE_SEND_SIG);
-			MODIFY_METHOD_PATTERN = Util.findMethod(shadowed, "modifyMethodPattern", "org.eclipse.jdt.core.search.SearchPattern");
+			MODIFY_METHOD_PATTERN = Util.findMethod(shadowed, "modifyMethodPattern", Object.class);
 		}
 		
 		public static Object resolveType(Object resolvedType, Object methodCall, Object scope) {


### PR DESCRIPTION
#3376 added a method that uses a eclipse only class in its signature. This breaks ecj. This PR replaces the type in the signature with `j.l.Object`.