### PR TITLE
Allow builds from intel MacBook

### DIFF
--- a/buildScripts/setup.ant.xml
+++ b/buildScripts/setup.ant.xml
@@ -55,6 +55,7 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 			<or>
 				<os arch="aarch64" />
 				<os arch="x86-64" />
+				<os arch="x86_64" />
 				<os arch="amd64" />
 			</or>
 		</and>


### PR DESCRIPTION
When trying to build from an intel MacBook with `ant -noinput dist`, it rejects my computer architecture and calls me a snowflake

```
Full eclipse testing requires downloading a native SWT binding.
This script knows how to download for OS = [mac, linux, or windows] and architecture = [aarch64 or x86-64].
You have something different, you unique snowflake you.
Your OS: "Mac OS X", Your arch: "x86_64".
```

The problem is that it expects a dash (`-`) but my mac reports an underscore (`_`), this is solved by adding `x86_64` alongside `x86-64`