### PR TITLE
[FEATURE] Add internString boolean flag on @Setter Annotation to reuse JVM string pool if you want

### DIFF
--- a/src/core/lombok/Setter.java
+++ b/src/core/lombok/Setter.java
@@ -92,4 +92,12 @@ public @interface Setter {
 	@Retention(RetentionPolicy.SOURCE)
 	@Target({})
 	@interface AnyAnnotation {}
+	
+	/**
+	 * If you want your setter to invoke {@link java.lang.String#intern() String.intern()} on input string to reuse JVM string pool, you can turn this to true.
+	 * Note: Can only take effect to String field. And a field level @Setter annotation can override type level @Setter annotation on this feature.
+	 * 
+	 * @return Whether or not use {@link java.lang.String#intern() String.intern()} on input string to reuse JVM string pool.
+	 */
+	boolean internString() default false;
 }

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -1050,7 +1050,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		Annotation[] methodAnns = EclipseHandlerUtil.findCopyableToSetterAnnotations(bfd.originalFieldNode);
 		if (methodAnns != null && methodAnns.length > 0) methodAnnsList = Arrays.asList(methodAnns);
 		ASTNode source = job.sourceNode.get();
-		MethodDeclaration setter = HandleSetter.createSetter(td, deprecate, fieldNode, setterName, bfd.name, bfd.nameOfSetFlag, job.oldChain, toEclipseModifier(job.accessInners),
+		MethodDeclaration setter = HandleSetter.createSetter(td, false, deprecate, fieldNode, setterName, bfd.name, bfd.nameOfSetFlag, job.oldChain, toEclipseModifier(job.accessInners),
 			job.sourceNode, methodAnnsList, bfd.annotations != null ? Arrays.asList(copyAnnotations(source, bfd.annotations)) : Collections.<Annotation>emptyList());
 		if (job.sourceNode.up().getKind() == Kind.METHOD) {
 			copyJavadocFromParam(bfd.originalFieldNode.up(), setter, td, bfd.name.toString());

--- a/src/core/lombok/eclipse/handlers/HandleData.java
+++ b/src/core/lombok/eclipse/handlers/HandleData.java
@@ -66,7 +66,7 @@ public class HandleData extends EclipseAnnotationHandler<Data> {
 		//and hitting 'find callers'.
 		
 		handleGetter.generateGetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true, Collections.<Annotation>emptyList());
-		handleSetter.generateSetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true, Collections.<Annotation>emptyList(), Collections.<Annotation>emptyList());
+		handleSetter.generateSetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, false, true, Collections.<Annotation>emptyList(), Collections.<Annotation>emptyList());
 		handleEqualsAndHashCode.generateEqualsAndHashCodeForType(typeNode, annotationNode);
 		handleToString.generateToStringForType(typeNode, annotationNode);
 		handleConstructor.generateRequiredArgsConstructor(

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -1009,7 +1009,7 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		
 		List<Annotation> methodAnnsList = Arrays.asList(EclipseHandlerUtil.findCopyableToSetterAnnotations(originalFieldNode));
 		addCheckerFrameworkReturnsReceiver(returnType, job.source, job.checkerFramework);
-		MethodDeclaration setter = HandleSetter.createSetter(td, deprecate, fieldNode, setterName, paramName, nameOfSetFlag, returnType, returnStatement, ClassFileConstants.AccPublic,
+		MethodDeclaration setter = HandleSetter.createSetter(td, false, deprecate, fieldNode, setterName, paramName, nameOfSetFlag, returnType, returnStatement, ClassFileConstants.AccPublic,
 			job.sourceNode, methodAnnsList, annosOnParam != null ? Arrays.asList(copyAnnotations(job.source, annosOnParam)) : Collections.<Annotation>emptyList());
 		if (job.sourceNode.up().getKind() == Kind.METHOD) {
 			copyJavadocFromParam(originalFieldNode.up(), setter, td, paramName.toString());

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -931,7 +931,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 		JavacTreeMaker maker = fieldNode.getTreeMaker();
 		
 		List<JCAnnotation> methodAnns = JavacHandlerUtil.findCopyableToSetterAnnotations(bfd.originalFieldNode);
-		JCMethodDecl newMethod = HandleSetter.createSetter(toJavacModifier(job.accessInners), deprecate, fieldNode, maker, setterName, bfd.name, bfd.nameOfSetFlag, job.oldChain, job.sourceNode, methodAnns, bfd.annotations);
+		JCMethodDecl newMethod = HandleSetter.createSetter(toJavacModifier(job.accessInners), false, deprecate, fieldNode, maker, setterName, bfd.name, bfd.nameOfSetFlag, job.oldChain, job.sourceNode, methodAnns, bfd.annotations);
 		recursiveSetGeneratedBy(newMethod, job.sourceNode);
 		if (job.sourceNode.up().getKind() == Kind.METHOD) {
 			copyJavadocFromParam(bfd.originalFieldNode.up(), newMethod, bfd.name.toString());

--- a/src/core/lombok/javac/handlers/HandleData.java
+++ b/src/core/lombok/javac/handlers/HandleData.java
@@ -63,7 +63,7 @@ public class HandleData extends JavacAnnotationHandler<Data> {
 		handleConstructor.generateRequiredArgsConstructor(typeNode, AccessLevel.PUBLIC, staticConstructorName, SkipIfConstructorExists.YES, annotationNode);
 		handleConstructor.generateExtraNoArgsConstructor(typeNode, annotationNode);
 		handleGetter.generateGetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true, List.<JCAnnotation>nil());
-		handleSetter.generateSetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true, List.<JCAnnotation>nil(), List.<JCAnnotation>nil());
+		handleSetter.generateSetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, false, true, List.<JCAnnotation>nil(), List.<JCAnnotation>nil());
 		handleEqualsAndHashCode.generateEqualsAndHashCodeForType(typeNode, annotationNode);
 		handleToString.generateToStringForType(typeNode, annotationNode);
 	}

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -966,7 +966,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		List<JCAnnotation> methodAnns = JavacHandlerUtil.findCopyableToSetterAnnotations(originalFieldNode);
 		returnType = addCheckerFrameworkReturnsReceiver(returnType, maker, job.builderType, job.checkerFramework);
 
-		JCMethodDecl newMethod = HandleSetter.createSetter(Flags.PUBLIC, deprecate, fieldNode, maker, setterName, paramName, nameOfSetFlag, returnType, returnStatement, job.sourceNode, methodAnns, annosOnParam);
+		JCMethodDecl newMethod = HandleSetter.createSetter(Flags.PUBLIC, false, deprecate, fieldNode, maker, setterName, paramName, nameOfSetFlag, returnType, returnStatement, job.sourceNode, methodAnns, annosOnParam);
 		if (job.sourceNode.up().getKind() == Kind.METHOD) {
 			copyJavadocFromParam(originalFieldNode.up(), newMethod, paramName.toString());
 		} else {

--- a/test/transform/resource/after-delombok/SetterInternOnClass.java
+++ b/test/transform/resource/after-delombok/SetterInternOnClass.java
@@ -1,0 +1,20 @@
+public class SetterInternOnClass {
+	private String str1;
+	private java.lang.String str2;
+	private int int1;
+
+	@java.lang.SuppressWarnings("all")
+	public void setStr1(final String str1) {
+		this.str1 = str1 == null ? null : str1.intern();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public void setStr2(final java.lang.String str2) {
+		this.str2 = str2 == null ? null : str2.intern();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public void setInt1(final int int1) {
+		this.int1 = int1;
+	}
+}

--- a/test/transform/resource/after-delombok/SetterInternOnField.java
+++ b/test/transform/resource/after-delombok/SetterInternOnField.java
@@ -1,0 +1,20 @@
+public class SetterInternOnField {
+	private String str1;
+	private java.lang.String str2;
+	private String str3;
+
+	@java.lang.SuppressWarnings("all")
+	public void setStr3(final String str3) {
+		this.str3 = str3;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public void setStr1(final String str1) {
+		this.str1 = str1 == null ? null : str1.intern();
+	}
+	
+	@java.lang.SuppressWarnings("all")
+	public void setStr2(final java.lang.String str2) {
+		this.str2 = str2 == null ? null : str2.intern();
+	}
+}

--- a/test/transform/resource/after-delombok/SetterInternWithBuilder.java
+++ b/test/transform/resource/after-delombok/SetterInternWithBuilder.java
@@ -1,0 +1,49 @@
+public class SetterInternWithBuilder {
+	private String str1;
+
+	@java.lang.SuppressWarnings("all")
+	SetterInternWithBuilder(final String str1) {
+		this.str1 = str1;
+	}
+
+
+	@java.lang.SuppressWarnings("all")
+	public static class SetterInternWithBuilderBuilder {
+		@java.lang.SuppressWarnings("all")
+		private String str1;
+
+		@java.lang.SuppressWarnings("all")
+		SetterInternWithBuilderBuilder() {
+		}
+
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		public SetterInternWithBuilder.SetterInternWithBuilderBuilder str1(final String str1) {
+			this.str1 = str1;
+			return this;
+		}
+
+		@java.lang.SuppressWarnings("all")
+		public SetterInternWithBuilder build() {
+			return new SetterInternWithBuilder(this.str1);
+		}
+
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "SetterInternWithBuilder.SetterInternWithBuilderBuilder(str1=" + this.str1 + ")";
+		}
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public static SetterInternWithBuilder.SetterInternWithBuilderBuilder builder() {
+		return new SetterInternWithBuilder.SetterInternWithBuilderBuilder();
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public void setStr1(final String str1) {
+		this.str1 = str1 == null ? null : str1.intern();
+	}
+}

--- a/test/transform/resource/after-delombok/SetterInternWithData.java
+++ b/test/transform/resource/after-delombok/SetterInternWithData.java
@@ -1,0 +1,51 @@
+public class SetterInternWithData {
+	private String str1;
+
+	@java.lang.SuppressWarnings("all")
+	public SetterInternWithData() {
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public String getStr1() {
+		return this.str1;
+	}
+
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	public boolean equals(final java.lang.Object o) {
+		if (o == this) return true;
+		if (!(o instanceof SetterInternWithData)) return false;
+		final SetterInternWithData other = (SetterInternWithData) o;
+		if (!other.canEqual((java.lang.Object) this)) return false;
+		final java.lang.Object this$str1 = this.getStr1();
+		final java.lang.Object other$str1 = other.getStr1();
+		if (this$str1 == null ? other$str1 != null : !this$str1.equals(other$str1)) return false;
+		return true;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	protected boolean canEqual(final java.lang.Object other) {
+		return other instanceof SetterInternWithData;
+	}
+
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	public int hashCode() {
+		final int PRIME = 59;
+		int result = 1;
+		final java.lang.Object $str1 = this.getStr1();
+		result = result * PRIME + ($str1 == null ? 43 : $str1.hashCode());
+		return result;
+	}
+
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	public java.lang.String toString() {
+		return "SetterInternWithData(str1=" + this.getStr1() + ")";
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public void setStr1(final String str1) {
+		this.str1 = str1 == null ? null : str1.intern();
+	}
+}

--- a/test/transform/resource/after-ecj/SetterInternOnClass.java
+++ b/test/transform/resource/after-ecj/SetterInternOnClass.java
@@ -1,0 +1,18 @@
+import lombok.Setter;
+public @Setter(internString = true) class SetterInternOnClass {
+  private String str1;
+  private java.lang.String str2;
+  private int int1;
+  public SetterInternOnClass() {
+    super();
+  }
+  public @java.lang.SuppressWarnings("all") void setStr1(final String str1) {
+    this.str1 = ((str1 == null) ? null : str1.intern());
+  }
+  public @java.lang.SuppressWarnings("all") void setStr2(final java.lang.String str2) {
+    this.str2 = ((str2 == null) ? null : str2.intern());
+  }
+  public @java.lang.SuppressWarnings("all") void setInt1(final int int1) {
+    this.int1 = int1;
+  }
+}

--- a/test/transform/resource/after-ecj/SetterInternOnField.java
+++ b/test/transform/resource/after-ecj/SetterInternOnField.java
@@ -1,0 +1,18 @@
+import lombok.Setter;
+public @Setter class SetterInternOnField {
+  private @Setter(internString = true) String str1;
+  private @Setter(internString = true) java.lang.String str2;
+  private String str3;
+  public SetterInternOnField() {
+    super();
+  }
+  public @java.lang.SuppressWarnings("all") void setStr1(final String str1) {
+    this.str1 = ((str1 == null) ? null : str1.intern());
+  }
+  public @java.lang.SuppressWarnings("all") void setStr2(final java.lang.String str2) {
+    this.str2 = ((str2 == null) ? null : str2.intern());
+  }
+  public @java.lang.SuppressWarnings("all") void setStr3(final String str3) {
+    this.str3 = str3;
+  }
+}

--- a/test/transform/resource/after-ecj/SetterInternWithBuilder.java
+++ b/test/transform/resource/after-ecj/SetterInternWithBuilder.java
@@ -1,0 +1,34 @@
+import lombok.Setter;
+import lombok.Builder;
+public @Builder class SetterInternWithBuilder {
+  public static @java.lang.SuppressWarnings("all") class SetterInternWithBuilderBuilder {
+    private @java.lang.SuppressWarnings("all") String str1;
+    @java.lang.SuppressWarnings("all") SetterInternWithBuilderBuilder() {
+      super();
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") SetterInternWithBuilder.SetterInternWithBuilderBuilder str1(final String str1) {
+      this.str1 = str1;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") SetterInternWithBuilder build() {
+      return new SetterInternWithBuilder(this.str1);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (("SetterInternWithBuilder.SetterInternWithBuilderBuilder(str1=" + this.str1) + ")");
+    }
+  }
+  private @Setter(internString = true) String str1;
+  @java.lang.SuppressWarnings("all") SetterInternWithBuilder(final String str1) {
+    super();
+    this.str1 = str1;
+  }
+  public static @java.lang.SuppressWarnings("all") SetterInternWithBuilder.SetterInternWithBuilderBuilder builder() {
+    return new SetterInternWithBuilder.SetterInternWithBuilderBuilder();
+  }
+  public @java.lang.SuppressWarnings("all") void setStr1(final String str1) {
+    this.str1 = ((str1 == null) ? null : str1.intern());
+  }
+}

--- a/test/transform/resource/after-ecj/SetterInternWithData.java
+++ b/test/transform/resource/after-ecj/SetterInternWithData.java
@@ -1,0 +1,41 @@
+import lombok.Setter;
+import lombok.Data;
+public @Data class SetterInternWithData {
+  private @Setter(internString = true) String str1;
+  public @java.lang.SuppressWarnings("all") void setStr1(final String str1) {
+    this.str1 = ((str1 == null) ? null : str1.intern());
+  }
+  public @java.lang.SuppressWarnings("all") String getStr1() {
+    return this.str1;
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") boolean equals(final java.lang.Object o) {
+    if ((o == this))
+        return true;
+    if ((! (o instanceof SetterInternWithData)))
+        return false;
+    final SetterInternWithData other = (SetterInternWithData) o;
+    if ((! other.canEqual((java.lang.Object) this)))
+        return false;
+    final java.lang.Object this$str1 = this.getStr1();
+    final java.lang.Object other$str1 = other.getStr1();
+    if (((this$str1 == null) ? (other$str1 != null) : (! this$str1.equals(other$str1))))
+        return false;
+    return true;
+  }
+  protected @java.lang.SuppressWarnings("all") boolean canEqual(final java.lang.Object other) {
+    return (other instanceof SetterInternWithData);
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") int hashCode() {
+    final int PRIME = 59;
+    int result = 1;
+    final java.lang.Object $str1 = this.getStr1();
+    result = ((result * PRIME) + (($str1 == null) ? 43 : $str1.hashCode()));
+    return result;
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+    return (("SetterInternWithData(str1=" + this.getStr1()) + ")");
+  }
+  public @java.lang.SuppressWarnings("all") SetterInternWithData() {
+    super();
+  }
+}

--- a/test/transform/resource/before/SetterInternOnClass.java
+++ b/test/transform/resource/before/SetterInternOnClass.java
@@ -1,0 +1,8 @@
+import lombok.Setter;
+
+@Setter(internString = true)
+public class SetterInternOnClass {
+	private String str1;
+    private java.lang.String str2;
+	private int int1;
+}

--- a/test/transform/resource/before/SetterInternOnField.java
+++ b/test/transform/resource/before/SetterInternOnField.java
@@ -1,0 +1,10 @@
+import lombok.Setter;
+
+@Setter
+public class SetterInternOnField {
+	@Setter(internString = true)
+    private String str1;
+	@Setter(internString = true)
+    private java.lang.String str2;
+	private String str3;
+}

--- a/test/transform/resource/before/SetterInternWithBuilder.java
+++ b/test/transform/resource/before/SetterInternWithBuilder.java
@@ -1,0 +1,8 @@
+import lombok.Setter;
+import lombok.Builder;
+
+@Builder
+public class SetterInternWithBuilder {
+	@Setter(internString = true)
+    private String str1;
+}

--- a/test/transform/resource/before/SetterInternWithData.java
+++ b/test/transform/resource/before/SetterInternWithData.java
@@ -1,0 +1,8 @@
+import lombok.Setter;
+import lombok.Data;
+
+@Data
+public class SetterInternWithData {
+	@Setter(internString = true)
+    private String str1;
+}


### PR DESCRIPTION
**Describe the feature**
Add internString boolean flag on @Setter Annotation. 

```Java
	/**
	 * If you want your setter to invoke {@link java.lang.String#intern() String.intern()} on input string to reuse JVM string pool, you can turn this to true.
	 * Note: Can only take effect to String field. And a field level @Setter annotation can override type level @Setter annotation on this feature.
	 * 
	 * @return Whether or not use {@link java.lang.String#intern() String.intern()} on input string to reuse JVM string pool.
	 */
	boolean internString() default false;
```

Example1
```
import lombok.Setter;

@Setter(internString = true)
public class SetterInternOnClass {
	private String str1;
    private java.lang.String str2;
	private int int1;
}
```
Will be compiled as 
```
public class SetterInternOnClass {
	private String str1;
	private java.lang.String str2;
	private int int1;

	@java.lang.SuppressWarnings("all")
	public void setStr1(final String str1) {
		this.str1 = str1 == null ? null : str1.intern();
	}

	@java.lang.SuppressWarnings("all")
	public void setStr2(final java.lang.String str2) {
		this.str2 = str2 == null ? null : str2.intern();
	}

	@java.lang.SuppressWarnings("all")
	public void setInt1(final int int1) {
		this.int1 = int1;
	}
}
```

Example2
```
import lombok.Setter;

@Setter
public class SetterInternOnField {
	@Setter(internString = true)
    private String str1;
	@Setter(internString = true)
    private java.lang.String str2;
	private String str3;
}
```
Will be compiled as 
```
public class SetterInternOnField {
	private String str1;
	private java.lang.String str2;
	private String str3;

	@java.lang.SuppressWarnings("all")
	public void setStr3(final String str3) {
		this.str3 = str3;
	}

	@java.lang.SuppressWarnings("all")
	public void setStr1(final String str1) {
		this.str1 = str1 == null ? null : str1.intern();
	}
	
	@java.lang.SuppressWarnings("all")
	public void setStr2(final java.lang.String str2) {
		this.str2 = str2 == null ? null : str2.intern();
	}
}
```


**Describe the target audience**
If u have a large number of Java POJOs in you project memory.
And the POJO has some string field that cannot be simply treated hard coded as java enum.
U may have a choice to reduce memory footprint in this case.

Example
```
import lombok.Setter;

@Setter
public class BankAccount {
    private String accountNumber;
    @Setter(internString = true)
    private String currencyCode;
}
```
All cuurenyCodes in the world may change sometimes and cannot be hard coded as enum.
We can get into this.

```
import lombok.Setter;

@Setter
public class BankAccount {
    private String accountNumber;
    @Setter(internString = true)
    private String currencyCode;

    @java.lang.SuppressWarnings("all")
        public void setAccountNumber(final String accountNumber) {
        this.accountNumber= accountNumber;
    }

    @java.lang.SuppressWarnings("all")
        public void setCurrencyCode(final String currencyCode) {
        this.currencyCode= currencyCode== null ? null : currencyCode.intern();
        }
    }
```



