### PR TITLE
Adding support for SequencedCollection, SequencedSet and SequencedMap from JDK 21

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,6 +33,7 @@ Mart Hagenaars <marthagenaars@gmail.com>
 Martin O'Connor <38929043+martinoconnor@users.noreply.github.com>
 Martin Panzer <postremus1996@googlemail.com>
 Mateusz Matela <mateusz.matela@gmail.com>
+Maxim Samoylych <msamoylych@gmail.com>
 Michael Dardis <git@md-5.net>
 Michael Ernst <mernst@alum.mit.edu>
 Michiel Verheul <cheelio@gmail.com>

--- a/src/core/lombok/core/GuavaTypeMap.java
+++ b/src/core/lombok/core/GuavaTypeMap.java
@@ -37,7 +37,10 @@ public final class GuavaTypeMap {
 		m.put("java.util.Map", "ImmutableMap");
 		m.put("java.util.Collection", "ImmutableList");
 		m.put("java.util.List", "ImmutableList");
-		
+		m.put("java.util.SequencedSet", "ImmutableSortedSet");
+		m.put("java.util.SequencedMap", "ImmutableSortedMap");
+		m.put("java.util.SequencedCollection", "ImmutableList");
+
 		m.put("com.google.common.collect.ImmutableSet", "ImmutableSet");
 		m.put("com.google.common.collect.ImmutableSortedSet", "ImmutableSortedSet");
 		m.put("com.google.common.collect.ImmutableMap", "ImmutableMap");

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilListSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilListSingularizer.java
@@ -50,7 +50,7 @@ import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 @Provides(EclipseSingularizer.class)
 public class EclipseJavaUtilListSingularizer extends EclipseJavaUtilListSetSingularizer {
 	@Override public LombokImmutableList<String> getSupportedTypes() {
-		return LombokImmutableList.of("java.util.List", "java.util.Collection", "java.lang.Iterable");
+		return LombokImmutableList.of("java.util.List", "java.util.Collection", "java.util.SequencedCollection", "java.lang.Iterable");
 	}
 	
 	private static final char[] EMPTY_LIST = {'e', 'm', 'p', 't', 'y', 'L', 'i', 's', 't'};

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilMapSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilMapSingularizer.java
@@ -66,7 +66,7 @@ import lombok.spi.Provides;
 @Provides(EclipseSingularizer.class)
 public class EclipseJavaUtilMapSingularizer extends EclipseJavaUtilSingularizer {
 	@Override public LombokImmutableList<String> getSupportedTypes() {
-		return LombokImmutableList.of("java.util.Map", "java.util.SortedMap", "java.util.NavigableMap");
+		return LombokImmutableList.of("java.util.Map", "java.util.SortedMap", "java.util.NavigableMap", "java.util.SequencedMap");
 	}
 	
 	private static final char[] EMPTY_SORTED_MAP = {'e', 'm', 'p', 't', 'y', 'S', 'o', 'r', 't', 'e', 'd', 'M', 'a', 'p'};
@@ -78,7 +78,7 @@ public class EclipseJavaUtilMapSingularizer extends EclipseJavaUtilSingularizer 
 	}
 	
 	@Override protected char[] getEmptyMakerSelector(String targetFqn) {
-		if (targetFqn.endsWith("SortedMap")) return EMPTY_SORTED_MAP;
+		if (targetFqn.endsWith("SortedMap") || targetFqn.endsWith("SequencedMap")) return EMPTY_SORTED_MAP;
 		if (targetFqn.endsWith("NavigableMap")) return EMPTY_NAVIGABLE_MAP;
 		return EMPTY_MAP;
 	}
@@ -348,6 +348,8 @@ public class EclipseJavaUtilMapSingularizer extends EclipseJavaUtilSingularizer 
 		
 		if (data.getTargetFqn().equals("java.util.Map")) {
 			statements.addAll(createJavaUtilSetMapInitialCapacitySwitchStatements(data, builderType, true, "emptyMap", "singletonMap", "LinkedHashMap", builderVariable));
+		} else if (data.getTargetFqn().equals("java.util.SequencedMap")) {
+			statements.addAll(createJavaUtilSimpleCreationAndFillStatements(data, builderType, true, true, false, true, "LinkedHashMap", builderVariable));
 		} else {
 			statements.addAll(createJavaUtilSimpleCreationAndFillStatements(data, builderType, true, true, false, true, "TreeMap", builderVariable));
 		}

--- a/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilSetSingularizer.java
+++ b/src/core/lombok/eclipse/handlers/singulars/EclipseJavaUtilSetSingularizer.java
@@ -34,7 +34,7 @@ import org.eclipse.jdt.internal.compiler.ast.Statement;
 @Provides(EclipseSingularizer.class)
 public class EclipseJavaUtilSetSingularizer extends EclipseJavaUtilListSetSingularizer {
 	@Override public LombokImmutableList<String> getSupportedTypes() {
-		return LombokImmutableList.of("java.util.Set", "java.util.SortedSet", "java.util.NavigableSet");
+		return LombokImmutableList.of("java.util.Set", "java.util.SortedSet", "java.util.NavigableSet", "java.util.SequencedSet");
 	}
 	
 	private static final char[] EMPTY_SORTED_SET = {'e', 'm', 'p', 't', 'y', 'S', 'o', 'r', 't', 'e', 'd', 'S', 'e', 't'};
@@ -46,7 +46,7 @@ public class EclipseJavaUtilSetSingularizer extends EclipseJavaUtilListSetSingul
 	}
 	
 	@Override protected char[] getEmptyMakerSelector(String targetFqn) {
-		if (targetFqn.endsWith("SortedSet")) return EMPTY_SORTED_SET;
+		if (targetFqn.endsWith("SortedSet") || targetFqn.endsWith("SequencedSet")) return EMPTY_SORTED_SET;
 		if (targetFqn.endsWith("NavigableSet")) return EMPTY_NAVIGABLE_SET;
 		return EMPTY_SET;
 	}
@@ -59,6 +59,8 @@ public class EclipseJavaUtilSetSingularizer extends EclipseJavaUtilListSetSingul
 		
 		if (data.getTargetFqn().equals("java.util.Set")) {
 			statements.addAll(createJavaUtilSetMapInitialCapacitySwitchStatements(data, builderType, false, "emptySet", "singleton", "LinkedHashSet", builderVariable));
+		} else if (data.getTargetFqn().equals("java.util.SequencedSet")) {
+			statements.addAll(createJavaUtilSimpleCreationAndFillStatements(data, builderType, false, true, false, true, "LinkedHashSet", builderVariable));
 		} else {
 			statements.addAll(createJavaUtilSimpleCreationAndFillStatements(data, builderType, false, true, false, true, "TreeSet", builderVariable));
 		}

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilListSingularizer.java
@@ -41,7 +41,7 @@ import com.sun.tools.javac.util.Name;
 @Provides(JavacSingularizer.class)
 public class JavacJavaUtilListSingularizer extends JavacJavaUtilListSetSingularizer {
 	@Override public LombokImmutableList<String> getSupportedTypes() {
-		return LombokImmutableList.of("java.util.List", "java.util.Collection", "java.lang.Iterable");
+		return LombokImmutableList.of("java.util.List", "java.util.Collection", "java.util.SequencedCollection", "java.lang.Iterable");
 	}
 	
 	@Override protected String getEmptyMaker(String target) {

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilMapSingularizer.java
@@ -50,12 +50,12 @@ import com.sun.tools.javac.util.Name;
 @Provides(JavacSingularizer.class)
 public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 	@Override public LombokImmutableList<String> getSupportedTypes() {
-		return LombokImmutableList.of("java.util.Map", "java.util.SortedMap", "java.util.NavigableMap");
+		return LombokImmutableList.of("java.util.Map", "java.util.SortedMap", "java.util.NavigableMap", "java.util.SequencedMap");
 	}
 	
 	@Override protected String getEmptyMaker(String target) {
+		if (target.endsWith("SortedMap") || target.endsWith("SequencedMap")) return "java.util.Collections.emptySortedMap";
 		if (target.endsWith("NavigableMap")) return "java.util.Collections.emptyNavigableMap";
-		if (target.endsWith("SortedMap")) return "java.util.Collections.emptySortedMap";
 		return "java.util.Collections.emptyMap";
 	}
 	
@@ -171,6 +171,8 @@ public class JavacJavaUtilMapSingularizer extends JavacJavaUtilSingularizer {
 		
 		if (data.getTargetFqn().equals("java.util.Map")) {
 			statements.appendList(createJavaUtilSetMapInitialCapacitySwitchStatements(maker, data, builderType, true, "emptyMap", "singletonMap", "LinkedHashMap", source, builderVariable));
+		} else if (data.getTargetFqn().equals("java.util.SequencedMap")) {
+			statements.appendList(createJavaUtilSimpleCreationAndFillStatements(maker, data, builderType, true, true, false, true, "LinkedHashMap", source, builderVariable));
 		} else {
 			statements.appendList(createJavaUtilSimpleCreationAndFillStatements(maker, data, builderType, true, true, false, true, "TreeMap", source, builderVariable));
 		}

--- a/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSetSingularizer.java
+++ b/src/core/lombok/javac/handlers/singulars/JavacJavaUtilSetSingularizer.java
@@ -35,11 +35,11 @@ import com.sun.tools.javac.util.Name;
 @Provides(JavacSingularizer.class)
 public class JavacJavaUtilSetSingularizer extends JavacJavaUtilListSetSingularizer {
 	@Override public LombokImmutableList<String> getSupportedTypes() {
-		return LombokImmutableList.of("java.util.Set", "java.util.SortedSet", "java.util.NavigableSet");
+		return LombokImmutableList.of("java.util.Set", "java.util.SortedSet", "java.util.NavigableSet", "java.util.SequencedSet");
 	}
 	
 	@Override protected String getEmptyMaker(String target) {
-		if (target.endsWith("SortedSet")) return "java.util.Collections.emptySortedSet";
+		if (target.endsWith("SortedSet") || target.endsWith("SequencedSet")) return "java.util.Collections.emptySortedSet";
 		if (target.endsWith("NavigableSet")) return "java.util.Collections.emptyNavigableSet";
 		return "java.util.Collections.emptySet";
 	}
@@ -49,6 +49,8 @@ public class JavacJavaUtilSetSingularizer extends JavacJavaUtilListSetSingulariz
 		
 		if (data.getTargetFqn().equals("java.util.Set")) {
 			statements.appendList(createJavaUtilSetMapInitialCapacitySwitchStatements(maker, data, builderType, false, "emptySet", "singleton", "LinkedHashSet", source, builderVariable));
+		} else if (data.getTargetFqn().equals("java.util.SequencedSet")) {
+			statements.appendList(createJavaUtilSimpleCreationAndFillStatements(maker, data, builderType, false, true, false, true, "LinkedHashSet", source, builderVariable));
 		} else {
 			statements.appendList(createJavaUtilSimpleCreationAndFillStatements(maker, data, builderType, false, true, false, true, "TreeSet", source, builderVariable));
 		}

--- a/test/transform/resource/after-delombok/BuilderSingularSequencedCollections.java
+++ b/test/transform/resource/after-delombok/BuilderSingularSequencedCollections.java
@@ -7,31 +7,40 @@ class BuilderSingularSequencedCollections<T, K, V> {
 	private SequencedMap<K, V> sequencedMap;
 	private SequencedSet<T> sequencedSet;
 	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
 	BuilderSingularSequencedCollections(final SequencedCollection<T> sequencedCollection, final SequencedMap<K, V> sequencedMap, final SequencedSet<T> sequencedSet) {
 		this.sequencedCollection = sequencedCollection;
 		this.sequencedMap = sequencedMap;
 		this.sequencedSet = sequencedSet;
 	}
 	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
 	public static class BuilderSingularSequencedCollectionsBuilder<T, K, V> {
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		private java.util.ArrayList<T> sequencedCollection;
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		private java.util.ArrayList<K> sequencedMap$key;
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		private java.util.ArrayList<V> sequencedMap$value;
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		private java.util.ArrayList<T> sequencedSet;
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		BuilderSingularSequencedCollectionsBuilder() {
 		}
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> col(final T col) {
 			if (this.sequencedCollection == null) this.sequencedCollection = new java.util.ArrayList<T>();
 			this.sequencedCollection.add(col);
 			return this;
 		}
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedCollection(final java.util.Collection<? extends T> sequencedCollection) {
 			if (sequencedCollection == null) {
 				throw new java.lang.NullPointerException("sequencedCollection cannot be null");
@@ -41,11 +50,13 @@ class BuilderSingularSequencedCollections<T, K, V> {
 			return this;
 		}
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedCollection() {
 			if (this.sequencedCollection != null) this.sequencedCollection.clear();
 			return this;
 		}
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> map(final K mapKey, final V mapValue) {
 			if (this.sequencedMap$key == null) {
 				this.sequencedMap$key = new java.util.ArrayList<K>();
@@ -56,6 +67,7 @@ class BuilderSingularSequencedCollections<T, K, V> {
 			return this;
 		}
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedMap(final java.util.Map<? extends K, ? extends V> sequencedMap) {
 			if (sequencedMap == null) {
 				throw new java.lang.NullPointerException("sequencedMap cannot be null");
@@ -71,6 +83,7 @@ class BuilderSingularSequencedCollections<T, K, V> {
 			return this;
 		}
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedMap() {
 			if (this.sequencedMap$key != null) {
 				this.sequencedMap$key.clear();
@@ -79,12 +92,14 @@ class BuilderSingularSequencedCollections<T, K, V> {
 			return this;
 		}
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> set(final T set) {
 			if (this.sequencedSet == null) this.sequencedSet = new java.util.ArrayList<T>();
 			this.sequencedSet.add(set);
 			return this;
 		}
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedSet(final java.util.Collection<? extends T> sequencedSet) {
 			if (sequencedSet == null) {
 				throw new java.lang.NullPointerException("sequencedSet cannot be null");
@@ -94,11 +109,13 @@ class BuilderSingularSequencedCollections<T, K, V> {
 			return this;
 		}
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedSet() {
 			if (this.sequencedSet != null) this.sequencedSet.clear();
 			return this;
 		}
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public BuilderSingularSequencedCollections<T, K, V> build() {
 			java.util.SequencedCollection<T> sequencedCollection;
 			switch (this.sequencedCollection == null ? 0 : this.sequencedCollection.size()) {
@@ -121,11 +138,13 @@ class BuilderSingularSequencedCollections<T, K, V> {
 		}
 		@java.lang.Override
 		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
 		public java.lang.String toString() {
 			return "BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder(sequencedCollection=" + this.sequencedCollection + ", sequencedMap$key=" + this.sequencedMap$key + ", sequencedMap$value=" + this.sequencedMap$value + ", sequencedSet=" + this.sequencedSet + ")";
 		}
 	}
 	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
 	public static <T, K, V> BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> builder() {
 		return new BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V>();
 	}

--- a/test/transform/resource/after-delombok/BuilderSingularSequencedCollections.java
+++ b/test/transform/resource/after-delombok/BuilderSingularSequencedCollections.java
@@ -1,0 +1,132 @@
+// version 21:
+import java.util.SequencedCollection;
+import java.util.SequencedMap;
+import java.util.SequencedSet;
+class BuilderSingularSequencedCollections<T, K, V> {
+	private SequencedCollection<T> sequencedCollection;
+	private SequencedMap<K, V> sequencedMap;
+	private SequencedSet<T> sequencedSet;
+	@java.lang.SuppressWarnings("all")
+	BuilderSingularSequencedCollections(final SequencedCollection<T> sequencedCollection, final SequencedMap<K, V> sequencedMap, final SequencedSet<T> sequencedSet) {
+		this.sequencedCollection = sequencedCollection;
+		this.sequencedMap = sequencedMap;
+		this.sequencedSet = sequencedSet;
+	}
+	@java.lang.SuppressWarnings("all")
+	public static class BuilderSingularSequencedCollectionsBuilder<T, K, V> {
+		@java.lang.SuppressWarnings("all")
+		private java.util.ArrayList<T> sequencedCollection;
+		@java.lang.SuppressWarnings("all")
+		private java.util.ArrayList<K> sequencedMap$key;
+		@java.lang.SuppressWarnings("all")
+		private java.util.ArrayList<V> sequencedMap$value;
+		@java.lang.SuppressWarnings("all")
+		private java.util.ArrayList<T> sequencedSet;
+		@java.lang.SuppressWarnings("all")
+		BuilderSingularSequencedCollectionsBuilder() {
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> col(final T col) {
+			if (this.sequencedCollection == null) this.sequencedCollection = new java.util.ArrayList<T>();
+			this.sequencedCollection.add(col);
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedCollection(final java.util.Collection<? extends T> sequencedCollection) {
+			if (sequencedCollection == null) {
+				throw new java.lang.NullPointerException("sequencedCollection cannot be null");
+			}
+			if (this.sequencedCollection == null) this.sequencedCollection = new java.util.ArrayList<T>();
+			this.sequencedCollection.addAll(sequencedCollection);
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedCollection() {
+			if (this.sequencedCollection != null) this.sequencedCollection.clear();
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> map(final K mapKey, final V mapValue) {
+			if (this.sequencedMap$key == null) {
+				this.sequencedMap$key = new java.util.ArrayList<K>();
+				this.sequencedMap$value = new java.util.ArrayList<V>();
+			}
+			this.sequencedMap$key.add(mapKey);
+			this.sequencedMap$value.add(mapValue);
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedMap(final java.util.Map<? extends K, ? extends V> sequencedMap) {
+			if (sequencedMap == null) {
+				throw new java.lang.NullPointerException("sequencedMap cannot be null");
+			}
+			if (this.sequencedMap$key == null) {
+				this.sequencedMap$key = new java.util.ArrayList<K>();
+				this.sequencedMap$value = new java.util.ArrayList<V>();
+			}
+			for (final java.util.Map.Entry<? extends K, ? extends V> $lombokEntry : sequencedMap.entrySet()) {
+				this.sequencedMap$key.add($lombokEntry.getKey());
+				this.sequencedMap$value.add($lombokEntry.getValue());
+			}
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedMap() {
+			if (this.sequencedMap$key != null) {
+				this.sequencedMap$key.clear();
+				this.sequencedMap$value.clear();
+			}
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> set(final T set) {
+			if (this.sequencedSet == null) this.sequencedSet = new java.util.ArrayList<T>();
+			this.sequencedSet.add(set);
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedSet(final java.util.Collection<? extends T> sequencedSet) {
+			if (sequencedSet == null) {
+				throw new java.lang.NullPointerException("sequencedSet cannot be null");
+			}
+			if (this.sequencedSet == null) this.sequencedSet = new java.util.ArrayList<T>();
+			this.sequencedSet.addAll(sequencedSet);
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedSet() {
+			if (this.sequencedSet != null) this.sequencedSet.clear();
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		public BuilderSingularSequencedCollections<T, K, V> build() {
+			java.util.SequencedCollection<T> sequencedCollection;
+			switch (this.sequencedCollection == null ? 0 : this.sequencedCollection.size()) {
+			case 0:
+				sequencedCollection = java.util.Collections.emptyList();
+				break;
+			case 1:
+				sequencedCollection = java.util.Collections.singletonList(this.sequencedCollection.get(0));
+				break;
+			default:
+				sequencedCollection = java.util.Collections.unmodifiableList(new java.util.ArrayList<T>(this.sequencedCollection));
+			}
+			java.util.SequencedMap<K, V> sequencedMap = new java.util.LinkedHashMap<K, V>();
+			if (this.sequencedMap$key != null) for (int $i = 0; $i < (this.sequencedMap$key == null ? 0 : this.sequencedMap$key.size()); $i++) sequencedMap.put(this.sequencedMap$key.get($i), (V) this.sequencedMap$value.get($i));
+			sequencedMap = java.util.Collections.unmodifiableSequencedMap(sequencedMap);
+			java.util.SequencedSet<T> sequencedSet = new java.util.LinkedHashSet<T>();
+			if (this.sequencedSet != null) sequencedSet.addAll(this.sequencedSet);
+			sequencedSet = java.util.Collections.unmodifiableSequencedSet(sequencedSet);
+			return new BuilderSingularSequencedCollections<T, K, V>(sequencedCollection, sequencedMap, sequencedSet);
+		}
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		public java.lang.String toString() {
+			return "BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder(sequencedCollection=" + this.sequencedCollection + ", sequencedMap$key=" + this.sequencedMap$key + ", sequencedMap$value=" + this.sequencedMap$value + ", sequencedSet=" + this.sequencedSet + ")";
+		}
+	}
+	@java.lang.SuppressWarnings("all")
+	public static <T, K, V> BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> builder() {
+		return new BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V>();
+	}
+}

--- a/test/transform/resource/after-ecj/BuilderSingularSequencedCollections.java
+++ b/test/transform/resource/after-ecj/BuilderSingularSequencedCollections.java
@@ -4,22 +4,22 @@ import java.util.SequencedMap;
 import java.util.SequencedSet;
 import lombok.Builder;
 import lombok.Singular;
-@Builder class BuilderSingularSequencedCollections<T, K, V> {
-  public static @java.lang.SuppressWarnings("all") class BuilderSingularSequencedCollectionsBuilder<T, K, V> {
-    private @java.lang.SuppressWarnings("all") java.util.ArrayList<T> sequencedCollection;
-    private @java.lang.SuppressWarnings("all") java.util.ArrayList<K> sequencedMap$key;
-    private @java.lang.SuppressWarnings("all") java.util.ArrayList<V> sequencedMap$value;
-    private @java.lang.SuppressWarnings("all") java.util.ArrayList<T> sequencedSet;
-    @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollectionsBuilder() {
+@lombok.Builder class BuilderSingularSequencedCollections<T, K, V> {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated class BuilderSingularSequencedCollectionsBuilder<T, K, V> {
+    private @java.lang.SuppressWarnings("all") @lombok.Generated java.util.ArrayList<T> sequencedCollection;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated java.util.ArrayList<K> sequencedMap$key;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated java.util.ArrayList<V> sequencedMap$value;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated java.util.ArrayList<T> sequencedSet;
+    @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollectionsBuilder() {
       super();
     }
-    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> col(final T col) {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> col(final T col) {
       if ((this.sequencedCollection == null))
           this.sequencedCollection = new java.util.ArrayList<T>();
       this.sequencedCollection.add(col);
       return this;
     }
-    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedCollection(final java.util.Collection<? extends T> sequencedCollection) {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedCollection(final java.util.Collection<? extends T> sequencedCollection) {
       if ((sequencedCollection == null))
           {
             throw new java.lang.NullPointerException("sequencedCollection cannot be null");
@@ -29,12 +29,12 @@ import lombok.Singular;
       this.sequencedCollection.addAll(sequencedCollection);
       return this;
     }
-    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedCollection() {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedCollection() {
       if ((this.sequencedCollection != null))
           this.sequencedCollection.clear();
       return this;
     }
-    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> map(final K mapKey, final V mapValue) {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> map(final K mapKey, final V mapValue) {
       if ((this.sequencedMap$key == null))
           {
             this.sequencedMap$key = new java.util.ArrayList<K>();
@@ -44,7 +44,7 @@ import lombok.Singular;
       this.sequencedMap$value.add(mapValue);
       return this;
     }
-    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedMap(final java.util.Map<? extends K, ? extends V> sequencedMap) {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedMap(final java.util.Map<? extends K, ? extends V> sequencedMap) {
       if ((sequencedMap == null))
           {
             throw new java.lang.NullPointerException("sequencedMap cannot be null");
@@ -61,7 +61,7 @@ import lombok.Singular;
         }
       return this;
     }
-    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedMap() {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedMap() {
       if ((this.sequencedMap$key != null))
           {
             this.sequencedMap$key.clear();
@@ -69,13 +69,13 @@ import lombok.Singular;
           }
       return this;
     }
-    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> set(final T set) {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> set(final T set) {
       if ((this.sequencedSet == null))
           this.sequencedSet = new java.util.ArrayList<T>();
       this.sequencedSet.add(set);
       return this;
     }
-    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedSet(final java.util.Collection<? extends T> sequencedSet) {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedSet(final java.util.Collection<? extends T> sequencedSet) {
       if ((sequencedSet == null))
           {
             throw new java.lang.NullPointerException("sequencedSet cannot be null");
@@ -85,12 +85,12 @@ import lombok.Singular;
       this.sequencedSet.addAll(sequencedSet);
       return this;
     }
-    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedSet() {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedSet() {
       if ((this.sequencedSet != null))
           this.sequencedSet.clear();
       return this;
     }
-    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections<T, K, V> build() {
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollections<T, K, V> build() {
       java.util.SequencedCollection<T> sequencedCollection;
       switch (((this.sequencedCollection == null) ? 0 : this.sequencedCollection.size())) {
       case 0 :
@@ -113,20 +113,20 @@ import lombok.Singular;
       sequencedSet = java.util.Collections.unmodifiableSequencedSet(sequencedSet);
       return new BuilderSingularSequencedCollections<T, K, V>(sequencedCollection, sequencedMap, sequencedSet);
     }
-    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+    public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
       return (((((((("BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder(sequencedCollection=" + this.sequencedCollection) + ", sequencedMap$key=") + this.sequencedMap$key) + ", sequencedMap$value=") + this.sequencedMap$value) + ", sequencedSet=") + this.sequencedSet) + ")");
     }
   }
   private @Singular("col") SequencedCollection<T> sequencedCollection;
   private @Singular("map") SequencedMap<K, V> sequencedMap;
   private @Singular("set") SequencedSet<T> sequencedSet;
-  @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections(final SequencedCollection<T> sequencedCollection, final SequencedMap<K, V> sequencedMap, final SequencedSet<T> sequencedSet) {
+  @java.lang.SuppressWarnings("all") @lombok.Generated BuilderSingularSequencedCollections(final SequencedCollection<T> sequencedCollection, final SequencedMap<K, V> sequencedMap, final SequencedSet<T> sequencedSet) {
     super();
     this.sequencedCollection = sequencedCollection;
     this.sequencedMap = sequencedMap;
     this.sequencedSet = sequencedSet;
   }
-  public static @java.lang.SuppressWarnings("all") <T, K, V>BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> builder() {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated <T, K, V>BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> builder() {
     return new BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V>();
   }
 }

--- a/test/transform/resource/after-ecj/BuilderSingularSequencedCollections.java
+++ b/test/transform/resource/after-ecj/BuilderSingularSequencedCollections.java
@@ -1,0 +1,132 @@
+// version 21:
+import java.util.SequencedCollection;
+import java.util.SequencedMap;
+import java.util.SequencedSet;
+import lombok.Builder;
+import lombok.Singular;
+@Builder class BuilderSingularSequencedCollections<T, K, V> {
+  public static @java.lang.SuppressWarnings("all") class BuilderSingularSequencedCollectionsBuilder<T, K, V> {
+    private @java.lang.SuppressWarnings("all") java.util.ArrayList<T> sequencedCollection;
+    private @java.lang.SuppressWarnings("all") java.util.ArrayList<K> sequencedMap$key;
+    private @java.lang.SuppressWarnings("all") java.util.ArrayList<V> sequencedMap$value;
+    private @java.lang.SuppressWarnings("all") java.util.ArrayList<T> sequencedSet;
+    @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollectionsBuilder() {
+      super();
+    }
+    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> col(final T col) {
+      if ((this.sequencedCollection == null))
+          this.sequencedCollection = new java.util.ArrayList<T>();
+      this.sequencedCollection.add(col);
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedCollection(final java.util.Collection<? extends T> sequencedCollection) {
+      if ((sequencedCollection == null))
+          {
+            throw new java.lang.NullPointerException("sequencedCollection cannot be null");
+          }
+      if ((this.sequencedCollection == null))
+          this.sequencedCollection = new java.util.ArrayList<T>();
+      this.sequencedCollection.addAll(sequencedCollection);
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedCollection() {
+      if ((this.sequencedCollection != null))
+          this.sequencedCollection.clear();
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> map(final K mapKey, final V mapValue) {
+      if ((this.sequencedMap$key == null))
+          {
+            this.sequencedMap$key = new java.util.ArrayList<K>();
+            this.sequencedMap$value = new java.util.ArrayList<V>();
+          }
+      this.sequencedMap$key.add(mapKey);
+      this.sequencedMap$value.add(mapValue);
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedMap(final java.util.Map<? extends K, ? extends V> sequencedMap) {
+      if ((sequencedMap == null))
+          {
+            throw new java.lang.NullPointerException("sequencedMap cannot be null");
+          }
+      if ((this.sequencedMap$key == null))
+          {
+            this.sequencedMap$key = new java.util.ArrayList<K>();
+            this.sequencedMap$value = new java.util.ArrayList<V>();
+          }
+      for (java.util.Map.Entry<? extends K, ? extends V> $lombokEntry : sequencedMap.entrySet())
+        {
+          this.sequencedMap$key.add($lombokEntry.getKey());
+          this.sequencedMap$value.add($lombokEntry.getValue());
+        }
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedMap() {
+      if ((this.sequencedMap$key != null))
+          {
+            this.sequencedMap$key.clear();
+            this.sequencedMap$value.clear();
+          }
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> set(final T set) {
+      if ((this.sequencedSet == null))
+          this.sequencedSet = new java.util.ArrayList<T>();
+      this.sequencedSet.add(set);
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> sequencedSet(final java.util.Collection<? extends T> sequencedSet) {
+      if ((sequencedSet == null))
+          {
+            throw new java.lang.NullPointerException("sequencedSet cannot be null");
+          }
+      if ((this.sequencedSet == null))
+          this.sequencedSet = new java.util.ArrayList<T>();
+      this.sequencedSet.addAll(sequencedSet);
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> clearSequencedSet() {
+      if ((this.sequencedSet != null))
+          this.sequencedSet.clear();
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections<T, K, V> build() {
+      java.util.SequencedCollection<T> sequencedCollection;
+      switch (((this.sequencedCollection == null) ? 0 : this.sequencedCollection.size())) {
+      case 0 :
+          sequencedCollection = java.util.Collections.emptyList();
+          break;
+      case 1 :
+          sequencedCollection = java.util.Collections.singletonList(this.sequencedCollection.get(0));
+          break;
+      default :
+          sequencedCollection = java.util.Collections.unmodifiableList(new java.util.ArrayList<T>(this.sequencedCollection));
+      }
+      java.util.SequencedMap<K, V> sequencedMap = new java.util.LinkedHashMap<K, V>();
+      if ((this.sequencedMap$key != null))
+          for (int $i = 0;; ($i < ((this.sequencedMap$key == null) ? 0 : this.sequencedMap$key.size())); $i ++)
+            sequencedMap.put(this.sequencedMap$key.get($i), this.sequencedMap$value.get($i));
+      sequencedMap = java.util.Collections.unmodifiableSequencedMap(sequencedMap);
+      java.util.SequencedSet<T> sequencedSet = new java.util.LinkedHashSet<T>();
+      if ((this.sequencedSet != null))
+          sequencedSet.addAll(this.sequencedSet);
+      sequencedSet = java.util.Collections.unmodifiableSequencedSet(sequencedSet);
+      return new BuilderSingularSequencedCollections<T, K, V>(sequencedCollection, sequencedMap, sequencedSet);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") java.lang.String toString() {
+      return (((((((("BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder(sequencedCollection=" + this.sequencedCollection) + ", sequencedMap$key=") + this.sequencedMap$key) + ", sequencedMap$value=") + this.sequencedMap$value) + ", sequencedSet=") + this.sequencedSet) + ")");
+    }
+  }
+  private @Singular("col") SequencedCollection<T> sequencedCollection;
+  private @Singular("map") SequencedMap<K, V> sequencedMap;
+  private @Singular("set") SequencedSet<T> sequencedSet;
+  @java.lang.SuppressWarnings("all") BuilderSingularSequencedCollections(final SequencedCollection<T> sequencedCollection, final SequencedMap<K, V> sequencedMap, final SequencedSet<T> sequencedSet) {
+    super();
+    this.sequencedCollection = sequencedCollection;
+    this.sequencedMap = sequencedMap;
+    this.sequencedSet = sequencedSet;
+  }
+  public static @java.lang.SuppressWarnings("all") <T, K, V>BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V> builder() {
+    return new BuilderSingularSequencedCollections.BuilderSingularSequencedCollectionsBuilder<T, K, V>();
+  }
+}

--- a/test/transform/resource/before/BuilderSingularSequencedCollections.java
+++ b/test/transform/resource/before/BuilderSingularSequencedCollections.java
@@ -1,0 +1,15 @@
+// version 21:
+
+import java.util.SequencedCollection;
+import java.util.SequencedMap;
+import java.util.SequencedSet;
+
+import lombok.Builder;
+import lombok.Singular;
+
+@Builder
+class BuilderSingularSequencedCollections<T, K, V> {
+	@Singular("col") private SequencedCollection<T> sequencedCollection;
+	@Singular("map") private SequencedMap<K, V> sequencedMap;
+	@Singular("set") private SequencedSet<T> sequencedSet;
+}

--- a/test/transform/resource/messages-ecj/BuilderSingularSequencedCollections.java.messages
+++ b/test/transform/resource/messages-ecj/BuilderSingularSequencedCollections.java.messages
@@ -1,0 +1,12 @@
+3 The import java.util.SequencedCollection cannot be resolved
+4 The import java.util.SequencedMap cannot be resolved
+5 The import java.util.SequencedSet cannot be resolved
+10 SequencedCollection cannot be resolved to a type
+10 SequencedMap cannot be resolved to a type
+10 SequencedSet cannot be resolved to a type
+10 java.util.SequencedCollection cannot be resolved to a type
+10 java.util.SequencedMap cannot be resolved to a type
+10 java.util.SequencedSet cannot be resolved to a type
+12 SequencedCollection cannot be resolved to a type
+13 SequencedMap cannot be resolved to a type
+14 SequencedSet cannot be resolved to a type

--- a/website/templates/features/Builder.html
+++ b/website/templates/features/Builder.html
@@ -126,11 +126,11 @@
 					<a href="https://docs.oracle.com/javase/8/docs/api/java/util/package-summary.html"><code>java.util</code></a>:
 					<ul>
 						<li>
-							<code>Iterable</code>, <code>Collection</code>, and <code>List</code> (backed by a compacted unmodifiable <code>ArrayList</code> in the general case).
+							<code>Iterable</code>, <code>Collection</code>, <code>SequencedCollection</code>, and <code>List</code> (backed by a compacted unmodifiable <code>ArrayList</code> in the general case).
 						</li><li>
-							<code>Set</code>, <code>SortedSet</code>, and <code>NavigableSet</code> (backed by a smartly sized unmodifiable <code>HashSet</code> or <code>TreeSet</code> in the general case).
+							<code>Set</code>, <code>SortedSet</code>, <code>NavigableSet</code>, and <code>SequencedSet</code> (backed by a smartly sized unmodifiable <code>LinkedHashSet</code> or <code>TreeSet</code> in the general case).
 						</li><li>
-							<code>Map</code>, <code>SortedMap</code>, and <code>NavigableMap</code> (backed by a smartly sized unmodifiable <code>HashMap</code> or <code>TreeMap</code> in the general case).
+							<code>Map</code>, <code>SortedMap</code>, <code>NavigableMap</code>, and <code>SequencedMap</code> (backed by a smartly sized unmodifiable <code>LinkedHashMap</code> or <code>TreeMap</code> in the general case).
 						</li>
 					</ul>
 				</li><li>


### PR DESCRIPTION
Adding support for `java.util.SequencedCollection`, `java.util.SequencedSet` and `java.util.SequencedMap` from JDK 21 for `@Singular` annotation (`@Builder`)