### PR TITLE
Handle field initializer in diet mode

### DIFF
--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2022 The Project Lombok Authors.
+ * Copyright (C) 2009-2024 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -2971,5 +2971,42 @@ public class EclipseHandlerUtil {
 			String newJavadoc = addReturnsThisIfNeeded(getParamJavadoc(methodComment, param));
 			setDocComment(cud, type, to, newJavadoc);
 		} catch (Exception ignore) {}
+	}
+
+	/**
+	 * Returns the method node containing the given annotation, or {@code null} if the given annotation node is not on a method or argument.
+	 */
+	public static EclipseNode getAnnotatedMethod(EclipseNode node) {
+		if (node == null || node.getKind() != Kind.ANNOTATION) return null;
+		
+		EclipseNode result = node.up();
+		if (result.getKind() == Kind.ARGUMENT) {
+			result = node.up();
+		}
+		if (result.getKind() != Kind.METHOD) {
+			result = null;
+		}
+		return result;
+	}
+
+	/**
+	 * Returns {@code true} if the given method node body was parsed.
+	 */
+	public static boolean hasParsedBody(EclipseNode method) {
+		if (method == null || method.getKind() != Kind.METHOD) return false;
+		
+		boolean isCompleteParse = method.getAst().isCompleteParse();
+		if (isCompleteParse) return true;
+		
+		AbstractMethodDeclaration methodDecl = (AbstractMethodDeclaration) method.get();
+		if (methodDecl.statements != null) return true;
+		
+		// If the method is part of a field initializer it was parsed
+		EclipseNode parent = method.up();
+		while (parent != null) {
+			if (parent.getKind() == Kind.FIELD) return true;
+			parent = parent.up();
+		}
+		return false;
 	}
 }

--- a/src/core/lombok/eclipse/handlers/HandleLocked.java
+++ b/src/core/lombok/eclipse/handlers/HandleLocked.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 The Project Lombok Authors.
+ * Copyright (C) 2021-2024 The Project Lombok Authors.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,15 +21,19 @@
  */
 package lombok.eclipse.handlers;
 
+import static lombok.eclipse.EcjAugments.ASTNode_handled;
+import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
+
+import org.eclipse.jdt.internal.compiler.ast.Annotation;
+import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
+
+import lombok.Locked;
 import lombok.core.AnnotationValues;
 import lombok.core.HandlerPriority;
 import lombok.eclipse.DeferUntilPostDiet;
 import lombok.eclipse.EclipseAnnotationHandler;
 import lombok.eclipse.EclipseNode;
-import lombok.Locked;
 import lombok.spi.Provides;
-import org.eclipse.jdt.internal.compiler.ast.Annotation;
-import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 
 /**
  * Handles the {@code lombok.Locked} annotation for eclipse.
@@ -52,5 +56,11 @@ public class HandleLocked extends EclipseAnnotationHandler<Locked> {
 	@Override public void preHandle(AnnotationValues<Locked> annotation, Annotation source, EclipseNode annotationNode) {
 		String annotationValue = annotation.getInstance().value();
 		HandleLockedUtil.preHandle(annotationValue, LOCK_TYPE_CLASS, LOCK_IMPL_CLASS, annotationNode);
+		
+		if (hasParsedBody(getAnnotatedMethod(annotationNode))) {
+			// This method has a body in diet mode, so we have to handle it now.
+			handle(annotation, source, annotationNode);
+			ASTNode_handled.set(source, true);
+		}
 	}
 }

--- a/src/core/lombok/eclipse/handlers/HandleLockedRead.java
+++ b/src/core/lombok/eclipse/handlers/HandleLockedRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 The Project Lombok Authors.
+ * Copyright (C) 2021-2024 The Project Lombok Authors.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,15 +21,19 @@
  */
 package lombok.eclipse.handlers;
 
