### PR TITLE
Remove generated nodes in search results

### DIFF
--- a/src/core/lombok/eclipse/TransformEclipseAST.java
+++ b/src/core/lombok/eclipse/TransformEclipseAST.java
@@ -170,6 +170,9 @@ public class TransformEclipseAST {
 		if (fileName != null && String.valueOf(fileName).endsWith("module-info.java")) return;
 		
 		if (Symbols.hasSymbol("lombok.disable")) return;
+		// The IndexingParser only supports a single import statement, restricting lombok annotations to either fully qualified ones or
+		// those specified in the last import statement. To avoid handling hard to reproduce edge cases, we opt to ignore the entire parser.
+		if ("org.eclipse.jdt.internal.core.search.indexing.IndexingParser".equals(parser.getClass().getName())) return;
 		if (alreadyTransformed(ast)) return;
 		
 		// Do NOT abort if (ast.bits & ASTNode.HasAllMethodBodies) != 0 - that doesn't work.

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -38,7 +38,6 @@ import java.util.Stack;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IAnnotatable;
 import org.eclipse.jdt.core.IAnnotation;
-import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
@@ -770,27 +769,6 @@ final class PatchFixesHider {
 				if (!isGenerated(m)) result.add(m);
 			}
 			return result.size() == methods.length ? methods : result.toArray(new IMethod[0]);
-		}
-		
-		public static SearchMatch[] removeGenerated(SearchMatch[] returnValue) {
-			List<SearchMatch> result = new ArrayList<SearchMatch>();
-			for (int j = 0; j < returnValue.length; j++) {
-				SearchMatch searchResult = returnValue[j];
-				if (searchResult.getElement() instanceof IField) {
-					IField field = (IField) searchResult.getElement();
-					
-					// can not check for value=lombok because annotation is
-					// not fully resolved
-					IAnnotation annotation = field.getAnnotation("Generated");
-					if (annotation != null) {
-						// Method generated at field location, skip
-						continue;
-					}
-					
-				}
-				result.add(searchResult);
-			}
-			return result.toArray(new SearchMatch[0]);
 		}
 		
 		public static SearchResultGroup[] createFakeSearchResult(SearchResultGroup[] returnValue,

--- a/test/eclipse/resource/rename/data/after/A.java
+++ b/test/eclipse/resource/rename/data/after/A.java
@@ -1,0 +1,12 @@
+package pkg;
+
+import lombok.Data;
+
+@Data
+public class A {
+	private String newString;
+	
+	public String test() {
+		return getNewString();
+	}
+}

--- a/test/eclipse/resource/rename/data/before/A.java
+++ b/test/eclipse/resource/rename/data/before/A.java
@@ -1,0 +1,12 @@
+package pkg;
+
+import lombok.Data;
+
+@Data
+public class A {
+	private String string;
+	
+	public String test() {
+		return getString();
+	}
+}

--- a/test/eclipse/resource/rename/nestedClass/after/A.java
+++ b/test/eclipse/resource/rename/nestedClass/after/A.java
@@ -1,0 +1,9 @@
+package pkg;
+
+public class A {
+	@lombok.Getter
+	@lombok.Setter
+	public static class Nested {
+		private String newString;
+	}
+}

--- a/test/eclipse/resource/rename/nestedClass/before/A.java
+++ b/test/eclipse/resource/rename/nestedClass/before/A.java
@@ -1,0 +1,9 @@
+package pkg;
+
+public class A {
+	@lombok.Getter
+	@lombok.Setter
+	public static class Nested {
+		private String string;
+	}
+}

--- a/test/eclipse/src/lombok/eclipse/refactoring/RenameTest.java
+++ b/test/eclipse/src/lombok/eclipse/refactoring/RenameTest.java
@@ -21,7 +21,7 @@ public class RenameTest {
 	
 	@Rule
 	public SetupBeforeAfterTest setup = new SetupBeforeAfterTest();
-	
+//	
 	@Test
 	public void simple() throws Exception {
 		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
@@ -30,6 +30,8 @@ public class RenameTest {
 		
 		RenameFieldProcessor renameFieldProcessor = new RenameFieldProcessor(field);
 		renameFieldProcessor.setNewElementName("newString");
+		renameFieldProcessor.setRenameGetter(true);
+		renameFieldProcessor.setRenameSetter(true);
 		
 		performRefactoring(renameFieldProcessor);
 	}
@@ -82,5 +84,34 @@ public class RenameTest {
 		renameMethodProcessor.setNewElementName("newTest");
 		
 		performRefactoring(renameMethodProcessor);
+	}
+	
+	@Test
+	public void data() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
+		IType type = cu.findPrimaryType();
+		IField field = type.getField("string");
+		
+		RenameFieldProcessor renameFieldProcessor = new RenameFieldProcessor(field);
+		renameFieldProcessor.setNewElementName("newString");
+		renameFieldProcessor.setRenameGetter(true);
+		renameFieldProcessor.setRenameSetter(true);
+		
+		performRefactoring(renameFieldProcessor);
+	}
+	
+	@Test
+	public void nestedClass() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("A.java");
+		IType type = cu.findPrimaryType();
+		IType nestedType = type.getType("Nested");
+		IField field = nestedType.getField("string");
+		
+		RenameFieldProcessor renameFieldProcessor = new RenameFieldProcessor(field);
+		renameFieldProcessor.setNewElementName("newString");
+		renameFieldProcessor.setRenameGetter(true);
+		renameFieldProcessor.setRenameSetter(true);
+		
+		performRefactoring(renameFieldProcessor);
 	}
 }


### PR DESCRIPTION
This PR fixes #1758

The old patch method exploited the fact that a field as result for a method search is never valid to indirectly detect lombok-generated nodes. Instead of extending this approach and adding support for classes, I decided to redesign it. Lombok now removes the nodes at an earlier stage, which allows the use of the normal generated flags.