### PR TITLE
Ignore annotations during array detection 

### DIFF
--- a/src/core/lombok/javac/handlers/HandleToString.java
+++ b/src/core/lombok/javac/handlers/HandleToString.java
@@ -206,7 +206,7 @@ public class HandleToString extends JavacAnnotationHandler<ToString> {
 				memberAccessor = createFieldAccessor(maker, memberNode, fieldAccess);
 			}
 			
-			JCExpression memberType = getFieldType(memberNode, fieldAccess);
+			JCExpression memberType = removeTypeUseAnnotations(getFieldType(memberNode, fieldAccess));
 			
 			// The distinction between primitive and object will be useful if we ever add a 'hideNulls' option.
 			@SuppressWarnings("unused")

--- a/src/utils/lombok/permit/Permit.java
+++ b/src/utils/lombok/permit/Permit.java
@@ -297,9 +297,9 @@ public class Permit {
 		}
 	}
 	
-	public static Object get(Field f, Object receiver) throws IllegalAccessException {
+	public static <T> T get(Field f, Object receiver) throws IllegalAccessException {
 		try {
-			return f.get(receiver);
+			return (T) f.get(receiver);
 		} catch (IllegalAccessException e) {
 			handleReflectionDebug(e, null);
 			throw e;

--- a/test/transform/resource/after-delombok/ToStringArray.java
+++ b/test/transform/resource/after-delombok/ToStringArray.java
@@ -1,0 +1,13 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+public class ToStringArray {
+	int[] primitiveArray;
+	Object[] objectArray;
+
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	public java.lang.String toString() {
+		return "ToStringArray(primitiveArray=" + java.util.Arrays.toString(this.primitiveArray) + ", objectArray=" + java.util.Arrays.deepToString(this.objectArray) + ")";
+	}
+}

--- a/test/transform/resource/after-delombok/ToStringArrayTypeAnnotations.java
+++ b/test/transform/resource/after-delombok/ToStringArrayTypeAnnotations.java
@@ -1,3 +1,4 @@
+//version 8:
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 

--- a/test/transform/resource/after-delombok/ToStringArrayTypeAnnotations.java
+++ b/test/transform/resource/after-delombok/ToStringArrayTypeAnnotations.java
@@ -1,0 +1,22 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+public class ToStringArrayTypeAnnotations {
+	@TA
+	int[] primitiveArray1;
+	int @TA [] primitiveArray2;
+	@TA
+	Object[] objectArray1;
+	Object @TA [] objectArray2;
+
+
+	@Target({ElementType.TYPE_USE})
+	@interface TA {
+	}
+
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	public java.lang.String toString() {
+		return "ToStringArrayTypeAnnotations(primitiveArray1=" + java.util.Arrays.toString(this.primitiveArray1) + ", primitiveArray2=" + java.util.Arrays.toString(this.primitiveArray2) + ", objectArray1=" + java.util.Arrays.deepToString(this.objectArray1) + ", objectArray2=" + java.util.Arrays.deepToString(this.objectArray2) + ")";
+	}
+}

--- a/test/transform/resource/after-ecj/ToStringArray.java
+++ b/test/transform/resource/after-ecj/ToStringArray.java
@@ -1,0 +1,12 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+public @lombok.ToString class ToStringArray {
+  int[] primitiveArray;
+  Object[] objectArray;
+  public ToStringArray() {
+    super();
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+    return (((("ToStringArray(primitiveArray=" + java.util.Arrays.toString(this.primitiveArray)) + ", objectArray=") + java.util.Arrays.deepToString(this.objectArray)) + ")");
+  }
+}

--- a/test/transform/resource/after-ecj/ToStringArrayTypeAnnotations.java
+++ b/test/transform/resource/after-ecj/ToStringArrayTypeAnnotations.java
@@ -1,0 +1,16 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+public @lombok.ToString class ToStringArrayTypeAnnotations {
+  @Target({ElementType.TYPE_USE}) @interface TA {
+  }
+  @TA int[] primitiveArray1;
+  int @TA [] primitiveArray2;
+  @TA Object[] objectArray1;
+  Object @TA [] objectArray2;
+  public ToStringArrayTypeAnnotations() {
+    super();
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+    return (((((((("ToStringArrayTypeAnnotations(primitiveArray1=" + java.util.Arrays.toString(this.primitiveArray1)) + ", primitiveArray2=") + java.util.Arrays.toString(this.primitiveArray2)) + ", objectArray1=") + java.util.Arrays.deepToString(this.objectArray1)) + ", objectArray2=") + java.util.Arrays.deepToString(this.objectArray2)) + ")");
+  }
+}

--- a/test/transform/resource/before/ToStringArray.java
+++ b/test/transform/resource/before/ToStringArray.java
@@ -1,0 +1,9 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@lombok.ToString
+public class ToStringArray {
+	int[] primitiveArray;
+	
+	Object[] objectArray;
+}

--- a/test/transform/resource/before/ToStringArrayTypeAnnotations.java
+++ b/test/transform/resource/before/ToStringArrayTypeAnnotations.java
@@ -1,3 +1,4 @@
+//version 8:
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 

--- a/test/transform/resource/before/ToStringArrayTypeAnnotations.java
+++ b/test/transform/resource/before/ToStringArrayTypeAnnotations.java
@@ -1,0 +1,15 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@lombok.ToString
+public class ToStringArrayTypeAnnotations {
+	@TA int[] primitiveArray1;
+	int @TA [] primitiveArray2;
+	
+	@TA Object[] objectArray1;
+	Object @TA [] objectArray2;
+	
+	@Target({ElementType.TYPE_USE})
+	@interface TA {
+	}
+}


### PR DESCRIPTION
This PR fixes #3416 

I also replaced the reflection code for type annotations in HandleEqualsAndHashcode with the handle methods and refactored the handler to use static final fields (allows JVM optimizations) and method guards (no exception for Java < 8).

The last commit fixes a problem with the Zulu JDK and the removal of record comopenent annotations.