+import static lombok.eclipse.EcjAugments.ASTNode_handled;
+import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
+
+import org.eclipse.jdt.internal.compiler.ast.Annotation;
+import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
+
+import lombok.Locked;
 import lombok.core.AnnotationValues;
 import lombok.core.HandlerPriority;
 import lombok.eclipse.DeferUntilPostDiet;
 import lombok.eclipse.EclipseAnnotationHandler;
 import lombok.eclipse.EclipseNode;
-import lombok.Locked;
 import lombok.spi.Provides;
-import org.eclipse.jdt.internal.compiler.ast.Annotation;
-import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 
 /**
  * Handles the {@code lombok.Locked.Read} annotation for eclipse.
@@ -53,5 +57,11 @@ public class HandleLockedRead extends EclipseAnnotationHandler<Locked.Read> {
 	@Override public void preHandle(AnnotationValues<Locked.Read> annotation, Annotation source, EclipseNode annotationNode) {
 		String annotationValue = annotation.getInstance().value();
 		HandleLockedUtil.preHandle(annotationValue, LOCK_TYPE_CLASS, LOCK_IMPL_CLASS, annotationNode);
+		
+		if (hasParsedBody(getAnnotatedMethod(annotationNode))) {
+			// This method has a body in diet mode, so we have to handle it now.
+			handle(annotation, source, annotationNode);
+			ASTNode_handled.set(source, true);
+		}
 	}
 }

--- a/src/core/lombok/eclipse/handlers/HandleLockedWrite.java
+++ b/src/core/lombok/eclipse/handlers/HandleLockedWrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 The Project Lombok Authors.
+ * Copyright (C) 2021-2024 The Project Lombok Authors.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,15 +21,19 @@
  */
 package lombok.eclipse.handlers;
 
+import static lombok.eclipse.EcjAugments.ASTNode_handled;
+import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
+
+import org.eclipse.jdt.internal.compiler.ast.Annotation;
+import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
+
+import lombok.Locked;
 import lombok.core.AnnotationValues;
 import lombok.core.HandlerPriority;
 import lombok.eclipse.DeferUntilPostDiet;
 import lombok.eclipse.EclipseAnnotationHandler;
 import lombok.eclipse.EclipseNode;
-import lombok.Locked;
 import lombok.spi.Provides;
-import org.eclipse.jdt.internal.compiler.ast.Annotation;
-import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 
 /**
  * Handles the {@code lombok.Locked.Write} annotation for eclipse.
@@ -53,5 +57,11 @@ public class HandleLockedWrite extends EclipseAnnotationHandler<Locked.Write> {
 	@Override public void preHandle(AnnotationValues<Locked.Write> annotation, Annotation source, EclipseNode annotationNode) {
 		String annotationValue = annotation.getInstance().value();
 		HandleLockedUtil.preHandle(annotationValue, LOCK_TYPE_CLASS, LOCK_IMPL_CLASS, annotationNode);
+		
+		if (hasParsedBody(getAnnotatedMethod(annotationNode))) {
+			// This method has a body in diet mode, so we have to handle it now.
+			handle(annotation, source, annotationNode);
+			ASTNode_handled.set(source, true);
+		}
 	}
 }

--- a/src/core/lombok/eclipse/handlers/HandleSneakyThrows.java
+++ b/src/core/lombok/eclipse/handlers/HandleSneakyThrows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 The Project Lombok Authors.
+ * Copyright (C) 2009-2024 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,21 +22,13 @@
 package lombok.eclipse.handlers;
 
 import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.eclipse.EcjAugments.ASTNode_handled;
 import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import lombok.ConfigurationKeys;
-import lombok.SneakyThrows;
-import lombok.core.AnnotationValues;
-import lombok.core.HandlerPriority;
-import lombok.eclipse.DeferUntilPostDiet;
-import lombok.eclipse.EclipseAnnotationHandler;
-import lombok.eclipse.EclipseNode;
-import lombok.spi.Provides;
 
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
@@ -58,6 +50,15 @@ import org.eclipse.jdt.internal.compiler.ast.ThrowStatement;
 import org.eclipse.jdt.internal.compiler.ast.TryStatement;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 
+import lombok.ConfigurationKeys;
+import lombok.SneakyThrows;
+import lombok.core.AnnotationValues;
+import lombok.core.HandlerPriority;
+import lombok.eclipse.DeferUntilPostDiet;
+import lombok.eclipse.EclipseAnnotationHandler;
+import lombok.eclipse.EclipseNode;
+import lombok.spi.Provides;
+
 /**
  * Handles the {@code lombok.HandleSneakyThrows} annotation for eclipse.
  */
