### PR TITLE
Add support for jakarta generated annotation

### DIFF
--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -59,6 +59,7 @@ public class ConfigurationKeys {
 	 * <em>BREAKING CHANGE</em>: Starting with lombok v1.16.20, defaults to {@code false} instead of {@code true}, as this annotation is broken in JDK9.
 	 * 
 	 * @see ConfigurationKeys#ADD_JAVAX_GENERATED_ANNOTATIONS
+	 * @see ConfigurationKeys#ADD_JAKARTA_GENERATED_ANNOTATIONS
 	 * @see ConfigurationKeys#ADD_LOMBOK_GENERATED_ANNOTATIONS
 	 * @deprecated Since version 1.16.14, use {@link #ADD_JAVAX_GENERATED_ANNOTATIONS} instead.
 	 */
@@ -73,6 +74,13 @@ public class ConfigurationKeys {
 	 * <em>BREAKING CHANGE</em>: Starting with lombok v1.16.20, defaults to {@code false} instead of {@code true}, as this annotation is broken in JDK9.
 	 */
 	public static final ConfigurationKey<Boolean> ADD_JAVAX_GENERATED_ANNOTATIONS = new ConfigurationKey<Boolean>("lombok.addJavaxGeneratedAnnotation", "Generate @javax.annotation.Generated on all generated code (default: follow lombok.addGeneratedAnnotation).") {};
+	
+	/**
+	 * lombok configuration: {@code lombok.addJakartaGeneratedAnnotation} = {@code true} | {@code false}.
+	 * 
+	 * If {@code true}, lombok generates {@code @jakarta.annotation.Generated("lombok")} on all fields, methods, and types that are generated.
+	 */
+	public static final ConfigurationKey<Boolean> ADD_JAKARTA_GENERATED_ANNOTATIONS = new ConfigurationKey<Boolean>("lombok.addJakartaGeneratedAnnotation", "Generate @jakarta.annotation.Generated on all generated code (default: false).") {};
 	
 	/**
 	 * lombok configuration: {@code lombok.addLombokGeneratedAnnotation} = {@code true} | {@code false}.

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -2088,6 +2088,7 @@ public class EclipseHandlerUtil {
 	private static final char[] GENERATED_CODE = "generated code".toCharArray();
 	private static final char[] LOMBOK = "lombok".toCharArray();
 	private static final char[][] JAVAX_ANNOTATION_GENERATED = Eclipse.fromQualifiedName("javax.annotation.Generated");
+	private static final char[][] JAKARTA_ANNOTATION_GENERATED = Eclipse.fromQualifiedName("jakarta.annotation.Generated");
 	private static final char[][] LOMBOK_GENERATED = Eclipse.fromQualifiedName("lombok.Generated");
 	private static final char[][] EDU_UMD_CS_FINDBUGS_ANNOTATIONS_SUPPRESSFBWARNINGS = Eclipse.fromQualifiedName("edu.umd.cs.findbugs.annotations.SuppressFBWarnings");
 	
@@ -2110,6 +2111,9 @@ public class EclipseHandlerUtil {
 		Annotation[] result = originalAnnotationArray;
 		if (HandlerUtil.shouldAddGenerated(node)) {
 			result = addAnnotation(source, result, JAVAX_ANNOTATION_GENERATED, new StringLiteral(LOMBOK, 0, 0, 0));
+		}
+		if (Boolean.TRUE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_JAKARTA_GENERATED_ANNOTATIONS))) {
+			result = addAnnotation(source, result, JAKARTA_ANNOTATION_GENERATED, new StringLiteral(LOMBOK, 0, 0, 0));
 		}
 		if (Boolean.TRUE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_LOMBOK_GENERATED_ANNOTATIONS))) {
 			result = addAnnotation(source, result, LOMBOK_GENERATED);

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1521,6 +1521,9 @@ public class JavacHandlerUtil {
 		if (HandlerUtil.shouldAddGenerated(node)) {
 			addAnnotation(mods, node, source, "javax.annotation.Generated", node.getTreeMaker().Literal("lombok"));
 		}
+		if (Boolean.TRUE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_JAKARTA_GENERATED_ANNOTATIONS))) {
+			addAnnotation(mods, node, source, "jakarta.annotation.Generated", node.getTreeMaker().Literal("lombok"));
+		}
 		if (Boolean.TRUE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_LOMBOK_GENERATED_ANNOTATIONS))) {
 			addAnnotation(mods, node, source, "lombok.Generated", null);
 		}

--- a/test/stubs/jakarta/annotation/Generated.java
+++ b/test/stubs/jakarta/annotation/Generated.java
@@ -1,0 +1,15 @@
+package jakarta.annotation;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(SOURCE)
+@Target({PACKAGE, TYPE, ANNOTATION_TYPE, METHOD, CONSTRUCTOR, FIELD, LOCAL_VARIABLE, PARAMETER})
+public @interface Generated {
+	String[] value();
+}

--- a/test/stubs/javax/annotation/Generated.java
+++ b/test/stubs/javax/annotation/Generated.java
@@ -1,0 +1,15 @@
+package javax.annotation;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(SOURCE)
+@Target({PACKAGE, TYPE, ANNOTATION_TYPE, METHOD, CONSTRUCTOR, FIELD, LOCAL_VARIABLE, PARAMETER})
+public @interface Generated {
+	String[] value();
+}

--- a/test/transform/resource/after-delombok/GeneratedJavaxJakarta.java
+++ b/test/transform/resource/after-delombok/GeneratedJavaxJakarta.java
@@ -1,7 +1,9 @@
-class GeneratedOffJavaxOn {
+class GeneratedJavaxJakarta {
 	int x;
+
 	@java.lang.SuppressWarnings("all")
 	@javax.annotation.Generated("lombok")
+	@jakarta.annotation.Generated("lombok")
 	public int getX() {
 		return this.x;
 	}

--- a/test/transform/resource/after-delombok/GeneratedJavaxOnLombokOn.java
+++ b/test/transform/resource/after-delombok/GeneratedJavaxOnLombokOn.java
@@ -1,4 +1,3 @@
-//version :8
 class GeneratedJavaxOnLombokOn {
 	int x;
 	@java.lang.SuppressWarnings("all")

--- a/test/transform/resource/after-delombok/GeneratedOn.java
+++ b/test/transform/resource/after-delombok/GeneratedOn.java
@@ -1,5 +1,6 @@
-class GeneratedOffJavaxOn {
+class GeneratedOn {
 	int x;
+
 	@java.lang.SuppressWarnings("all")
 	@javax.annotation.Generated("lombok")
 	public int getX() {

--- a/test/transform/resource/after-ecj/GeneratedJavaxJakarta.java
+++ b/test/transform/resource/after-ecj/GeneratedJavaxJakarta.java
@@ -1,0 +1,9 @@
+class GeneratedJavaxJakarta {
+  @lombok.Getter int x;
+  GeneratedJavaxJakarta() {
+    super();
+  }
+  public @java.lang.SuppressWarnings("all") @javax.annotation.Generated("lombok") @jakarta.annotation.Generated("lombok") int getX() {
+    return this.x;
+  }
+}

--- a/test/transform/resource/after-ecj/GeneratedOn.java
+++ b/test/transform/resource/after-ecj/GeneratedOn.java
@@ -1,0 +1,9 @@
+class GeneratedOn {
+  @lombok.Getter int x;
+  GeneratedOn() {
+    super();
+  }
+  public @java.lang.SuppressWarnings("all") @javax.annotation.Generated("lombok") int getX() {
+    return this.x;
+  }
+}

--- a/test/transform/resource/before/EqualsAndHashCodeWithSomeExistingMethods.java
+++ b/test/transform/resource/before/EqualsAndHashCodeWithSomeExistingMethods.java
@@ -1,4 +1,3 @@
-//CONF: lombok.addGeneratedAnnotation = false
 import lombok.*;
 import static lombok.AccessLevel.NONE;
 

--- a/test/transform/resource/before/GeneratedJavaxJakarta.java
+++ b/test/transform/resource/before/GeneratedJavaxJakarta.java
@@ -1,0 +1,6 @@
+//CONF: lombok.addJavaxGeneratedAnnotation = true
+//CONF: lombok.addJakartaGeneratedAnnotation = true
+class GeneratedJavaxJakarta {
+	@lombok.Getter
+	int x;
+}

--- a/test/transform/resource/before/GeneratedJavaxOnLombokOn.java
+++ b/test/transform/resource/before/GeneratedJavaxOnLombokOn.java
@@ -1,6 +1,5 @@
 //CONF: lombok.addJavaxGeneratedAnnotation = true
 //CONF: lombok.addLombokGeneratedAnnotation = true
-//version :8
 class GeneratedJavaxOnLombokOn {
 	@lombok.Getter
 	int x;

--- a/test/transform/resource/before/GeneratedOffJavaxOn.java
+++ b/test/transform/resource/before/GeneratedOffJavaxOn.java
@@ -1,6 +1,5 @@
 //CONF: lombok.addGeneratedAnnotation = false
 //CONF: lombok.addJavaxGeneratedAnnotation = true
-//version :8
 class GeneratedOffJavaxOn {
 	@lombok.Getter
 	int x;

--- a/test/transform/resource/before/GeneratedOn.java
+++ b/test/transform/resource/before/GeneratedOn.java
@@ -1,0 +1,5 @@
+//CONF: lombok.addGeneratedAnnotation = true
+class GeneratedOn {
+	@lombok.Getter
+	int x;
+}

--- a/test/transform/resource/messages-delombok/EqualsAndHashCodeWithSomeExistingMethods.java.messages
+++ b/test/transform/resource/messages-delombok/EqualsAndHashCodeWithSomeExistingMethods.java.messages
@@ -1,1 +1,1 @@
-5 Not generating equals: One of equals or hashCode exists. You should either write both of these or none of these (in the latter case, lombok generates them).
+4 Not generating equals: One of equals or hashCode exists. You should either write both of these or none of these (in the latter case, lombok generates them).

--- a/test/transform/resource/messages-ecj/EqualsAndHashCodeWithSomeExistingMethods.java.messages
+++ b/test/transform/resource/messages-ecj/EqualsAndHashCodeWithSomeExistingMethods.java.messages
@@ -1,1 +1,1 @@
-5 Not generating equals: One of equals or hashCode exists. You should either write both of these or none of these (in the latter case, lombok generates them).
+4 Not generating equals: One of equals or hashCode exists. You should either write both of these or none of these (in the latter case, lombok generates them).


### PR DESCRIPTION
This PR fixes #3248

I also removed the source directive in a completly unrelated testcase, added a new testcase for the deprecated configuration key and enabled the `javax.annotation.Generated` testcases for java 9+.