### PR TITLE
Add option to mark SuperBuilder as root

### DIFF
--- a/src/core/lombok/experimental/SuperBuilder.java
+++ b/src/core/lombok/experimental/SuperBuilder.java
@@ -33,7 +33,8 @@ import lombok.Singular;
  * The SuperBuilder annotation creates a so-called 'builder' aspect to the class that is annotated with {@code @SuperBuilder}, but which works well when extending.
  * It is similar to {@code @Builder}, except it is only legal on types, is less configurable, but allows you to {@code extends} other builder-able classes.
  * <p>
- * All classes in the hierarchy must be annotated with {@code @SuperBuilder}.
+ * All classes in the hierarchy must be annotated with {@code @SuperBuilder}. To relax this requirement, set {@link SuperBuilder#root()} to {@code true}
+ * on the top-most class in the hierarchy which should have a generated builder.
  * <p>
  * Lombok generates 2 inner 'builder' classes, which extend the parent class' builder class (unless your class doesn't have an extends clause).
  * Lombok also generates a static method named {@code builder()}, and a protected constructor that takes 1 argument of the builderclass type.
@@ -81,4 +82,12 @@ public @interface SuperBuilder {
 	 * @return The prefix to prepend to generated method names.
 	 */
 	String setterPrefix() default "";
+
+	/**
+	 * If <code>true</code>, ignore extends clause of the annotated class and do not produce builders for any of its
+	 * superclasses. This will only work if superclasses of the annotated class have default constructors.
+	 *
+	 * @return Whether to stop with super-builder generation at this class.
+	 */
+	boolean root() default false;
 }

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -256,7 +256,10 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			// A class name with a generics type, e.g., "Superclass<A>".
 			extendsClause = ((JCTypeApply) extendsClause).getType();
 		}
-		if (extendsClause instanceof JCFieldAccess) {
+		if (annInstance.root()) {
+			// This is the root builder, stop generating builder superclasses
+			superclassBuilderClass = null;
+		} else if (extendsClause instanceof JCFieldAccess) {
 			Name superclassName = ((JCFieldAccess) extendsClause).getIdentifier();
 			String builderClassNameTemplate = BuilderJob.getBuilderClassNameTemplate(annotationNode, null);
 			String superclassBuilderClassName = job.replaceBuilderClassName(superclassName.toString(), builderClassNameTemplate);


### PR DESCRIPTION
I have a kotlin abstract class (coming from a shared library) that I extend in java code which makes an attempt to use `@SuperBuilder` annotation.

This doesn't work because, as explained in the javadoc, all classes in the hierarchy (well, at least ones which are present in `extends` clauses of annotated classes)  must be annotated with `@SuperBuilder`.

This change adds option to mark a class as the root of a super-builder hierarchy: `@SuperBuilder(root=true)`, which relaxes the constraint mentioned in the previous paragraph.

In case this fits well with the existing design and you indicate that you are willing to merge, I'd be happy to polish it and update any docs or tests which I missed.



