### PR TITLE
Prevent inlining for OperatorId constants 

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -24,9 +24,9 @@ jobs:
           path: |
             ivyCache
             lib
-          key: ${{ runner.os }}-${{ hashFiles('**/ivy.xml') }}
+          key: ivy-${{ hashFiles('**/ivy.xml') }}
           restore-keys: |
-            ${{ runner.os }}-
+            ivy-
         
       - name: Build with Ant
         run: ant -noinput dist
@@ -83,9 +83,9 @@ jobs:
           path: |
             ivyCache
             lib
-          key: ${{ runner.os }}-${{ hashFiles('**/ivy.xml') }}
+          key: ivy-${{ hashFiles('**/ivy.xml') }}
           restore-keys: |
-            ${{ runner.os }}-
+            ivy-
         
       - name: Run tests
         run: ant -noinput test.${{ matrix.goal }}
@@ -100,8 +100,10 @@ jobs:
         - eclipse-202006
         - eclipse-202006-jdk8
         - eclipse-202212
+        - eclipse-202309
         - eclipse-oxygen-full
         - eclipse-2022-03-full
+        - eclipse-2023-09-full
         - ecj11
         - ecj14
         - ecj16
@@ -112,10 +114,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
 
       - name: Cache dependencies
@@ -124,9 +126,25 @@ jobs:
           path: |
             ivyCache
             lib
-          key: ${{ runner.os }}-${{ hashFiles('**/ivy.xml') }}
+          key: ivy-${{ hashFiles('**/ivy.xml') }}
           restore-keys: |
-            ${{ runner.os }}-
+            ivy-
+
+      - name: Cache base testenv
+        if: ${{ !endsWith(matrix.version, 'full') }}
+        uses: actions/cache@v3
+        with:
+          path: |
+            testenv
+          key: base-testenv-${{ hashFiles('**/setup.ant.xml') }}
+
+      - name: Cache full testenv
+        if: ${{ endsWith(matrix.version, 'full') }}
+        uses: actions/cache@v3
+        with:
+          path: |
+            testenv
+          key: ${{ matrix.version }}-testenv-${{ hashFiles('**/setup.ant.xml') }}
           
       - name: Build with Ant
         run: xvfb-run ant -noinput dist test.${{ matrix.version }}

--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -28,9 +28,10 @@
 		<conf name="ecj16" />
 		<conf name="ecj19" />
 		
-		<conf name="eclipse-202212" />
 		<conf name="eclipse-oxygen" />
 		<conf name="eclipse-202006" />
+		<conf name="eclipse-202212" />
+		<conf name="eclipse-202309" />
 		
 		<conf name="mapstruct" />
 	</configurations>
@@ -81,18 +82,6 @@
 		
 		<!-- eclipses -->
 		
-		<dependency org="org.eclipse.platform" name="org.eclipse.core.runtime" rev="3.26.100" conf="eclipse-202212->default" transitive="false" />
-		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.core" rev="3.32.0" conf="eclipse-202212->default" transitive="false" />
-		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.ui" rev="3.27.100" conf="eclipse-202212->default" transitive="false" />
-		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.common" rev="3.17.0" conf="eclipse-202212->default" transitive="false" />
-		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.registry" rev="3.11.200" conf="eclipse-202212->default" transitive="false" />
-		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.app" rev="1.6.200" conf="eclipse-202212->default" transitive="false" />
-		<dependency org="org.eclipse.platform" name="org.eclipse.core.resources" rev="3.18.100" conf="eclipse-202212->default" transitive="false" />
-		<dependency org="org.eclipse.platform" name="org.eclipse.core.contenttype" rev="3.8.200" conf="eclipse-202212->default" transitive="false" />
-		<dependency org="org.eclipse.platform" name="org.eclipse.core.jobs" rev="3.13.200" conf="eclipse-202212->default" transitive="false" />
-		<dependency org="org.eclipse.platform" name="org.eclipse.osgi" rev="3.18.200" conf="eclipse-202212->default" transitive="false" />
-		<dependency org="org.eclipse.platform" name="org.eclipse.text" rev="3.12.300" conf="eclipse-202212->default" transitive="false" />
-		
 		<dependency org="org.eclipse.platform" name="org.eclipse.core.runtime" rev="3.13.0" conf="eclipse-oxygen->default" transitive="false" />
 		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.core" rev="3.13.102" conf="eclipse-oxygen->default" transitive="false" />
 		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.ui" rev="3.13.100" conf="eclipse-oxygen->default" transitive="false" />
