### PR TITLE
Fix confusing behaviour of NonNull annotations.

### DIFF
--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -381,7 +381,12 @@ public class ConfigurationKeys {
 	 * If set, <em>any</em> usage of {@code @NonNull} results in a warning / error.
 	 */
 	public static final ConfigurationKey<FlagUsageType> NON_NULL_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.nonNull.flagUsage", "Emit a warning or error if @NonNull is used.") {};
-	
+
+
+	/**
+	 * Foreign {@code @NonNull} annotations  (like {@code javax.annotations.NotNull} or {@code org.jetbrains.annotations.NotNull}) are handled the same way as {@code lombok.NonNull}
+	 */
+	public static final ConfigurationKey<Boolean> NON_NULL_FOREIGN_ANNOTATIONS = new ConfigurationKey<Boolean>("lombok.nonNull.useForeignAnnotations", "Foreign @NonNull annotations (like javax.annotations.NotNull or org.jetbrains.annotations.NotNull) are handled the same way as lombok.NonNull (default: true)") {};
 	// ----- SneakyThrows -----
 	
 	/**

--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -382,13 +382,12 @@ public class ConfigurationKeys {
 	 */
 	public static final ConfigurationKey<FlagUsageType> NON_NULL_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.nonNull.flagUsage", "Emit a warning or error if @NonNull is used.") {};
 
-
 	/**
-	 * Foreign {@code @NonNull} annotations  (like {@code javax.annotations.NotNull} or {@code org.jetbrains.annotations.NotNull}) are handled the same way as {@code lombok.NonNull}
+	 * Foreign {@code @NonNull} annotations  (like {@code javax.annotations.NotNull} or {@code org.jetbrains.annotations.NotNull}) are handled the same way as {@code lombok.NonNull}.
 	 */
 	public static final ConfigurationKey<Boolean> NON_NULL_FOREIGN_ANNOTATIONS = new ConfigurationKey<Boolean>("lombok.nonNull.useForeignAnnotations", "Foreign @NonNull annotations (like javax.annotations.NotNull or org.jetbrains.annotations.NotNull) are handled the same way as lombok.NonNull (default: true)") {};
 	// ----- SneakyThrows -----
-	
+
 	/**
 	 * lombok configuration: {@code lombok.sneakyThrows.flagUsage} = {@code WARNING} | {@code ERROR}.
 	 * 

--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -78,8 +78,10 @@ public class HandlerUtil {
 	public static int primeForNull() {
 		return 43;
 	}
-	
-	public static final List<String> FOREIGN_NONNULL_ANNOTATIONS, LOMBOK_NONNULL_ANNOTATIONS, BASE_COPYABLE_ANNOTATIONS, COPY_TO_SETTER_ANNOTATIONS, COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS, JACKSON_COPY_TO_BUILDER_ANNOTATIONS;
+
+	private static final List<String> NONNULL_ANNOTATIONS, LOMBOK_NONNULL_ANNOTATIONS;
+
+	public static final List<String> BASE_COPYABLE_ANNOTATIONS, COPY_TO_SETTER_ANNOTATIONS, COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS, JACKSON_COPY_TO_BUILDER_ANNOTATIONS;
 	static {
 		// This is a list of annotations with a __highly specific meaning__: All annotations in this list indicate that passing null for the relevant item is __never__ acceptable, regardless of settings or circumstance.
 		// In other words, things like 'this models a database table, and the db table column has a nonnull constraint', or 'this represents a web form, and if this is null, the form is invalid' __do not count__ and should not be in this list;
@@ -88,7 +90,8 @@ public class HandlerUtil {
 		// In addition, the intent for these annotations is that they can be used 'in public' - it's not for internal-only usage annotations.
 		
 		// Presence of these annotations mean that lombok will generate null checks in any created setters and constructors.
-		FOREIGN_NONNULL_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
+		// It will also add additional null checks if method parameters are annotated.
+		NONNULL_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"android.annotation.NonNull",
 			"android.support.annotation.NonNull",
 			"android.support.annotation.RecentlyNonNull",
@@ -120,6 +123,8 @@ public class HandlerUtil {
 			"reactor.util.annotation.NonNull",
 		}));
 
+		// by default, for non-null checks, the NONNULL_ANNOTATION list is checked. If foreign non null annotations are disabled, this list is used,
+		// which usually contains only the lombok.NonNull annotation
 		LOMBOK_NONNULL_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"lombok.NonNull",
 		}));
@@ -985,7 +990,12 @@ public class HandlerUtil {
 		return null;
 	}
 
+	/**
+	 * Determines the list of non-null annotations that should be used.
+	 * @param useForeignAnnotations the config parameter, if we want to use foreign non-null annotations (default: true).
+	 * @return depending on the config, it either returns a list of all known non-null annotations or just containing the lombok.NonNull annotation
+	 */
 	public static List<String> nonNullAnnotations(Boolean useForeignAnnotations) {
-		return Boolean.FALSE.equals(useForeignAnnotations) ? LOMBOK_NONNULL_ANNOTATIONS : FOREIGN_NONNULL_ANNOTATIONS;
+		return Boolean.FALSE.equals(useForeignAnnotations) ? LOMBOK_NONNULL_ANNOTATIONS : NONNULL_ANNOTATIONS;
 	}
 }

