### PR TITLE
Prepend jdt.core classloader to the parser classloader

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -109,6 +109,7 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 		patchRenameField(sm);
 		patchInline(sm);
 		patchNullCheck(sm);
+		patchCrossModuleClassLoading(sm);
 		
 		patchForTests(sm);
 		
@@ -1030,6 +1031,13 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 				.request(StackRequest.RETURN_VALUE, StackRequest.PARAM1, StackRequest.PARAM2)
 				.transplant()
 				.build());
+	}
+	
+	private static void patchCrossModuleClassLoading(ScriptManager sm) {
+		sm.addScriptIfWitness(OSGI_TYPES, ScriptBuilder.wrapReturnValue()
+			.target(new MethodTarget("org.eclipse.jdt.internal.compiler.parser.Parser", "<clinit>"))
+			.wrapMethod(new Hook("lombok.launch.PatchFixesHider$ModuleClassLoading", "parserClinit", "void"))
+			.build());
 	}
 	
 	private static void patchForTests(ScriptManager sm) {

--- a/src/launch/lombok/launch/ShadowClassLoader.java
+++ b/src/launch/lombok/launch/ShadowClassLoader.java
@@ -112,6 +112,7 @@ class ShadowClassLoader extends ClassLoader {
 	public void prependParent(ClassLoader loader) {
 		if (loader == null) return;
 		if (loader == getParent()) return;
+		if (loader == this) return;
 		prependedParentLoaders.add(loader);
 	}
 	


### PR DESCRIPTION
This PR fixes #3440

I finished this some time ago but somehow forgot to create a PR. This is my third (?) attempt to properly fix the classloading problems caused by the seperation of the eclipse bundles. In some cases the last version called the prepend method to late.