@@ -117,6 +106,31 @@
 		<dependency org="org.eclipse.platform" name="org.eclipse.core.jobs" rev="3.10.800" conf="eclipse-202006->default" transitive="false" />
 		<dependency org="org.eclipse.platform" name="org.eclipse.osgi" rev="3.15.300" conf="eclipse-202006->default" transitive="false" />
 		<dependency org="org.eclipse.platform" name="org.eclipse.text" rev="3.10.200" conf="eclipse-202006->default" transitive="false" />
+		
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.runtime" rev="3.26.100" conf="eclipse-202212->default" transitive="false" />
+		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.core" rev="3.32.0" conf="eclipse-202212->default" transitive="false" />
+		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.ui" rev="3.27.100" conf="eclipse-202212->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.common" rev="3.17.0" conf="eclipse-202212->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.registry" rev="3.11.200" conf="eclipse-202212->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.app" rev="1.6.200" conf="eclipse-202212->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.resources" rev="3.18.100" conf="eclipse-202212->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.contenttype" rev="3.8.200" conf="eclipse-202212->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.jobs" rev="3.13.200" conf="eclipse-202212->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.osgi" rev="3.18.200" conf="eclipse-202212->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.text" rev="3.12.300" conf="eclipse-202212->default" transitive="false" />
+		
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.runtime" rev="3.29.0" conf="eclipse-202309->default" transitive="false" />
+		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.core" rev="3.35.0" conf="eclipse-202309->default" transitive="false" />
+		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.ui" rev="3.30.0" conf="eclipse-202309->default" transitive="false" />
+		<dependency org="org.eclipse.jdt" name="ecj" rev="3.35.0" conf="eclipse-202309->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.common" rev="3.18.100" conf="eclipse-202309->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.registry" rev="3.11.300" conf="eclipse-202309->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.app" rev="1.6.300" conf="eclipse-202309->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.resources" rev="3.19.100" conf="eclipse-202309->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.contenttype" rev="3.9.100" conf="eclipse-202309->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.jobs" rev="3.15.0" conf="eclipse-202309->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.osgi" rev="3.18.500" conf="eclipse-202309->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.text" rev="3.13.100" conf="eclipse-202309->default" transitive="false" />
 		
 		<!-- integration with other libraries -->
 		<dependency org="org.mapstruct" name="mapstruct-processor" rev="1.3.1.Final" conf="mapstruct->default" transitive="false" />

--- a/buildScripts/setup.ant.xml
+++ b/buildScripts/setup.ant.xml
@@ -19,7 +19,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 -->
-<project name="lombok.setup" default="deps" xmlns:ivy="antlib:com.zwitserloot.ivyplusplus" basedir="..">
+<project name="lombok.setup" default="deps" xmlns:ivy="antlib:com.zwitserloot.ivyplusplus" xmlns:unless="ant:unless" basedir="..">
 	<description>
 This buildfile is part of projectlombok.org. It sets up the build itself.
 	</description>
@@ -167,6 +167,10 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 		<fetchdep.eclipse.osgi name="2022-03" version="4.23/R-4.23-202203080310" />
 	</target>
 	
+	<target name="deps.eclipse.2023-09" depends="deps.rtstubs18, compile.support">
+		<fetchdep.eclipse.osgi name="2023-09" version="4.29/R-4.29-202309031000" />
+	</target>
+	
 	<macrodef name="fetchdep.ecj">
 		<attribute name="version" />
 		<sequential>
@@ -192,6 +196,9 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 		<attribute name="name" />
 		<attribute name="version" />
 		<sequential>
