### PR TITLE
Add NonNull annotations to test cases for testing annotation copying

### DIFF
--- a/test/transform/resource/after-delombok/DataPlain.java
+++ b/test/transform/resource/after-delombok/DataPlain.java
@@ -1,6 +1,6 @@
 class Data1 {
 	final int x;
-	String name;
+	@lombok.NonNull String name;
 	@java.lang.SuppressWarnings("all")
 	public Data1(final int x) {
 		this.x = x;
@@ -9,12 +9,13 @@ class Data1 {
 	public int getX() {
 		return this.x;
 	}
+	@lombok.NonNull
 	@java.lang.SuppressWarnings("all")
 	public String getName() {
 		return this.name;
 	}
 	@java.lang.SuppressWarnings("all")
-	public void setName(final String name) {
+	public void setName(@lombok.NonNull final String name) {
 		this.name = name;
 	}
 	@java.lang.Override

--- a/test/transform/resource/after-delombok/ValuePlain.java
+++ b/test/transform/resource/after-delombok/ValuePlain.java
@@ -1,8 +1,9 @@
 final class Value1 {
 	private final int x;
+	@lombok.NonNull
 	private final String name;
 	@java.lang.SuppressWarnings("all")
-	public Value1(final int x, final String name) {
+	public Value1(final int x, @lombok.NonNull final String name) {
 		this.x = x;
 		this.name = name;
 	}
@@ -10,6 +11,7 @@ final class Value1 {
 	public int getX() {
 		return this.x;
 	}
+	@lombok.NonNull
 	@java.lang.SuppressWarnings("all")
 	public String getName() {
 		return this.name;

--- a/test/transform/resource/before/DataPlain.java
+++ b/test/transform/resource/before/DataPlain.java
@@ -1,7 +1,7 @@
 import lombok.Data;
 @lombok.Data class Data1 {
 	final int x;
-	String name;
+	@lombok.NonNull String name;
 }
 @Data class Data2 {
 	final int x;

--- a/test/transform/resource/before/ValuePlain.java
+++ b/test/transform/resource/before/ValuePlain.java
@@ -1,7 +1,7 @@
 import lombok.Value;
 @lombok.Value class Value1 {
 	final int x;
-	String name;
+	@lombok.NonNull String name;
 }
 @Value @lombok.experimental.NonFinal class Value2 {
 	public int x;


### PR DESCRIPTION
Closes https://github.com/projectlombok/lombok/issues/3318

This PR introduces `@NonNull` annotations as part of `@Data` and `@Value` classes' fields in order to be copied from fields to constructors, getters and setters as requested in https://github.com/projectlombok/lombok/issues/3318#issuecomment-1894757426.