--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -79,7 +79,7 @@ public class HandlerUtil {
 		return 43;
 	}
 	
-	public static final List<String> NONNULL_ANNOTATIONS, BASE_COPYABLE_ANNOTATIONS, COPY_TO_SETTER_ANNOTATIONS, COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS, JACKSON_COPY_TO_BUILDER_ANNOTATIONS;
+	public static final List<String> FOREIGN_NONNULL_ANNOTATIONS, LOMBOK_NONNULL_ANNOTATIONS, BASE_COPYABLE_ANNOTATIONS, COPY_TO_SETTER_ANNOTATIONS, COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS, JACKSON_COPY_TO_BUILDER_ANNOTATIONS;
 	static {
 		// This is a list of annotations with a __highly specific meaning__: All annotations in this list indicate that passing null for the relevant item is __never__ acceptable, regardless of settings or circumstance.
 		// In other words, things like 'this models a database table, and the db table column has a nonnull constraint', or 'this represents a web form, and if this is null, the form is invalid' __do not count__ and should not be in this list;
@@ -88,7 +88,7 @@ public class HandlerUtil {
 		// In addition, the intent for these annotations is that they can be used 'in public' - it's not for internal-only usage annotations.
 		
 		// Presence of these annotations mean that lombok will generate null checks in any created setters and constructors.
-		NONNULL_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
+		FOREIGN_NONNULL_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"android.annotation.NonNull",
 			"android.support.annotation.NonNull",
 			"android.support.annotation.RecentlyNonNull",
@@ -119,7 +119,11 @@ public class HandlerUtil {
 			"org.springframework.lang.NonNull",
 			"reactor.util.annotation.NonNull",
 		}));
-		
+
+		LOMBOK_NONNULL_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
+			"lombok.NonNull",
+		}));
+
 		// This is a list of annotations that lombok will automatically 'copy' - be it to the method (when generating a getter for a field annotated with one of these), or to a parameter (generating a setter, with-er, or builder 'setter').
 		// You can't disable this behaviour, so the list should only contain annotations where 'copy it!' is the desired behaviour in at least 95%, preferably 98%, of all non-buggy usages.
 		// As a general rule, lombok takes on maintenance of adding all nullity-related annotations here, _if_ they fit the definition of language-level nullity as per {@see #NONNULL_ANNOTATIONS}. As a consequence, everything from the NONNULL list should probably
@@ -979,5 +983,9 @@ public class HandlerUtil {
 			return matcher.group();
 		}
 		return null;
+	}
+
+	public static List<String> nonNullAnnotations(Boolean useForeignAnnotations) {
+		return Boolean.FALSE.equals(useForeignAnnotations) ? LOMBOK_NONNULL_ANNOTATIONS : FOREIGN_NONNULL_ANNOTATIONS;
 	}
 }