+			<condition property="@{name}.isoxygen">
+				<equals arg1="@{name}" arg2="oxygen"/>
+			</condition>
 			<java classname="lombok.eclipse.dependencies.DownloadEclipseDependencies" failonerror="true">
 				<classpath>
 					<path refid="cp.buildtools" />
@@ -200,18 +207,28 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 				<arg value="@{target}" />
 				<arg value="eclipse-@{name}" />
 				<arg value="https://download.eclipse.org/eclipse/updates/@{version}/plugins/" />
+				<arg value="bcpg" />
+				<arg value="bcprov" />
 				<arg value="com.ibm.icu" />
 				<arg value="com.sun.jna" />
 				<arg value="com.sun.jna.platform" />
-				<arg value="javax.inject" />
+				<arg value="jakarta.inject.jakarta.inject-api" />
+				<arg value="jakarta.annotation-api" />
+				<arg value="jakarta.servlet-api" />
 				<arg value="javax.annotation" />
+				<arg value="javax.inject" />
+				<arg value="javax.el-api" />
+				<arg value="javax.servlet.jsp-api" />
 				<arg value="org.apache.batik.constants" />
 				<arg value="org.apache.batik.css" />
 				<arg value="org.apache.batik.i18n" />
 				<arg value="org.apache.batik.util" />
+				<arg value="org.apache.commons.collections" />
+				<arg value="org.apache.commons.commons-beanutils" />
+				<arg value="org.apache.commons.commons-io" />
 				<arg value="org.apache.commons.io" />
-				<arg value="org.apache.commons.logging" />
 				<arg value="org.apache.commons.jxpath" />
+				<arg value="org.apache.commons.logging" />
 				<arg value="org.apache.felix.scr" />
 				<arg value="org.apache.xmlgraphics" />
 				<arg value="org.bouncycastle.bcpg" />
@@ -274,6 +291,7 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 				<arg value="org.eclipse.equinox.security" />
 				<arg value="org.eclipse.help" />
 				<arg value="org.eclipse.jdt.core" />
+				<arg value="org.eclipse.jdt.core.compiler.batch" unless:set="@{name}.isoxygen" />
 				<arg value="org.eclipse.jdt.core.manipulation" />
 				<arg value="org.eclipse.jdt.debug" />
 				<arg value="org.eclipse.jdt.launching" />
@@ -304,6 +322,12 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 				<arg value="org.eclipse.ui.workbench" />
 				<arg value="org.eclipse.ui.workbench.texteditor" />
 				<arg value="org.eclipse.urischeme" />
+				<arg value="org.jdom" />
+				<arg value="org.osgi.service.prefs" />
+				<arg value="org.osgi.service.event" />
+				<arg value="org.osgi.service.component" />
+				<arg value="org.osgi.util.function" />
+				<arg value="org.osgi.util.promise" />
 				<arg value="org.tukaani.xz" />
 				<arg value="org.w3c.css.sac" />
 				<arg value="org.w3c.dom.events" />

--- a/buildScripts/tests.ant.xml
+++ b/buildScripts/tests.ant.xml
@@ -213,6 +213,11 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 		<test.eclipse-X version="202006" compiler.compliance.level="8" />
 	</target>
 	
+	<target name="test.eclipse-202309" depends="test.compile, test.formatter.compile" description="runs the tests on your default VM, testing the 2023-09 release of eclipse">
+		<fetchdep.eclipse version="202309" />
+		<test.eclipse-X version="202309" />
+	</target>
+	
 	<macrodef name="test.eclipse-X-full">
 		<attribute name="version" />
 		<sequential>
@@ -250,6 +255,10 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 	
 	<target name="test.eclipse-2022-03-full" depends="test.eclipse.compile, test.formatter.compile, deps.eclipse.2022-03" description="runs the full eclipse tests on your default VM, testing the 2022-03 release of eclipse">
 		<test.eclipse-X-full version="2022-03" />
+	</target>
+	
+	<target name="test.eclipse-2023-09-full" depends="test.eclipse.compile, test.formatter.compile, deps.eclipse.2023-09" description="runs the full eclipse tests on your default VM, testing the 2023-09 release of eclipse">
+		<test.eclipse-X-full version="2023-09" />
 	</target>
 	
 	<macrodef name="test.ecj-X">

