### PR TITLE
Exclude the classloader for jasperreports-plugin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,8 +28,9 @@ Luan Nico <luannico27@gmail.com>
 Maarten Mulders <mthmulders@users.noreply.github.com>
 Mark Haynes <markhaynes.work@gmail.com>
 Mart Hagenaars <marthagenaars@gmail.com>
-Mateusz Matela <mateusz.matela@gmail.com>
 Martin O'Connor <38929043+martinoconnor@users.noreply.github.com>
+Martin Panzer <postremus1996@googlemail.com>
+Mateusz Matela <mateusz.matela@gmail.com>
 Michael Dardis <git@md-5.net>
 Michael Ernst <mernst@alum.mit.edu>
 Michiel Verheul <cheelio@gmail.com>

--- a/doc/changelog.markdown
+++ b/doc/changelog.markdown
@@ -3,6 +3,7 @@ Lombok Changelog
 
 ### v1.18.31 "Edgy Guinea Pig"
 * FEATURE: `@Locked` has been introduced. Like `@Synchronized` but with `java.util.concurrent.locks` locks instead of the `synchronized` primitive. Thanks, Pim van der Loos for the PR! [Issue #3506](https://github.com/projectlombok/lombok/issues/3506).
+* BUGFIX: Eclipse projects using the com.pro-crafting.tools:jasperreports-plugin will now compile
 * We recently released v1.18.30; there is no edge release since then.
 
 ### v1.18.30 (September 20th, 2023)

--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -62,6 +62,7 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 				if (loader != null) {					
 					if (loader.getClass().getName().startsWith("org.sonar.classloader.")) return false; // Relevant to bug #2351
 					if (loader.toString().contains("com.alexnederlof:jasperreports-plugin")) return false; //Relevant to bug #1036
+					if (loader.toString().contains("com.pro-crafting.tools:jasperreports-plugin")) return false; //Relevant to bug #1036
 				}
 				if (!(loader instanceof URLClassLoader)) return true;
 				ClassLoader parent = loader.getParent();


### PR DESCRIPTION
Basically the same fix as in #3079. Just new coordinates for the maven plugin.
Was reported over at [Jasper-report-maven-plugin/issues/52](https://github.com/pro-crafting/Jasper-report-maven-plugin/issues/52)