### PR TITLE
Support argument widening for extension methods

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 The Project Lombok Authors.
+ * Copyright (C) 2012-2023 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -64,7 +64,6 @@ import org.eclipse.jdt.internal.compiler.lookup.ProblemMethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
-import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 import org.eclipse.jdt.internal.core.search.matching.MethodPattern;
 
@@ -346,13 +345,7 @@ public class PatchExtensionMethod {
 							arg.resolveType(scope);
 						}
 						if (arg.resolvedType != null) {
-							if (!param.isBaseType() && arg.resolvedType.isBaseType()) {
-								int id = arg.resolvedType.id;
-								arg.implicitConversion = TypeIds.BOXING | (id + (id << 4)); // magic see TypeIds
-							} else if (param.isBaseType() && !arg.resolvedType.isBaseType()) {
-								int id = parameters[i].id;
-								arg.implicitConversion = TypeIds.UNBOXING | (id + (id << 4)); // magic see TypeIds
-							}
+							arg.computeConversion(scope, param, arg.resolvedType);
 						}
 					}
 					

--- a/test/transform/resource/after-delombok/ExtensionMethodWidening.java
+++ b/test/transform/resource/after-delombok/ExtensionMethodWidening.java
@@ -1,0 +1,13 @@
+class ExtensionMethodWidening {
+	public void test() {
+		String string = "test";
+		ExtensionMethodWidening.Extensions.widening(string, 1);
+	}
+
+
+	static class Extensions {
+		public static String widening(String string, long a) {
+			return string + " " + a;
+		}
+	}
+}

--- a/test/transform/resource/after-ecj/ExtensionMethodWidening.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodWidening.java
@@ -1,0 +1,18 @@
+import lombok.experimental.ExtensionMethod;
+@ExtensionMethod({ExtensionMethodWidening.Extensions.class}) class ExtensionMethodWidening {
+  static class Extensions {
+    Extensions() {
+      super();
+    }
+    public static String widening(String string, long a) {
+      return ((string + " ") + a);
+    }
+  }
+  ExtensionMethodWidening() {
+    super();
+  }
+  public void test() {
+    String string = "test";
+    ExtensionMethodWidening.Extensions.widening(string, 1);
+  }
+}

--- a/test/transform/resource/before/ExtensionMethodWidening.java
+++ b/test/transform/resource/before/ExtensionMethodWidening.java
@@ -1,0 +1,15 @@
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod({ExtensionMethodWidening.Extensions.class})
+class ExtensionMethodWidening {
+	public void test() {
+		String string = "test";
+		string.widening(1);
+	}
+	
+	static class Extensions {
+		public static String widening(String string, long a) {
+			return string + " " + a;
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes #3463

`Expression::computeConversion` can handle all these conversions for us.