--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -1028,6 +1028,14 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 				.request(StackRequest.RETURN_VALUE, StackRequest.PARAM1)
 				.wrapMethod(new Hook("lombok.launch.PatchFixesHider$Tests", "getBundle", "java.lang.Object", "java.lang.Object", "java.lang.Class"))
 				.build());
+		
+		sm.addScriptIfWitness(new String[] {"lombok/transform/TestWithEcj"}, ScriptBuilder.exitEarly()
+				.target(new MethodTarget("org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration", "print"))
+				.decisionMethod(new Hook("lombok.launch.PatchFixesHider$Tests", "isImplicitCanonicalConstructor", "boolean", "org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration", "java.lang.Object"))
+				.valueMethod(new Hook("lombok.launch.PatchFixesHider$Tests", "returnStringBuffer", "java.lang.StringBuffer", "java.lang.Object", "java.lang.StringBuffer"))
+				.request(StackRequest.THIS, StackRequest.PARAM2)
+				.transplant()
+				.build());
 	}
 
 }

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -21,6 +21,9 @@
  */
 package lombok.launch;
 
+import static lombok.eclipse.EcjAugments.ASTNode_generatedBy;
+import static lombok.eclipse.Eclipse.*;
+
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -61,8 +64,6 @@ import org.eclipse.jdt.internal.corext.refactoring.SearchResultGroup;
 import org.eclipse.jdt.internal.corext.refactoring.structure.MemberVisibilityAdjustor.IncomingMemberVisibilityAdjustment;
 
 import lombok.permit.Permit;
-
-import static lombok.eclipse.EcjAugments.ASTNode_generatedBy;
 
 /** These contain a mix of the following:
  * <ul>
@@ -924,6 +925,14 @@ final class PatchFixesHider {
 				}
 			}
 			return null;
+		}
+		
+		public static boolean isImplicitCanonicalConstructor(AbstractMethodDeclaration method, Object parameter) {
+			return (method.bits & IsCanonicalConstructor) != 0 && (method.bits & IsImplicit) != 0;
+		}
+		
+		public static StringBuffer returnStringBuffer(Object p1, StringBuffer buffer) {
+			return buffer;
 		}
 	}
 }

--- a/src/stubs/org/eclipse/jdt/internal/compiler/ast/OperatorIds.java
+++ b/src/stubs/org/eclipse/jdt/internal/compiler/ast/OperatorIds.java
@@ -1,0 +1,36 @@
+package org.eclipse.jdt.internal.compiler.ast;
+
+/**
+ * This stub prevents constant inlining.
+ */
+public interface OperatorIds {
+	public static final int AND_AND = null != null ? 0 : 0;
+	public static final int OR_OR = null != null ? 1 : 1;
+	public static final int AND = null != null ? 2 : 2;
+	public static final int OR = null != null ? 3 : 3;
+	public static final int LESS = null != null ? 4 : 4;
+	public static final int LESS_EQUAL = null != null ? 5 : 5;
+	public static final int GREATER = null != null ? 6 : 6;
+	public static final int GREATER_EQUAL = null != null ? 7 : 7;
+	public static final int XOR = null != null ? 8 : 8;
+	public static final int DIVIDE = null != null ? 9 : 9;
+	public static final int LEFT_SHIFT = null != null ? 10 : 10;
+	public static final int NOT = null != null ? 11 : 11;
+	public static final int TWIDDLE = null != null ? 12 : 12;
+	public static final int MINUS = null != null ? 13 : 13;
+	public static final int PLUS = null != null ? 14 : 14;
+	public static final int MULTIPLY = null != null ? 15 : 15;
+	public static final int REMAINDER = null != null ? 16 : 16;
+	public static final int RIGHT_SHIFT = null != null ? 17 : 17;
+	public static final int EQUAL_EQUAL = null != null ? 18 : 18;
+	public static final int UNSIGNED_RIGHT_SHIFT = null != null ? 19 : 19;
+	public static final int NumberOfTables = null != null ? 20 : 20;
+	
+	public static final int QUESTIONCOLON = null != null ? 23 : 23;
+	
+	public static final int NOT_EQUAL = null != null ? 29 : 29;
+	public static final int EQUAL = null != null ? 30 : 30;
+	public static final int INSTANCEOF = null != null ? 31 : 31;
+	public static final int PLUS_PLUS = null != null ? 32 : 32;
+	public static final int MINUS_MINUS = null != null ? 33 : 33;
+}

