### PR TITLE
Keep initializer position for lazy getter

### DIFF
--- a/src/core/lombok/javac/JavacAugments.java
+++ b/src/core/lombok/javac/JavacAugments.java
@@ -34,4 +34,5 @@ public final class JavacAugments {
 	public static final FieldAugment<JCTree, Boolean> JCTree_handled = FieldAugment.augment(JCTree.class, boolean.class, "lombok$handled");
 	public static final FieldAugment<JCTree, JCTree> JCTree_generatedNode = FieldAugment.circularSafeAugment(JCTree.class, JCTree.class, "lombok$generatedNode");
 	public static final FieldAugment<JCImport, Boolean> JCImport_deletable = FieldAugment.circularSafeAugment(JCImport.class, Boolean.class, "lombok$deletable");
+	public static final FieldAugment<JCTree, Boolean> JCTree_keepPosition = FieldAugment.augment(JCTree.class, boolean.class, "lombok$keepPosition");
 }

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -25,6 +25,7 @@ import static com.sun.tools.javac.code.Flags.GENERATEDCONSTR;
 import static lombok.core.handlers.HandlerUtil.*;
 import static lombok.javac.Javac.*;
 import static lombok.javac.JavacAugments.JCTree_generatedNode;
+import static lombok.javac.JavacAugments.JCTree_keepPosition;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -126,6 +127,7 @@ public class JavacHandlerUtil {
 		
 		@Override public void scan(JCTree tree) {
 			if (tree == null) return;
+			if (JCTree_keepPosition.get(tree)) return;
 			setGeneratedBy(tree, source);
 			super.scan(tree);
 		}
@@ -173,10 +175,11 @@ public class JavacHandlerUtil {
 		}
 		JCTree_generatedNode.set(node, sourceNode.get());
 		
-		if (!inNetbeansEditor(sourceNode.getContext()) || isParameter(node)) {
-			node.pos = sourceNode.getStartPos();
-			storeEnd(node, sourceNode.getEndPosition(), (JCCompilationUnit) sourceNode.top().get());
-		}
+		if (JCTree_keepPosition.get(node)) return node;
+		if (inNetbeansEditor(sourceNode.getContext()) && !isParameter(node)) return node;
+		
+		node.pos = sourceNode.getStartPos();
+		storeEnd(node, sourceNode.getEndPosition(), (JCCompilationUnit) sourceNode.top().get());
 		return node;
 	}
 

--- a/test/transform/resource/after-delombok/GetterLazyArguments.java
+++ b/test/transform/resource/after-delombok/GetterLazyArguments.java
@@ -17,6 +17,7 @@ class GetterLazyArguments {
 	private final java.util.concurrent.atomic.AtomicReference<java.lang.Object> field3 = new java.util.concurrent.atomic.AtomicReference<java.lang.Object>();
 	private final java.util.concurrent.atomic.AtomicReference<java.lang.Object> field4 = new java.util.concurrent.atomic.AtomicReference<java.lang.Object>();
 	private final java.util.concurrent.atomic.AtomicReference<java.lang.Object> field5 = new java.util.concurrent.atomic.AtomicReference<java.lang.Object>();
+	private final java.util.concurrent.atomic.AtomicReference<java.lang.Object> field6 = new java.util.concurrent.atomic.AtomicReference<java.lang.Object>();
 
 	@java.lang.SuppressWarnings({"all", "unchecked"})
 	public String getField1() {
@@ -98,5 +99,21 @@ class GetterLazyArguments {
 			}
 		}
 		return (String) (value == this.field5 ? null : value);
+	}
+
+	@java.lang.SuppressWarnings({"all", "unchecked"})
+	public String getField6() {
+		java.lang.Object value = this.field6.get();
+		if (value == null) {
+			synchronized (this.field6) {
+				value = this.field6.get();
+				if (value == null) {
+					final String actualValue = true ? stringInt(true ? "a" : "b", true ? 1 : 0) : "";
+					value = actualValue == null ? this.field6 : actualValue;
+					this.field6.set(value);
+				}
+			}
+		}
+		return (String) (value == this.field6 ? null : value);
 	}
 }

--- a/test/transform/resource/after-delombok/GetterLazyErrorPosition.java
+++ b/test/transform/resource/after-delombok/GetterLazyErrorPosition.java
@@ -1,0 +1,19 @@
+class GetterLazyErrorPosition {
+	private final java.util.concurrent.atomic.AtomicReference<java.lang.Object> field = new java.util.concurrent.atomic.AtomicReference<java.lang.Object>();
+
+	@java.lang.SuppressWarnings({"all", "unchecked"})
+	public String getField() {
+		java.lang.Object value = this.field.get();
+		if (value == null) {
+			synchronized (this.field) {
+				value = this.field.get();
+				if (value == null) {
+					final String actualValue = true ? "" : new ErrorPosition();
+					value = actualValue == null ? this.field : actualValue;
+					this.field.set(value);
+				}
+			}
+		}
+		return (String) (value == this.field ? null : value);
+	}
+}

