### PR TITLE
[website] Fix typo on GetterSetter page

### DIFF
--- a/website/templates/features/GetterSetter.html
+++ b/website/templates/features/GetterSetter.html
@@ -28,7 +28,7 @@
 		</dd><dt>
 			<code>lombok.accessors.fluent</code> = [<code>true</code> | <code>false</code>] (default: false)
 		</dt><dd>
-			If set to <code>true</code>, generated getters and setters will not be prefixed with the bean-standard '<code>get</code>, <code>is</code> or <code>set</code>; instead, the methods will use the same name as the field (minus prefixes). An explicitly configured <code>chain</code> parameter of an <a href="/features/experimental/Accessors"><code>@Accessors</code></a> annotation takes precedence over this setting.
+			If set to <code>true</code>, generated getters and setters will not be prefixed with the bean-standard '<code>get</code>, <code>is</code> or <code>set</code>; instead, the methods will use the same name as the field (minus prefixes). An explicitly configured <code>fluent</code> parameter of an <a href="/features/experimental/Accessors"><code>@Accessors</code></a> annotation takes precedence over this setting.
 		</dd><dt>
 			<code>lombok.accessors.prefix</code> += <em>a field prefix</em> (default: empty list)
 		</dt><dd>


### PR DESCRIPTION
Just a typo, it should say "fluent" instead of "chain" here.