--- a/src/support/lombok/eclipse/dependencies/DownloadEclipseDependencies.java
+++ b/src/support/lombok/eclipse/dependencies/DownloadEclipseDependencies.java
@@ -41,11 +41,14 @@ public class DownloadEclipseDependencies {
 					downloadFile(path, updatePage, pluginTarget);
 				} catch (Exception e) {
 				}
-				try {
-					int index = path.lastIndexOf("_");
-					String source = path.substring(0, index) + ".source" + path.substring(index);
-					downloadFile(source, updatePage, pluginTarget);
-				} catch (Exception e) {
+				
+				int index = path.lastIndexOf("_");
+				String source = path.substring(0, index) + ".source" + path.substring(index);
+				if (indexData.contains(source)) {
+					try {
+						downloadFile(source, updatePage, pluginTarget);
+					} catch (Exception e) {
+					}
 				}
 			} else {
 				System.out.println("Bundle \"" + pkg + "\" not found");

--- a/test/core/src/lombok/RunTestsViaEcj.java
+++ b/test/core/src/lombok/RunTestsViaEcj.java
@@ -99,6 +99,7 @@ public class RunTestsViaEcj extends AbstractRunTests {
 		warnings.put(CompilerOptions.OPTION_ReportNonStaticAccessToStatic, "warning");
 		warnings.put("org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures", "ignore");
 		warnings.put(CompilerOptions.OPTION_Source, (ecjCompilerVersion < 9 ? "1." : "") + ecjCompilerVersion);
+		warnings.put("org.eclipse.jdt.core.compiler.codegen.useStringConcatFactory", "disabled");
 		options.set(warnings);
 		return options;
 	}

--- a/test/transform/resource/after-ecj/BuilderSimpleOnRecord.java
+++ b/test/transform/resource/after-ecj/BuilderSimpleOnRecord.java
@@ -30,11 +30,6 @@ public @lombok.Builder(access = lombok.AccessLevel.PROTECTED) record BuilderSimp
   }
 /* Implicit */  private final List<T> l;
 /* Implicit */  private final String a;
-  public BuilderSimpleOnRecord(List<T> l, String a) {
-    super();
-    .l = l;
-    .a = a;
-  }
   protected static @java.lang.SuppressWarnings("all") <T>BuilderSimpleOnRecord.BuilderSimpleOnRecordBuilder<T> builder() {
     return new BuilderSimpleOnRecord.BuilderSimpleOnRecordBuilder<T>();
   }

--- a/test/transform/resource/after-ecj/BuilderSingularOnRecord.java
+++ b/test/transform/resource/after-ecj/BuilderSingularOnRecord.java
@@ -117,12 +117,6 @@ public @Builder record BuilderSingularOnRecord(List children, Collection scarves
 /* Implicit */  private final List<T> children;
 /* Implicit */  private final Collection<? extends Number> scarves;
 /* Implicit */  private final List rawList;
-  public BuilderSingularOnRecord(@Singular List<T> children, @Singular Collection<? extends Number> scarves, @SuppressWarnings("all") @Singular("rawList") List rawList) {
-    super();
-    .children = children;
-    .scarves = scarves;
-    .rawList = rawList;
-  }
   public static @java.lang.SuppressWarnings("all") <T>BuilderSingularOnRecord.BuilderSingularOnRecordBuilder<T> builder() {
     return new BuilderSingularOnRecord.BuilderSingularOnRecordBuilder<T>();
   }

--- a/test/transform/resource/after-ecj/ConstructorsOnRecord.java
+++ b/test/transform/resource/after-ecj/ConstructorsOnRecord.java
@@ -5,9 +5,4 @@ import lombok.RequiredArgsConstructor;
 public @AllArgsConstructor @RequiredArgsConstructor @NoArgsConstructor record ConstructorsOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public ConstructorsOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/DataOnRecord.java
+++ b/test/transform/resource/after-ecj/DataOnRecord.java
@@ -3,9 +3,4 @@ import lombok.Data;
 public @Data record DataOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public DataOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/EqualsAndHashCodeOnRecord.java
+++ b/test/transform/resource/after-ecj/EqualsAndHashCodeOnRecord.java
@@ -3,9 +3,4 @@ import lombok.EqualsAndHashCode;
 public @EqualsAndHashCode record EqualsAndHashCodeOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public EqualsAndHashCodeOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/ExtensionMethodOnRecord.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodOnRecord.java
@@ -9,9 +9,6 @@ public @ExtensionMethod(ExtensionMethodOnRecord.Extensions.class) record Extensi
       return Integer.valueOf(s);
     }
   }