--- a/src/core/lombok/eclipse/HandlerLibrary.java
+++ b/src/core/lombok/eclipse/HandlerLibrary.java
@@ -222,6 +222,8 @@ public class HandlerLibrary {
 
 		String fqn = resolver.typeRefToFullyQualifiedName(annotationNode, typeLibrary, toQualifiedName(annotation.type.getTypeName()));
 		if (fqn == null) {
+			// We have found an unknown annotation, so check, if this could be an alternative nonNull annotation
+			// and treat it like lombok.NonNull
 			if (isNonNullAnnotation(annotationNode, annotation)) {
 				fqn = lombok.NonNull.class.getName();
 			} else {

--- a/src/core/lombok/eclipse/HandlerLibrary.java
+++ b/src/core/lombok/eclipse/HandlerLibrary.java
@@ -219,9 +219,16 @@ public class HandlerLibrary {
 		TypeResolver resolver = new TypeResolver(annotationNode.getImportList());
 		TypeReference rawType = annotation.type;
 		if (rawType == null) return Long.MAX_VALUE;
-		
+
 		String fqn = resolver.typeRefToFullyQualifiedName(annotationNode, typeLibrary, toQualifiedName(annotation.type.getTypeName()));
-		if (fqn == null) return Long.MAX_VALUE;
+		if (fqn == null) {
+			if (isNonNullAnnotation(annotationNode.up(), annotation)) {
+				fqn = lombok.NonNull.class.getName();
+
+			} else {
+				return Long.MAX_VALUE;
+			}
+		}
 		AnnotationHandlerContainer<?> container = annotationHandlers.get(fqn);
 		if (container == null) return Long.MAX_VALUE;
 		

--- a/src/core/lombok/eclipse/HandlerLibrary.java
+++ b/src/core/lombok/eclipse/HandlerLibrary.java
@@ -222,9 +222,8 @@ public class HandlerLibrary {
 
 		String fqn = resolver.typeRefToFullyQualifiedName(annotationNode, typeLibrary, toQualifiedName(annotation.type.getTypeName()));
 		if (fqn == null) {
-			if (isNonNullAnnotation(annotationNode.up(), annotation)) {
+			if (isNonNullAnnotation(annotationNode, annotation)) {
 				fqn = lombok.NonNull.class.getName();
-
 			} else {
 				return Long.MAX_VALUE;
 			}

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -802,7 +802,12 @@ public class EclipseHandlerUtil {
 		}
 		return false;
 	}
-	
+
+	public static boolean isNonNullAnnotation(EclipseNode node, Annotation annotation) {
+		for (String bn : NONNULL_ANNOTATIONS) if (typeMatches(bn, node, annotation.type)) return true;
+		return false;
+	}
+
 	private static final Annotation[] EMPTY_ANNOTATIONS_ARRAY = new Annotation[0];
 	
 	/**

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -787,7 +787,7 @@ public class EclipseHandlerUtil {
 		for (EclipseNode child : node.down()) {
 			if (child.getKind() != Kind.ANNOTATION) continue;
 			Annotation annotation = (Annotation) child.get();
-			for (String bn : NONNULL_ANNOTATIONS) if (typeMatches(bn, node, annotation.type)) return true;
+			if (isNonNullAnnotation(node, annotation)) return true;
 		}
 		return false;
 	}
@@ -797,14 +797,16 @@ public class EclipseHandlerUtil {
 		for (Annotation annotation : anns) {
 			TypeReference typeRef = annotation.type;
 			if (typeRef != null && typeRef.getTypeName() != null) {
-				for (String bn : NONNULL_ANNOTATIONS) if (typeMatches(bn, node, typeRef)) return true;
+				Boolean useForeignAnnotations = node.getAst().readConfiguration(ConfigurationKeys.NON_NULL_FOREIGN_ANNOTATIONS);
+				for (String bn : nonNullAnnotations(useForeignAnnotations)) if (typeMatches(bn, node, typeRef)) return true;
 			}
 		}
 		return false;
 	}
 
 	public static boolean isNonNullAnnotation(EclipseNode node, Annotation annotation) {
-		for (String bn : NONNULL_ANNOTATIONS) if (typeMatches(bn, node, annotation.type)) return true;
+		Boolean useForeignAnnotations = node.getAst().readConfiguration(ConfigurationKeys.NON_NULL_FOREIGN_ANNOTATIONS);
+		for (String bn : nonNullAnnotations(useForeignAnnotations)) if (typeMatches(bn, node, annotation.type)) return true;
 		return false;
 	}
 

--- a/src/core/lombok/javac/HandlerLibrary.java
+++ b/src/core/lombok/javac/HandlerLibrary.java
@@ -22,7 +22,7 @@
 package lombok.javac;
 
 import static lombok.javac.JavacAugments.JCTree_handled;
-
+import static lombok.javac.handlers.JavacHandlerUtil.isNonNullAnnotation;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -245,7 +245,14 @@ public class HandlerLibrary {
 		TypeResolver resolver = new TypeResolver(node.getImportList());
 		String rawType = annotation.annotationType.toString();
 		String fqn = resolver.typeRefToFullyQualifiedName(node, typeLibrary, rawType);
-		if (fqn == null) return;
+		if (fqn == null) {
+			if (isNonNullAnnotation(node.up(), annotation)) {
+				fqn = lombok.NonNull.class.getName();
+			} else {
+				return;
+			}
+		}
+
 		List<AnnotationHandlerContainer<?>> containers = annotationHandlers.get(fqn);
 		if (containers == null) return;
 		

--- a/src/core/lombok/javac/HandlerLibrary.java
+++ b/src/core/lombok/javac/HandlerLibrary.java
@@ -246,7 +246,7 @@ public class HandlerLibrary {
 		String rawType = annotation.annotationType.toString();
 		String fqn = resolver.typeRefToFullyQualifiedName(node, typeLibrary, rawType);
 		if (fqn == null) {
-			if (isNonNullAnnotation(node.up(), annotation)) {
+			if (isNonNullAnnotation(node, annotation)) {
 				fqn = lombok.NonNull.class.getName();
 			} else {
 				return;

--- a/src/core/lombok/javac/HandlerLibrary.java
+++ b/src/core/lombok/javac/HandlerLibrary.java
@@ -246,6 +246,8 @@ public class HandlerLibrary {
 		String rawType = annotation.annotationType.toString();
 		String fqn = resolver.typeRefToFullyQualifiedName(node, typeLibrary, rawType);
 		if (fqn == null) {
+			// We have found an unknown annotation, so check, if this could be an alternative nonNull annotation
+			// and treat it like lombok.NonNull
 			if (isNonNullAnnotation(node, annotation)) {
 				fqn = lombok.NonNull.class.getName();
 			} else {

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1708,7 +1708,8 @@ public class JavacHandlerUtil {
 
 	public static boolean isNonNullAnnotation(JavacNode node, JCAnnotation annotation) {
 		String annotationTypeName = getTypeName(annotation.annotationType);
-		for (String nn : NONNULL_ANNOTATIONS) if (typeMatches(nn, node, annotationTypeName)) return true;
+		Boolean useForeignAnnotations = node.getAst().readConfiguration(ConfigurationKeys.NON_NULL_FOREIGN_ANNOTATIONS);
+		for (String nn : nonNullAnnotations(useForeignAnnotations)) if (typeMatches(nn, node, annotationTypeName)) return true;
 		return false;
 	}
 

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1690,8 +1690,7 @@ public class JavacHandlerUtil {
 		for (JavacNode child : node.down()) {
 			if (child.getKind() == Kind.ANNOTATION) {
 				JCAnnotation annotation = (JCAnnotation) child.get();
-				String annotationTypeName = getTypeName(annotation.annotationType);
-				for (String nn : NONNULL_ANNOTATIONS) if (typeMatches(nn, node, annotationTypeName)) return true;
+				if (isNonNullAnnotation(node, annotation)) return true;
 			}
 		}
 		
@@ -1701,13 +1700,18 @@ public class JavacHandlerUtil {
 	public static boolean hasNonNullAnnotations(JavacNode node, List<JCAnnotation> anns) {
 		if (anns == null) return false;
 		for (JCAnnotation ann : anns) {
-			String annotationTypeName = getTypeName(ann.annotationType);
-			for (String nn : NONNULL_ANNOTATIONS) if (typeMatches(nn, node, annotationTypeName)) return true;
+			if (isNonNullAnnotation(node, ann)) return true;
 		}
 		
 		return false;
 	}
-	
+
+	public static boolean isNonNullAnnotation(JavacNode node, JCAnnotation annotation) {
+		String annotationTypeName = getTypeName(annotation.annotationType);
+		for (String nn : NONNULL_ANNOTATIONS) if (typeMatches(nn, node, annotationTypeName)) return true;
+		return false;
+	}
+
 	/**
 	 * Searches the given field node for annotations and returns each one that is 'copyable' (either via configuration or from the base list).
 	 */

--- a/test/transform/resource/after-delombok/NonNullJavaxOnParameter.java
+++ b/test/transform/resource/after-delombok/NonNullJavaxOnParameter.java
@@ -1,4 +1,5 @@
 //version 8:
+import javax.annotation.Nonnull;
 class NonNullJavaxOnParameter extends Thread {
 	NonNullJavaxOnParameter(@javax.annotation.Nonnull String arg) {
 		this(arg, "");
@@ -31,7 +32,7 @@ class NonNullJavaxOnParameter extends Thread {
 		}
 		if (arg != null) throw new IllegalStateException();
 	}
-	public void test(@javax.annotation.Nonnull String stringArg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
+	public void test(@javax.annotation.Nonnull String stringArg, @Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
 		if (stringArg == null) {
 			throw new java.lang.NullPointerException("stringArg is marked non-null but is null");
 		}

--- a/test/transform/resource/after-delombok/NonNullJavaxOnParameter.java
+++ b/test/transform/resource/after-delombok/NonNullJavaxOnParameter.java
@@ -1,0 +1,55 @@
+//version 8:
+class NonNullJavaxOnParameter extends Thread {
+	NonNullJavaxOnParameter(@javax.annotation.Nonnull String arg) {
+		this(arg, "");
+		if (arg == null) {
+			throw new java.lang.NullPointerException("arg is marked non-null but is null");
+		}
+	}
+	NonNullJavaxOnParameter(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2) {
+		super(arg);
+		if (arg2 == null) {
+			throw new java.lang.NullPointerException("arg2 is marked non-null but is null");
+		}
+		if (arg == null) throw new NullPointerException();
+	}
+	public void test2(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull String arg3) {
+		if (arg == null) {
+			throw new java.lang.NullPointerException("arg is marked non-null but is null");
+		}
+		if (arg3 == null) {
+			throw new java.lang.NullPointerException("arg3 is marked non-null but is null");
+		}
+		if (arg2 == null) {
+			throw new NullPointerException("arg2");
+		}
+		if (arg == null) System.out.println("Hello");
+	}
+	public void test3(@javax.annotation.Nonnull String arg) {
+		if (arg == null) {
+			throw new java.lang.NullPointerException("arg is marked non-null but is null");
+		}
+		if (arg != null) throw new IllegalStateException();
+	}
+	public void test(@javax.annotation.Nonnull String stringArg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
+		if (stringArg == null) {
+			throw new java.lang.NullPointerException("stringArg is marked non-null but is null");
+		}
+		if (arg2 == null) {
+			throw new java.lang.NullPointerException("arg2 is marked non-null but is null");
+		}
+	}
+	public void test(@javax.annotation.Nonnull String arg) {
+		if (arg == null) {
+			throw new java.lang.NullPointerException("arg is marked non-null but is null");
+		}
+		System.out.println("Hey");
+		if (arg == null) throw new NullPointerException();
+	}
+	public void testWithAssert(@javax.annotation.Nonnull String param) {
+		assert param != null;
+	}
+	public void testWithAssertAndMessage(@javax.annotation.Nonnull String param) {
+		assert param != null : "Oops";
+	}
+}

--- a/test/transform/resource/after-delombok/NonNullJavaxPlain.java
+++ b/test/transform/resource/after-delombok/NonNullJavaxPlain.java
@@ -1,0 +1,43 @@
+//version 8:
+import java.lang.annotation.*;
+
+class NonNullJavaxPlain {
+	@javax.annotation.Nonnull
+	int i;
+	@javax.annotation.Nonnull
+	String s;
+
+	@java.lang.SuppressWarnings("all")
+	public NonNullJavaxPlain(@javax.annotation.Nonnull final int i, @javax.annotation.Nonnull final String s) {
+		if (s == null) {
+			throw new java.lang.NullPointerException("s is marked non-null but is null");
+		}
+		this.i = i;
+		this.s = s;
+	}
+
+	@javax.annotation.Nonnull
+	@java.lang.SuppressWarnings("all")
+	public int getI() {
+		return this.i;
+	}
+
+	@javax.annotation.Nonnull
+	@java.lang.SuppressWarnings("all")
+	public String getS() {
+		return this.s;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public void setI(@javax.annotation.Nonnull final int i) {
+		this.i = i;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public void setS(@javax.annotation.Nonnull final String s) {
+		if (s == null) {
+			throw new java.lang.NullPointerException("s is marked non-null but is null");
+		}
+		this.s = s;
+	}
+}

--- a/test/transform/resource/after-delombok/NonNullNoJavaxOnParameter.java
+++ b/test/transform/resource/after-delombok/NonNullNoJavaxOnParameter.java
@@ -1,0 +1,41 @@
+//version 8:
+//CONF: lombok.nonNull.useForeignAnnotations = false
+import javax.annotation.Nonnull;
+
+class NonNullNoJavaxOnParameter extends Thread {
+	NonNullNoJavaxOnParameter(@javax.annotation.Nonnull String arg) {
+		this(arg, "");
+	}
+
+	NonNullNoJavaxOnParameter(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2) {
+		super(arg);
+		if (arg == null) throw new NullPointerException();
+	}
+
+	public void test2(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull String arg3) {
+		if (arg2 == null) {
+			throw new NullPointerException("arg2");
+		}
+		if (arg == null) System.out.println("Hello");
+	}
+
+	public void test3(@javax.annotation.Nonnull String arg) {
+		if (arg != null) throw new IllegalStateException();
+	}
+
+	public void test(@javax.annotation.Nonnull String stringArg, @Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
+	}
+
+	public void test(@javax.annotation.Nonnull String arg) {
+		System.out.println("Hey");
+		if (arg == null) throw new NullPointerException();
+	}
+
+	public void testWithAssert(@javax.annotation.Nonnull String param) {
+		assert param != null;
+	}
+
+	public void testWithAssertAndMessage(@javax.annotation.Nonnull String param) {
+		assert param != null : "Oops";
+	}
+}

--- a/test/transform/resource/after-delombok/NonNullNoJavaxPlain.java
+++ b/test/transform/resource/after-delombok/NonNullNoJavaxPlain.java
@@ -1,0 +1,36 @@
+//version 8:
+//CONF: lombok.nonNull.useForeignAnnotations = false
+import java.lang.annotation.*;
+
+class NonNullNoJavaxPlain {
+	@javax.annotation.Nonnull
+	int i;
+	@javax.annotation.Nonnull
+	String s;
+
+	@java.lang.SuppressWarnings("all")
+	public NonNullNoJavaxPlain() {
+	}
+
+	@javax.annotation.Nonnull
+	@java.lang.SuppressWarnings("all")
+	public int getI() {
+		return this.i;
+	}
+
+	@javax.annotation.Nonnull
+	@java.lang.SuppressWarnings("all")
+	public String getS() {
+		return this.s;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public void setI(@javax.annotation.Nonnull final int i) {
+		this.i = i;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public void setS(@javax.annotation.Nonnull final String s) {
+		this.s = s;
+	}
+}

--- a/test/transform/resource/after-ecj/NonNullJavaxOnParameter.java
+++ b/test/transform/resource/after-ecj/NonNullJavaxOnParameter.java
@@ -1,3 +1,4 @@
+import javax.annotation.Nonnull;
 class NonNullJavaxOnParameter extends Thread {
   <clinit>() {
   }
@@ -41,7 +42,7 @@ class NonNullJavaxOnParameter extends Thread {
     if ((arg != null))
         throw new IllegalStateException();
   }
-  public void test(@javax.annotation.Nonnull String stringArg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
+  public void test(@javax.annotation.Nonnull String stringArg, @Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
     if ((stringArg == null))
         {
           throw new java.lang.NullPointerException("stringArg is marked non-null but is null");

--- a/test/transform/resource/after-ecj/NonNullJavaxOnParameter.java
+++ b/test/transform/resource/after-ecj/NonNullJavaxOnParameter.java
@@ -1,0 +1,69 @@
+class NonNullJavaxOnParameter extends Thread {
+  <clinit>() {
+  }
+  NonNullJavaxOnParameter(@javax.annotation.Nonnull String arg) {
+    this(arg, "");
+    if ((arg == null))
+        {
+          throw new java.lang.NullPointerException("arg is marked non-null but is null");
+        }
+  }
+  NonNullJavaxOnParameter(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2) {
+    super(arg);
+    if ((arg2 == null))
+        {
+          throw new java.lang.NullPointerException("arg2 is marked non-null but is null");
+        }
+    if ((arg == null))
+        throw new NullPointerException();
+  }
+  public void test2(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull String arg3) {
+    if ((arg == null))
+        {
+          throw new java.lang.NullPointerException("arg is marked non-null but is null");
+        }
+    if ((arg3 == null))
+        {
+          throw new java.lang.NullPointerException("arg3 is marked non-null but is null");
+        }
+    if ((arg2 == null))
+        {
+          throw new NullPointerException("arg2");
+        }
+    if ((arg == null))
+        System.out.println("Hello");
+  }
+  public void test3(@javax.annotation.Nonnull String arg) {
+    if ((arg == null))
+        {
+          throw new java.lang.NullPointerException("arg is marked non-null but is null");
+        }
+    if ((arg != null))
+        throw new IllegalStateException();
+  }
+  public void test(@javax.annotation.Nonnull String stringArg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
+    if ((stringArg == null))
+        {
+          throw new java.lang.NullPointerException("stringArg is marked non-null but is null");
+        }
+    if ((arg2 == null))
+        {
+          throw new java.lang.NullPointerException("arg2 is marked non-null but is null");
+        }
+  }
+  public void test(@javax.annotation.Nonnull String arg) {
+    if ((arg == null))
+        {
+          throw new java.lang.NullPointerException("arg is marked non-null but is null");
+        }
+    System.out.println("Hey");
+    if ((arg == null))
+        throw new NullPointerException();
+  }
+  public void testWithAssert(@javax.annotation.Nonnull String param) {
+    assert (param != null);
+  }
+  public void testWithAssertAndMessage(@javax.annotation.Nonnull String param) {
+    assert (param != null): "Oops";
+  }
+}

--- a/test/transform/resource/after-ecj/NonNullJavaxPlain.java
+++ b/test/transform/resource/after-ecj/NonNullJavaxPlain.java
@@ -1,0 +1,30 @@
+import java.lang.annotation.*;
+@lombok.RequiredArgsConstructor @lombok.Getter @lombok.Setter class NonNullJavaxPlain {
+  @javax.annotation.Nonnull int i;
+  @javax.annotation.Nonnull String s;
+  public @java.lang.SuppressWarnings("all") NonNullJavaxPlain(final @javax.annotation.Nonnull int i, final @javax.annotation.Nonnull String s) {
+    super();
+    if ((s == null))
+        {
+          throw new java.lang.NullPointerException("s is marked non-null but is null");
+        }
+    this.i = i;
+    this.s = s;
+  }
+  public @javax.annotation.Nonnull @java.lang.SuppressWarnings("all") int getI() {
+    return this.i;
+  }
+  public @javax.annotation.Nonnull @java.lang.SuppressWarnings("all") String getS() {
+    return this.s;
+  }
+  public @java.lang.SuppressWarnings("all") void setI(final @javax.annotation.Nonnull int i) {
+    this.i = i;
+  }
+  public @java.lang.SuppressWarnings("all") void setS(final @javax.annotation.Nonnull String s) {
+    if ((s == null))
+        {
+          throw new java.lang.NullPointerException("s is marked non-null but is null");
+        }
+    this.s = s;
+  }
+}

--- a/test/transform/resource/after-ecj/NonNullNoJavaxOnParameter.java
+++ b/test/transform/resource/after-ecj/NonNullNoJavaxOnParameter.java
@@ -1,0 +1,38 @@
+import javax.annotation.Nonnull;
+class NonNullNoJavaxOnParameter extends Thread {
+  <clinit>() {
+  }
+  NonNullNoJavaxOnParameter(@javax.annotation.Nonnull String arg) {
+    this(arg, "");
+  }
+  NonNullNoJavaxOnParameter(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2) {
+    super(arg);
+    if ((arg == null))
+        throw new NullPointerException();
+  }
+  public void test2(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull String arg3) {
+    if ((arg2 == null))
+        {
+          throw new NullPointerException("arg2");
+        }
+    if ((arg == null))
+        System.out.println("Hello");
+  }
+  public void test3(@javax.annotation.Nonnull String arg) {
+    if ((arg != null))
+        throw new IllegalStateException();
+  }
+  public void test(@javax.annotation.Nonnull String stringArg, @Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
+  }
+  public void test(@javax.annotation.Nonnull String arg) {
+    System.out.println("Hey");
+    if ((arg == null))
+        throw new NullPointerException();
+  }
+  public void testWithAssert(@javax.annotation.Nonnull String param) {
+    assert (param != null);
+  }
+  public void testWithAssertAndMessage(@javax.annotation.Nonnull String param) {
+    assert (param != null): "Oops";
+  }
+}

--- a/test/transform/resource/after-ecj/NonNullNoJavaxPlain.java
+++ b/test/transform/resource/after-ecj/NonNullNoJavaxPlain.java
@@ -1,0 +1,20 @@
+import java.lang.annotation.*;
+@lombok.RequiredArgsConstructor @lombok.Getter @lombok.Setter class NonNullNoJavaxPlain {
+  @javax.annotation.Nonnull int i;
+  @javax.annotation.Nonnull String s;
+  public @java.lang.SuppressWarnings("all") NonNullNoJavaxPlain() {
+    super();
+  }
+  public @javax.annotation.Nonnull @java.lang.SuppressWarnings("all") int getI() {
+    return this.i;
+  }
+  public @javax.annotation.Nonnull @java.lang.SuppressWarnings("all") String getS() {
+    return this.s;
+  }
+  public @java.lang.SuppressWarnings("all") void setI(final @javax.annotation.Nonnull int i) {
+    this.i = i;
+  }
+  public @java.lang.SuppressWarnings("all") void setS(final @javax.annotation.Nonnull String s) {
+    this.s = s;
+  }
+}

--- a/test/transform/resource/before/NonNullJavaxOnParameter.java
+++ b/test/transform/resource/before/NonNullJavaxOnParameter.java
@@ -1,0 +1,40 @@
+//version 8:
+class NonNullJavaxOnParameter extends Thread {
+	NonNullJavaxOnParameter(@javax.annotation.Nonnull String arg) {
+		this(arg, "");
+	}
+	
+	NonNullJavaxOnParameter(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2) {
+		super(arg);
+		if (arg == null) throw new NullPointerException();
+	}
+	
+	public void test2(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull String arg3) {
+		if (arg2 == null) {
+			throw new NullPointerException("arg2");
+		}
+		if (arg == null) System.out.println("Hello");
+	}
+	
+	public void test3(@javax.annotation.Nonnull String arg) {
+		if (arg != null) throw new IllegalStateException();
+	}
+	
+	public void test(@javax.annotation.Nonnull String stringArg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
+		
+	}
+	
+	public void test(@javax.annotation.Nonnull String arg) {
+		System.out.println("Hey");
+		if (arg == null) throw new NullPointerException();
+	}
+	
+	public void testWithAssert(@javax.annotation.Nonnull String param) {
+		assert param != null;
+	}
+	
+	public void testWithAssertAndMessage(@javax.annotation.Nonnull String param) {
+		assert param != null : "Oops";
+	}
+
+}

--- a/test/transform/resource/before/NonNullJavaxOnParameter.java
+++ b/test/transform/resource/before/NonNullJavaxOnParameter.java
@@ -1,4 +1,5 @@
 //version 8:
+import javax.annotation.Nonnull;
 class NonNullJavaxOnParameter extends Thread {
 	NonNullJavaxOnParameter(@javax.annotation.Nonnull String arg) {
 		this(arg, "");
@@ -20,7 +21,7 @@ class NonNullJavaxOnParameter extends Thread {
 		if (arg != null) throw new IllegalStateException();
 	}
 	
-	public void test(@javax.annotation.Nonnull String stringArg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
+	public void test(@javax.annotation.Nonnull String stringArg, @Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
 		
 	}
 	

--- a/test/transform/resource/before/NonNullJavaxPlain.java
+++ b/test/transform/resource/before/NonNullJavaxPlain.java
@@ -1,0 +1,12 @@
+//version 8:
+import java.lang.annotation.*;
+
+@lombok.RequiredArgsConstructor
+@lombok.Getter
+@lombok.Setter
+class NonNullJavaxPlain {
+	@javax.annotation.Nonnull
+	int i;
+	@javax.annotation.Nonnull
+	String s;
+}

--- a/test/transform/resource/before/NonNullNoJavaxOnParameter.java
+++ b/test/transform/resource/before/NonNullNoJavaxOnParameter.java
@@ -1,0 +1,43 @@
+//version 8:
+//unchanged
+//CONF: lombok.nonNull.useForeignAnnotations = false
+import javax.annotation.Nonnull;
+class NonNullNoJavaxOnParameter extends Thread {
+	NonNullNoJavaxOnParameter(@javax.annotation.Nonnull String arg) {
+		this(arg, "");
+	}
+
+	NonNullNoJavaxOnParameter(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2) {
+		super(arg);
+		if (arg == null) throw new NullPointerException();
+	}
+	
+	public void test2(@javax.annotation.Nonnull String arg, @javax.annotation.Nonnull String arg2, @javax.annotation.Nonnull String arg3) {
+		if (arg2 == null) {
+			throw new NullPointerException("arg2");
+		}
+		if (arg == null) System.out.println("Hello");
+	}
+	
+	public void test3(@javax.annotation.Nonnull String arg) {
+		if (arg != null) throw new IllegalStateException();
+	}
+	
+	public void test(@javax.annotation.Nonnull String stringArg, @Nonnull String arg2, @javax.annotation.Nonnull int primitiveArg) {
+		
+	}
+	
+	public void test(@javax.annotation.Nonnull String arg) {
+		System.out.println("Hey");
+		if (arg == null) throw new NullPointerException();
+	}
+	
+	public void testWithAssert(@javax.annotation.Nonnull String param) {
+		assert param != null;
+	}
+	
+	public void testWithAssertAndMessage(@javax.annotation.Nonnull String param) {
+		assert param != null : "Oops";
+	}
+
+}

--- a/test/transform/resource/before/NonNullNoJavaxPlain.java
+++ b/test/transform/resource/before/NonNullNoJavaxPlain.java
@@ -1,0 +1,13 @@
+//version 8:
+//CONF: lombok.nonNull.useForeignAnnotations = false
+import java.lang.annotation.*;
+
+@lombok.RequiredArgsConstructor
+@lombok.Getter
+@lombok.Setter
+class NonNullNoJavaxPlain {
+	@javax.annotation.Nonnull
+	int i;
+	@javax.annotation.Nonnull
+	String s;
+}

--- a/test/transform/resource/messages-delombok/NonNullJavaxOnParameter.java.messages
+++ b/test/transform/resource/messages-delombok/NonNullJavaxOnParameter.java.messages
@@ -1,0 +1,1 @@
+23 @NonNull is meaningless on a primitive.

--- a/test/transform/resource/messages-delombok/NonNullJavaxPlain.java.messages
+++ b/test/transform/resource/messages-delombok/NonNullJavaxPlain.java.messages
@@ -1,0 +1,3 @@
+8 @NonNull is meaningless on a primitive.
+4 @NonNull is meaningless on a primitive.
+6 @NonNull is meaningless on a primitive.

--- a/test/transform/resource/messages-ecj/NonNullJavaxOnParameter.java.messages
+++ b/test/transform/resource/messages-ecj/NonNullJavaxOnParameter.java.messages
@@ -1,0 +1,3 @@
+16 Dead code
+23 @NonNull is meaningless on a primitive.
+29 Dead code

--- a/test/transform/resource/messages-ecj/NonNullJavaxPlain.java.messages
+++ b/test/transform/resource/messages-ecj/NonNullJavaxPlain.java.messages
@@ -1,0 +1,1 @@
+8 @NonNull is meaningless on a primitive.

--- a/test/transform/resource/messages-idempotent/NonNullJavaxOnParameter.java.messages
+++ b/test/transform/resource/messages-idempotent/NonNullJavaxOnParameter.java.messages
@@ -1,0 +1,1 @@
+34 @NonNull is meaningless on a primitive.

--- a/test/transform/resource/messages-idempotent/NonNullJavaxPlain.java.messages
+++ b/test/transform/resource/messages-idempotent/NonNullJavaxPlain.java.messages
@@ -1,0 +1,3 @@
+5 @NonNull is meaningless on a primitive.
+11 @NonNull is meaningless on a primitive.
+32 @NonNull is meaningless on a primitive.


### PR DESCRIPTION
See #3305 

This PR fixes the inconsistent behaviour, that non-lombok `@NonNull` annotations are honored at fields, but not on method/constructor parameters.

It also adds a config option to completely turn off or on the use of foreign nonNull annotations