@@ -73,6 +74,15 @@ public class HandleSneakyThrows extends EclipseAnnotationHandler<SneakyThrows> {
 		DeclaredException(String exceptionName, ASTNode node) {
 			this.exceptionName = exceptionName;
 			this.node = node;
+		}
+	}
+	
+	@Override
+	public void preHandle(AnnotationValues<SneakyThrows> annotation, Annotation ast, EclipseNode annotationNode) {
+		if (hasParsedBody(getAnnotatedMethod(annotationNode))) {
+			// This method has a body in diet mode, so we have to handle it now.
+			handle(annotation, ast, annotationNode);
+			ASTNode_handled.set(ast, true);
 		}
 	}
 	

--- a/src/core/lombok/eclipse/handlers/HandleSynchronized.java
+++ b/src/core/lombok/eclipse/handlers/HandleSynchronized.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 The Project Lombok Authors.
+ * Copyright (C) 2009-2024 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,7 @@
 package lombok.eclipse.handlers;
 
 import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.eclipse.EcjAugments.ASTNode_handled;
 import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
 
 import java.lang.reflect.Modifier;
@@ -70,6 +71,12 @@ public class HandleSynchronized extends EclipseAnnotationHandler<Synchronized> {
 		if (method.isAbstract()) return;
 		
 		createLockField(annotation, annotationNode, new boolean[] {method.isStatic()}, false);
+		
+		if (hasParsedBody(getAnnotatedMethod(annotationNode))) {
+			// This method has a body in diet mode, so we have to handle it now.
+			handle(annotation, source, annotationNode);
+			ASTNode_handled.set(source, true);
+		}
 	}
 	
 	public char[] createLockField(AnnotationValues<Synchronized> annotation, EclipseNode annotationNode, boolean[] isStatic, boolean reportErrors) {

--- a/test/core/src/lombok/LombokTestSource.java
+++ b/test/core/src/lombok/LombokTestSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 The Project Lombok Authors.
+ * Copyright (C) 2014-2024 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -58,6 +58,7 @@ public class LombokTestSource {
 	private final boolean skipCompareContent;
 	private final boolean skipIdempotent;
 	private final boolean unchanged;
+	private final boolean verifyDiet;
 	private final int versionLowerLimit, versionUpperLimit;
 	private final ConfigurationResolver configuration;
 	private final String specifiedEncoding;
@@ -113,6 +114,10 @@ public class LombokTestSource {
 		return skipIdempotent;
 	}
 	
+	public boolean isVerifyDiet() {
+		return verifyDiet;
+	}
+	
 	public String getSpecifiedEncoding() {
 		return specifiedEncoding;
 	}
@@ -162,6 +167,7 @@ public class LombokTestSource {
 	private static final Pattern SKIP_COMPARE_CONTENT_PATTERN = Pattern.compile("^\\s*skip[- ]?compare[- ]?contents?\\s*(?:[-:].*)?$", Pattern.CASE_INSENSITIVE);
 	private static final Pattern SKIP_IDEMPOTENT_PATTERN = Pattern.compile("^\\s*skip[- ]?idempotent\\s*(?:[-:].*)?$", Pattern.CASE_INSENSITIVE);
 	private static final Pattern ISSUE_REF_PATTERN = Pattern.compile("^\\s*issue #?\\d+(:?\\s+.*)?$", Pattern.CASE_INSENSITIVE);
+	private static final Pattern VERIFY_DIET_PATTERN = Pattern.compile("^\\s*eclipse:\\s*verify[- ]?diet\\s*(?:[-:].*)?$", Pattern.CASE_INSENSITIVE);
 	
 	private LombokTestSource(File file, String content, List<CompilerMessageMatcher> messages, List<String> directives) {
 		this.file = file;
@@ -175,6 +181,7 @@ public class LombokTestSource {
 		boolean skipCompareContent = false;
 		boolean skipIdempotent = false;
 		boolean unchanged = false;
+		boolean verifyDiet = false;
 		String encoding = null;
 		Map<String, String> formats = new HashMap<String, String>();
 		String[] platformLimit = null;
@@ -202,6 +209,10 @@ public class LombokTestSource {
 				continue;
 			}
 			if (ISSUE_REF_PATTERN.matcher(directive).matches()) {
+				continue;
+			}
+			if (VERIFY_DIET_PATTERN.matcher(directive).matches()) {
+				verifyDiet = true;
 				continue;
 			}
 			
@@ -257,6 +268,7 @@ public class LombokTestSource {
 		this.skipCompareContent = skipCompareContent;
 		this.skipIdempotent = skipIdempotent;
 		this.unchanged = unchanged;
+		this.verifyDiet = verifyDiet;
 		this.platforms = platformLimit == null ? null : Arrays.asList(platformLimit);
 		
 		ConfigurationProblemReporter reporter = new ConfigurationProblemReporter() {

--- a/test/core/src/lombok/RunTestsViaEcj.java
+++ b/test/core/src/lombok/RunTestsViaEcj.java
@@ -123,8 +123,8 @@ public class RunTestsViaEcj extends AbstractRunTests {
 	}
 	
 	@Override
-	public TransformationResult transformCode(File file, TestParameters parameters) throws Throwable {
-		TransformationResult result = new TransformationResult();
+	public TransformationResult transformCode(File file, final TestParameters parameters) throws Throwable {
+		final TransformationResult result = new TransformationResult();
 		final AtomicReference<CompilationResult> compilationResult_ = new AtomicReference<CompilationResult>();
 		final AtomicReference<CompilationUnitDeclaration> compilationUnit_ = new AtomicReference<CompilationUnitDeclaration>();
 		ICompilerRequestor bitbucketRequestor = new ICompilerRequestor() {

--- a/test/core/src/lombok/RunTestsViaEcj.java
+++ b/test/core/src/lombok/RunTestsViaEcj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 The Project Lombok Authors.
+ * Copyright (C) 2010-2024 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,18 +22,13 @@
 package lombok;
 
 import java.io.File;
-import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-
-import lombok.eclipse.Eclipse;
-import lombok.javac.CapturingDiagnosticListener.CompilerMessage;
 
 import org.eclipse.core.internal.registry.ExtensionRegistry;
 import org.eclipse.core.internal.runtime.Activator;
@@ -61,18 +56,19 @@ import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
+import lombok.eclipse.Eclipse;
+import lombok.javac.CapturingDiagnosticListener.CompilerMessage;
+
 public class RunTestsViaEcj extends AbstractRunTests {
-	protected CompilerOptions ecjCompilerOptions() {
+	protected CompilerOptions ecjCompilerOptions(TestParameters parameters) {
 		CompilerOptions options = new CompilerOptions();
 		Map<String, String> warnings = new HashMap<String, String>();
 		
-		String javaVersionString = System.getProperty("compiler.compliance.level");
 		long ecjCompilerVersionConstant = Eclipse.getLatestEcjCompilerVersionConstant();
 		long ecjCompilerVersion = Eclipse.getEcjCompilerVersion();
-		if (javaVersionString != null) {
-			long javaVersion = Long.parseLong(javaVersionString);
-			ecjCompilerVersionConstant = (javaVersion + 44) << 16;
-			ecjCompilerVersion = javaVersion;
+		if (parameters.getSourceVersion() != null) {
+			ecjCompilerVersionConstant = (parameters.getSourceVersion() + 44) << 16;
+			ecjCompilerVersion = parameters.getSourceVersion();
 		} else {
 			// Preview features are only allowed if the maximum compiler version is equal to the source version
 			warnings.put("org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures", "enabled");
@@ -127,7 +123,8 @@ public class RunTestsViaEcj extends AbstractRunTests {
 	}
 	
 	@Override
-	public boolean transformCode(Collection<CompilerMessage> messages, StringWriter result, File file, String encoding, Map<String, String> formatPreferences, int minVersion, boolean checkPositions) throws Throwable {
+	public TransformationResult transformCode(File file, TestParameters parameters) throws Throwable {
+		TransformationResult result = new TransformationResult();
 		final AtomicReference<CompilationResult> compilationResult_ = new AtomicReference<CompilationResult>();
 		final AtomicReference<CompilationUnitDeclaration> compilationUnit_ = new AtomicReference<CompilationUnitDeclaration>();
 		ICompilerRequestor bitbucketRequestor = new ICompilerRequestor() {
@@ -143,12 +140,18 @@ public class RunTestsViaEcj extends AbstractRunTests {
 			sourceUnit = getSourceUnit(file, source);
 		} catch (Throwable t) {
 			t.printStackTrace();
-			return false;
+			result.setChanged(false);
+			return result;
 		}
 		
-		Compiler ecjCompiler = new Compiler(createFileSystem(file, minVersion), ecjErrorHandlingPolicy(), ecjCompilerOptions(), bitbucketRequestor, new DefaultProblemFactory(Locale.ENGLISH)) {
+		Compiler ecjCompiler = new Compiler(createFileSystem(file), ecjErrorHandlingPolicy(), ecjCompilerOptions(parameters), bitbucketRequestor, new DefaultProblemFactory(Locale.ENGLISH)) {
 			@Override protected synchronized void addCompilationUnit(ICompilationUnit inUnit, CompilationUnitDeclaration parsedUnit) {
-				if (inUnit == sourceUnit) compilationUnit_.set(parsedUnit);
+				if (inUnit == sourceUnit) {
+					compilationUnit_.set(parsedUnit);
+					if (parameters.isVerifyDiet()) {
+						result.setOutput(parsedUnit.toString());
+					}
+				}
 				super.addCompilationUnit(inUnit, parsedUnit);
 			}
 		};
@@ -161,24 +164,28 @@ public class RunTestsViaEcj extends AbstractRunTests {
 		CategorizedProblem[] problems = compilationResult.getAllProblems();
 		
 		if (problems != null) for (CategorizedProblem p : problems) {
-			messages.add(new CompilerMessage(p.getSourceLineNumber(), p.getSourceStart(), p.isError(), p.getMessage()));
+			result.addMessage(new CompilerMessage(p.getSourceLineNumber(), p.getSourceStart(), p.isError(), p.getMessage()));
 		}
 		
 		CompilationUnitDeclaration cud = compilationUnit_.get();
 		
-		if (cud == null) result.append("---- No CompilationUnit provided by ecj ----");
-		else {
-			String output = cud.toString();
-			// starting somewhere around ecj16, the print code is a bit too cavalier with printing modifiers.
-			output = output.replace("non-sealed @val", "@val");
-			result.append(output);
+		if (cud == null) {
+			result.setOutput("---- No CompilationUnit provided by ecj ----");
+		} else {
+			if (!parameters.isVerifyDiet()) {
+				String output = cud.toString();
+				// starting somewhere around ecj16, the print code is a bit too cavalier with printing modifiers.
+				output = output.replace("non-sealed @val", "@val");
+				result.setOutput(output);
+			}
+			
+			if (eclipseAvailable()) {
+				EclipseDomConversion.toDomAst(cud, sourceArray);
+			}
 		}
 		
-		if (eclipseAvailable()) {
-			EclipseDomConversion.toDomAst(cud, sourceArray);
-		}
-		
-		return true;
+		result.setChanged(true);
+		return result;
 	}
 	
 	@SuppressWarnings("unused")
@@ -238,7 +245,7 @@ public class RunTestsViaEcj extends AbstractRunTests {
 		}
 	}
 	
-	private FileSystem createFileSystem(File file, int minVersion) {
+	private FileSystem createFileSystem(File file) {
 		List<String> classpath = new ArrayList<String>();
 		if (new File("bin/main").exists()) classpath.add("bin/main");
 		classpath.add("dist/lombok.jar");

--- a/test/core/src/lombok/TestParameters.java
+++ b/test/core/src/lombok/TestParameters.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok;
+
+import java.util.Map;
+
+public class TestParameters {
+	private Long sourceVersion;
+	private Long targetVersion;
+	
+	// Javac only
+	private Integer minVersion;
+	private String encoding;
+	private Map<String, String> formatPreferences;
+	private boolean checkPositions;
+	
+	// Eclipse/Ecj only
+	private boolean verifyDiet;
+	
+	public Long getSourceVersion() {
+		return sourceVersion;
+	}
+	
+	public void setSourceVersion(Long sourceVersion) {
+		this.sourceVersion = sourceVersion;
+	}
+	
+	public Long getTargetVersion() {
+		return targetVersion;
+	}
+	
+	public void setTargetVersion(Long targetVersion) {
+		this.targetVersion = targetVersion;
+	}
+	
+	public Integer getMinVersion() {
+		return minVersion;
+	}
+	
+	public void setMinVersion(Integer minVersion) {
+		this.minVersion = minVersion;
+	}
+	
+	public String getEncoding() {
+		return encoding;
+	}
+	
+	public void setEncoding(String encoding) {
+		this.encoding = encoding;
+	}
+	
+	public Map<String, String> getFormatPreferences() {
+		return formatPreferences;
+	}
+	
+	public void setFormatPreferences(Map<String, String> formatPreferences) {
+		this.formatPreferences = formatPreferences;
+	}
+	
+	public boolean isCheckPositions() {
+		return checkPositions;
+	}
+	
+	public void setCheckPositions(boolean checkPositions) {
+		this.checkPositions = checkPositions;
+	}
+	
+	public boolean isVerifyDiet() {
+		return verifyDiet;
+	}
+	
+	public void setVerifyDiet(boolean verifyDiet) {
+		this.verifyDiet = verifyDiet;
+	}
+}

--- a/test/core/src/lombok/TransformationResult.java
+++ b/test/core/src/lombok/TransformationResult.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok;
+
+import java.util.LinkedHashSet;
+
+import lombok.javac.CapturingDiagnosticListener.CompilerMessage;
+
+public class TransformationResult {
+	private boolean changed;
+	private boolean success;
+	private LinkedHashSet<CompilerMessage> messages = new LinkedHashSet<CompilerMessage>();
+	private String output;
+	
+	public void addMessage(CompilerMessage message) {
+		getMessages().add(message);
+	}
+	
+	public void setOutput(String output) {
+		this.output = output;
+	}
+	
+	public String getOutput() {
+		return output;
+	}
+	
+	public boolean isChanged() {
+		return changed;
+	}
+	
+	public void setChanged(boolean changed) {
+		this.changed = changed;
+	}
+	
+	public boolean isSuccess() {
+		return success;
+	}
+	
+	public void setSuccess(boolean success) {
+		this.success = success;
+	}
+	
+	public LinkedHashSet<CompilerMessage> getMessages() {
+		return messages;
+	}
+}

--- a/test/transform/resource/after-delombok/LockedInInitializer.java
+++ b/test/transform/resource/after-delombok/LockedInInitializer.java
@@ -1,0 +1,41 @@
+public class LockedInInitializer {
+	public static final Runnable LOCKED = new Runnable() {
+		@java.lang.SuppressWarnings("all")
+		private final java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
+		@Override
+		public void run() {
+			this.$lock.lock();
+			try {
+				System.out.println("test");
+			} finally {
+				this.$lock.unlock();
+			}
+		}
+	};
+	public static final Runnable LOCKED_READ = new Runnable() {
+		@java.lang.SuppressWarnings("all")
+		private final java.util.concurrent.locks.ReadWriteLock $lock = new java.util.concurrent.locks.ReentrantReadWriteLock();
+		@Override
+		public void run() {
+			this.$lock.readLock().lock();
+			try {
+				System.out.println("test");
+			} finally {
+				this.$lock.readLock().unlock();
+			}
+		}
+	};
+	public static final Runnable LOCKED_WRITE = new Runnable() {
+		@java.lang.SuppressWarnings("all")
+		private final java.util.concurrent.locks.ReadWriteLock $lock = new java.util.concurrent.locks.ReentrantReadWriteLock();
+		@Override
+		public void run() {
+			this.$lock.writeLock().lock();
+			try {
+				System.out.println("test");
+			} finally {
+				this.$lock.writeLock().unlock();
+			}
+		}
+	};
+}

--- a/test/transform/resource/after-delombok/SneakyThrowsInInitializer.java
+++ b/test/transform/resource/after-delombok/SneakyThrowsInInitializer.java
@@ -1,0 +1,12 @@
+public class SneakyThrowsInInitializer {
+	public static final Runnable R = new Runnable() {
+		@Override
+		public void run() {
+			try {
+				System.out.println("test");
+			} catch (final java.lang.Throwable $ex) {
+				throw lombok.Lombok.sneakyThrow($ex);
+			}
+		}
+	};
+}

--- a/test/transform/resource/after-delombok/SynchronizedInInitializer.java
+++ b/test/transform/resource/after-delombok/SynchronizedInInitializer.java
@@ -1,0 +1,12 @@
+public class SynchronizedInInitializer {
+	public static final Runnable SYNCHRONIZED = new Runnable() {
+		@java.lang.SuppressWarnings("all")
+		private final java.lang.Object $lock = new java.lang.Object[0];
+		@Override
+		public void run() {
+			synchronized (this.$lock) {
+				System.out.println("test");
+			}
+		}
+	};
+}

--- a/test/transform/resource/after-ecj/LockedInInitializer.java
+++ b/test/transform/resource/after-ecj/LockedInInitializer.java
@@ -1,0 +1,49 @@
+import lombok.Locked;
+public class LockedInInitializer {
+  public static final Runnable LOCKED = new Runnable() {
+    private final java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
+    public @Override @Locked void run() {
+      this.$lock.lock();
+      try
+        {
+          System.out.println("test");
+        }
+      finally
+        {
+          this.$lock.unlock();
+        }
+    }
+  };
+  public static final Runnable LOCKED_READ = new Runnable() {
+    private final java.util.concurrent.locks.ReadWriteLock $lock = new java.util.concurrent.locks.ReentrantReadWriteLock();
+    public @Override @Locked.Read void run() {
+      this.$lock.readLock().lock();
+      try
+        {
+          System.out.println("test");
+        }
+      finally
+        {
+          this.$lock.readLock().unlock();
+        }
+    }
+  };
+  public static final Runnable LOCKED_WRITE = new Runnable() {
+    private final java.util.concurrent.locks.ReadWriteLock $lock = new java.util.concurrent.locks.ReentrantReadWriteLock();
+    public @Override @Locked.Write void run() {
+      this.$lock.writeLock().lock();
+      try
+        {
+          System.out.println("test");
+        }
+      finally
+        {
+          this.$lock.writeLock().unlock();
+        }
+    }
+  };
+  <clinit>() {
+  }
+  public LockedInInitializer() {
+  }
+}

--- a/test/transform/resource/after-ecj/SneakyThrowsInInitializer.java
+++ b/test/transform/resource/after-ecj/SneakyThrowsInInitializer.java
@@ -1,0 +1,19 @@
+import lombok.SneakyThrows;
+public class SneakyThrowsInInitializer {
+  public static final Runnable R = new Runnable() {
+    public @Override @SneakyThrows void run() {
+      try
+        {
+          System.out.println("test");
+        }
+      catch (final java.lang.Throwable $ex)
+        {
+          throw lombok.Lombok.sneakyThrow($ex);
+        }
+    }
+  };
+  <clinit>() {
+  }
+  public SneakyThrowsInInitializer() {
+  }
+}

--- a/test/transform/resource/after-ecj/SynchronizedInInitializer.java
+++ b/test/transform/resource/after-ecj/SynchronizedInInitializer.java
@@ -1,0 +1,16 @@
+import lombok.Synchronized;
+public class SynchronizedInInitializer {
+  public static final Runnable SYNCHRONIZED = new Runnable() {
+    private final java.lang.Object $lock = new java.lang.Object[0];
+    public @Override @Synchronized void run() {
+      synchronized (this.$lock)
+        {
+          System.out.println("test");
+        }
+    }
+  };
+  <clinit>() {
+  }
+  public SynchronizedInInitializer() {
+  }
+}

--- a/test/transform/resource/before/LockedInInitializer.java
+++ b/test/transform/resource/before/LockedInInitializer.java
@@ -1,0 +1,26 @@
+//eclipse: verify diet
+import lombok.Locked;
+
+public class LockedInInitializer {
+	public static final Runnable LOCKED = new Runnable() {
+		@Override
+		@Locked
+		public void run() {
+			System.out.println("test");
+		}
+	};
+	public static final Runnable LOCKED_READ = new Runnable() {
+		@Override
+		@Locked.Read
+		public void run() {
+			System.out.println("test");
+		}
+	};
+	public static final Runnable LOCKED_WRITE = new Runnable() {
+		@Override
+		@Locked.Write
+		public void run() {
+			System.out.println("test");
+		}
+	};
+}

--- a/test/transform/resource/before/SneakyThrowsInInitializer.java
+++ b/test/transform/resource/before/SneakyThrowsInInitializer.java
@@ -1,0 +1,15 @@
+//eclipse: verify diet
+import lombok.SneakyThrows;
+
+public class SneakyThrowsInInitializer {
+
+	public static final Runnable R = new Runnable() {
+		
+		@Override
+		@SneakyThrows
+		public void run() {
+			System.out.println("test");
+			
+		}
+	};
+}

--- a/test/transform/resource/before/SynchronizedInInitializer.java
+++ b/test/transform/resource/before/SynchronizedInInitializer.java
@@ -1,0 +1,12 @@
+//eclipse: verify diet
+import lombok.Synchronized;
+
+public class SynchronizedInInitializer {
+	public static final Runnable SYNCHRONIZED = new Runnable() {
+		@Override
+		@Synchronized
+		public void run() {
+			System.out.println("test");
+		}
+	};
+}


### PR DESCRIPTION
This PR fixes #1443

The eclipse parser disables diet parse for field initializers, and if one of these initializers contains an anonymous type, it may also contain a method with a lombok annotation. In some cases, eclipse will resolve the bindings after the diet parse and lombok will generate unresolved code. To prevent this I added some code to identify and handle this case.

I was unable to reproduce this problem in an automated full eclipse test but I added a new source directive to compare the diet result.