-  public ExtensionMethodOnRecord() {
-    super();
-  }
   public void test() {
     ExtensionMethodOnRecord.Extensions.intValue("1");
   }

--- a/test/transform/resource/after-ecj/FieldDefaultsOnRecord.java
+++ b/test/transform/resource/after-ecj/FieldDefaultsOnRecord.java
@@ -2,9 +2,4 @@
 public @lombok.experimental.FieldDefaults(makeFinal = true) record FieldDefaultsOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public FieldDefaultsOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/FieldDefaultsViaConfigOnRecord.java
+++ b/test/transform/resource/after-ecj/FieldDefaultsViaConfigOnRecord.java
@@ -2,9 +2,4 @@
 public record FieldDefaultsViaConfigOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public FieldDefaultsViaConfigOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/FieldNameConstantsOnRecord.java
+++ b/test/transform/resource/after-ecj/FieldNameConstantsOnRecord.java
@@ -18,11 +18,4 @@ public @FieldNameConstants(level = AccessLevel.PACKAGE) record FieldNameConstant
   static double skipMeToo;
   <clinit>() {
   }
-  public FieldNameConstantsOnRecord(String iAmADvdPlayer, int $skipMe,  int andMe, String butPrintMePlease) {
-    super();
-    .iAmADvdPlayer = iAmADvdPlayer;
-    .$skipMe = $skipMe;
-    .andMe = andMe;
-    .butPrintMePlease = butPrintMePlease;
-  }
 }

--- a/test/transform/resource/after-ecj/GetterOnRecord.java
+++ b/test/transform/resource/after-ecj/GetterOnRecord.java
@@ -3,9 +3,4 @@ import lombok.Getter;
 public @Getter record GetterOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public GetterOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/JacksonizedOnRecord.java
+++ b/test/transform/resource/after-ecj/JacksonizedOnRecord.java
@@ -58,11 +58,6 @@ public @lombok.extern.jackson.Jacksonized @lombok.Builder @JsonIgnoreProperties 
   }
 /* Implicit */  private final String string;
 /* Implicit */  private final List<String> values;
-  public JacksonizedOnRecord(@JsonProperty("test") @Nullable String string, @lombok.Singular List<String> values) {
-    super();
-    .string = string;
-    .values = values;
-  }
   public static @java.lang.SuppressWarnings("all") JacksonizedOnRecord.JacksonizedOnRecordBuilder builder() {
     return new JacksonizedOnRecord.JacksonizedOnRecordBuilder();
   }

--- a/test/transform/resource/after-ecj/LockedInRecord.java
+++ b/test/transform/resource/after-ecj/LockedInRecord.java
@@ -3,11 +3,6 @@ public record LockedInRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
   private final java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
-  public LockedInRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
   public @Locked void foo() {
     String foo = "bar";
   }

--- a/test/transform/resource/after-ecj/LoggerConfigOnRecord.java
+++ b/test/transform/resource/after-ecj/LoggerConfigOnRecord.java
@@ -3,9 +3,4 @@ import lombok.extern.slf4j.Slf4j;
 public @Slf4j record LoggerConfigOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public LoggerConfigOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/LoggerFloggerRecord.java
