### PR TITLE
Remove javac support for getter on enum members

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleGetter.java
+++ b/src/core/lombok/eclipse/handlers/HandleGetter.java
@@ -168,7 +168,7 @@ public class HandleGetter extends EclipseAnnotationHandler<Getter> {
 	public void createGetterForField(AccessLevel level,
 			EclipseNode fieldNode, EclipseNode errorNode, ASTNode source, boolean whineIfExists, boolean lazy, List<Annotation> onMethod) {
 		
-		if (fieldNode.getKind() != Kind.FIELD) {
+		if (fieldNode.getKind() != Kind.FIELD || fieldNode.isEnumMember()) {
 			errorNode.addError(GETTER_NODE_NOT_SUPPORTED_ERR);
 			return;
 		}

--- a/src/core/lombok/javac/handlers/HandleGetter.java
+++ b/src/core/lombok/javac/handlers/HandleGetter.java
@@ -165,7 +165,7 @@ public class HandleGetter extends JavacAnnotationHandler<Getter> {
 	public void createGetterForField(AccessLevel level,
 			JavacNode fieldNode, JavacNode source, boolean whineIfExists, boolean lazy, List<JCAnnotation> onMethod) {
 		
-		if (fieldNode.getKind() != Kind.FIELD) {
+		if (fieldNode.getKind() != Kind.FIELD || fieldNode.isEnumMember()) {
 			source.addError(GETTER_NODE_NOT_SUPPORTED_ERR);
 			return;
 		}

--- a/test/transform/resource/after-delombok/GetterEnumConstant.java
+++ b/test/transform/resource/after-delombok/GetterEnumConstant.java
@@ -1,0 +1,3 @@
+enum GetterEnumConstant {
+	ONE;
+}

--- a/test/transform/resource/after-ecj/GetterEnumConstant.java
+++ b/test/transform/resource/after-ecj/GetterEnumConstant.java
@@ -1,0 +1,9 @@
+import lombok.Getter;
+enum GetterEnumConstant {
+  @Getter ONE(),
+  <clinit>() {
+  }
+  GetterEnumConstant() {
+    super();
+  }
+}

--- a/test/transform/resource/before/GetterEnumConstant.java
+++ b/test/transform/resource/before/GetterEnumConstant.java
@@ -1,0 +1,6 @@
+import lombok.Getter;
+
+enum GetterEnumConstant {
+	@Getter
+	ONE;
+}

--- a/test/transform/resource/messages-delombok/GetterEnumConstant.java.messages
+++ b/test/transform/resource/messages-delombok/GetterEnumConstant.java.messages
@@ -1,0 +1,1 @@
+4 @Getter is only supported on a class, an enum, or a field.

--- a/test/transform/resource/messages-ecj/GetterEnumConstant.java.messages
+++ b/test/transform/resource/messages-ecj/GetterEnumConstant.java.messages
@@ -1,0 +1,1 @@
+4 @Getter is only supported on a class, an enum, or a field.


### PR DESCRIPTION
This PR fixes #3427

This is a breaking change for `javac` but I cannot imagine why someone want to generate a static getter for an enum member.