--- a/test/transform/resource/after-ecj/GetterLazyArguments.java
+++ b/test/transform/resource/after-ecj/GetterLazyArguments.java
@@ -4,6 +4,7 @@ class GetterLazyArguments {
   private final @lombok.Getter(lazy = true) java.util.concurrent.atomic.AtomicReference<java.lang.Object> field3 = new java.util.concurrent.atomic.AtomicReference<java.lang.Object>();
   private final @lombok.Getter(lazy = true) java.util.concurrent.atomic.AtomicReference<java.lang.Object> field4 = new java.util.concurrent.atomic.AtomicReference<java.lang.Object>();
   private final @lombok.Getter(lazy = true) java.util.concurrent.atomic.AtomicReference<java.lang.Object> field5 = new java.util.concurrent.atomic.AtomicReference<java.lang.Object>();
+  private final @lombok.Getter(lazy = true) java.util.concurrent.atomic.AtomicReference<java.lang.Object> field6 = new java.util.concurrent.atomic.AtomicReference<java.lang.Object>();
   GetterLazyArguments() {
     super();
   }
@@ -102,5 +103,22 @@ class GetterLazyArguments {
             }
         }
     return (String) ((value == this.field5) ? null : value);
+  }
+  public @java.lang.SuppressWarnings({"all", "unchecked"}) String getField6() {
+    java.lang.Object value = this.field6.get();
+    if ((value == null))
+        {
+          synchronized (this.field6)
+            {
+              value = this.field6.get();
+              if ((value == null))
+                  {
+                    final String actualValue = (true ? stringInt((true ? "a" : "b"), (true ? 1 : 0)) : "");
+                    value = ((actualValue == null) ? this.field6 : actualValue);
+                    this.field6.set(value);
+                  }
+            }
+        }
+    return (String) ((value == this.field6) ? null : value);
   }
 }

--- a/test/transform/resource/before/GetterLazyArguments.java
+++ b/test/transform/resource/before/GetterLazyArguments.java
@@ -18,4 +18,7 @@ class GetterLazyArguments {
 	
 	@lombok.Getter(lazy=true)
 	private final String field5 = stringRunnable(("a"), () -> { });
+	
+	@lombok.Getter(lazy=true)
+	private final String field6 = true ? stringInt(true ? "a" : "b", true ? 1 : 0) : "";
 }

--- a/test/transform/resource/before/GetterLazyErrorPosition.java
+++ b/test/transform/resource/before/GetterLazyErrorPosition.java
@@ -1,0 +1,8 @@
+//platform javac: positions in eclipse are hard...
+class GetterLazyErrorPosition {
+	@lombok.Getter(lazy=true)
+	private final String field = 
+		true ? 
+		"" : 
+		new ErrorPosition();
+}

--- a/test/transform/resource/messages-delombok/GetterLazyErrorPosition.java.messages
+++ b/test/transform/resource/messages-delombok/GetterLazyErrorPosition.java.messages
@@ -1,0 +1,1 @@
+6 cannot find symbol symbol: class ErrorPosition location: class GetterLazyErrorPosition

--- a/test/transform/resource/messages-delombok/GetterLazyErrorPosition.java.messages
+++ b/test/transform/resource/messages-delombok/GetterLazyErrorPosition.java.messages
@@ -1,1 +1,1 @@
-6 cannot find symbol symbol: class ErrorPosition location: class GetterLazyErrorPosition
+7 cannot find symbol

--- a/test/transform/resource/messages-idempotent/GetterLazyErrorPosition.java.messages
+++ b/test/transform/resource/messages-idempotent/GetterLazyErrorPosition.java.messages
@@ -1,0 +1,1 @@
+11 cannot find symbol symbol: class ErrorPosition location: class GetterLazyErrorPosition

--- a/test/transform/resource/messages-idempotent/GetterLazyErrorPosition.java.messages
+++ b/test/transform/resource/messages-idempotent/GetterLazyErrorPosition.java.messages
@@ -1,1 +1,1 @@
-11 cannot find symbol symbol: class ErrorPosition location: class GetterLazyErrorPosition
+11 cannot find symbol


### PR DESCRIPTION
This PR fixes #3481 and fixes #3448 and fixes #3314

`javac` uses the class `UniquePos` to cache method argument types. This leads to problems for generated nodes that share the same position.
We only handled that case for direct method invocations and not nested ones as reported in the linked issues. Simply keeping the original position for the whole initializer fixes this problem. This also leads to generated error messages for the initializer and not the getter annotation which is a nice side effect.