+++ b/test/transform/resource/after-ecj/LoggerFloggerRecord.java
@@ -6,10 +6,6 @@ class LoggerFloggerRecord {
     private static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
     <clinit>() {
     }
-    public Inner(String x) {
-      super();
-      .x = x;
-    }
   }
   LoggerFloggerRecord() {
     super();

--- a/test/transform/resource/after-ecj/LoggerSlf4jOnRecord.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4jOnRecord.java
@@ -6,9 +6,4 @@ public @Slf4j record LoggerSlf4jOnRecord(String a, String b) {
   private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jOnRecord.class);
   <clinit>() {
   }
-  public LoggerSlf4jOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/SetterOnRecord.java
+++ b/test/transform/resource/after-ecj/SetterOnRecord.java
@@ -3,9 +3,4 @@ import lombok.Setter;
 public @Setter record SetterOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public SetterOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/SynchronizedInRecord.java
+++ b/test/transform/resource/after-ecj/SynchronizedInRecord.java
@@ -3,11 +3,6 @@ public record SynchronizedInRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
   private final java.lang.Object $lock = new java.lang.Object[0];
-  public SynchronizedInRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
   public @Synchronized void foo() {
     String foo = "bar";
   }

--- a/test/transform/resource/after-ecj/ToStringOnRecord.java
+++ b/test/transform/resource/after-ecj/ToStringOnRecord.java
@@ -3,9 +3,4 @@ import lombok.ToString;
 public @ToString record ToStringOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public ToStringOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/UtilityClassOnRecord.java
+++ b/test/transform/resource/after-ecj/UtilityClassOnRecord.java
@@ -3,9 +3,4 @@ import lombok.experimental.UtilityClass;
 public @UtilityClass record UtilityClassOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public UtilityClassOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/ValueOnRecord.java
+++ b/test/transform/resource/after-ecj/ValueOnRecord.java
@@ -3,9 +3,4 @@ import lombok.Value;
 public @Value record ValueOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public ValueOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
 }

--- a/test/transform/resource/after-ecj/WithByOnRecord.java
+++ b/test/transform/resource/after-ecj/WithByOnRecord.java
@@ -3,11 +3,6 @@ import lombok.experimental.WithBy;
 public @WithBy record WithByOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public WithByOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
   public @java.lang.SuppressWarnings("all") WithByOnRecord withABy(final java.util.function.Function<? super String, ? extends String> transformer) {
     return new WithByOnRecord(transformer.apply(this.a), this.b);
   }

--- a/test/transform/resource/after-ecj/WithByOnRecordComponent.java
+++ b/test/transform/resource/after-ecj/WithByOnRecordComponent.java
@@ -3,11 +3,6 @@ import lombok.experimental.WithBy;
 public record WithByOnRecordComponent(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public WithByOnRecordComponent( String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
   public @java.lang.SuppressWarnings("all") WithByOnRecordComponent withABy(final java.util.function.Function<? super String, ? extends String> transformer) {
     return new WithByOnRecordComponent(transformer.apply(this.a), this.b);
   }

--- a/test/transform/resource/after-ecj/WithOnRecord.java
+++ b/test/transform/resource/after-ecj/WithOnRecord.java
@@ -3,11 +3,6 @@ import lombok.With;
 public @With record WithOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public WithOnRecord(String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
   /**
    * @return a clone of this object, except with this updated property (returns {@code this} if an identical value is passed).
    */

--- a/test/transform/resource/after-ecj/WithOnRecordComponent.java
+++ b/test/transform/resource/after-ecj/WithOnRecordComponent.java
@@ -3,11 +3,6 @@ import lombok.With;
 public record WithOnRecordComponent(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  public WithOnRecordComponent( String a, String b) {
-    super();
-    .a = a;
-    .b = b;
-  }
   /**
    * @return a clone of this object, except with this updated property (returns {@code this} if an identical value is passed).
    */


### PR DESCRIPTION
This PR  fixes #3536

The new stub utilizes conditional expressions to prevent inlining and force the resolution of the constants at runtime. Additionally I added the latest eclipse as test target and updated the pipeline to use these targets. To standardize the generated eclipse test output between different versions, lombok now hides implicit constructors in the print method.