### PR TITLE
Fix type detection of nested annotations

### DIFF
--- a/buildScripts/vm-finder.ant.xml
+++ b/buildScripts/vm-finder.ant.xml
@@ -143,7 +143,7 @@ and rerun the build; this build is capable of finding VMs automatically on many 
 			<matches pattern="^\s*$" string="${jvm.loc}" />
 		</condition>
 		<fail if="jvm.loc.aborted">aborted</fail>
-		<fail if="jvm.loc.invalid">.
+		<fail>.
 
 ERROR: That does not appear to be a valid location; ${jvm.loc}/bin/${exe.java} should exist.
 			<condition>

--- a/test/stubs/test/lombok/other/Other.java
+++ b/test/stubs/test/lombok/other/Other.java
@@ -1,0 +1,11 @@
+package test.lombok.other;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public class Other {
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface TA {
+  }
+}

--- a/test/transform/resource/after-delombok/NestedClassAndAnnotationNestedInImportedSibling.java
+++ b/test/transform/resource/after-delombok/NestedClassAndAnnotationNestedInImportedSibling.java
@@ -1,0 +1,35 @@
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import test.lombok.NestedClassAndAnnotationNestedInImportedSibling.Other.OtherNested.TA;
+
+public class NestedClassAndAnnotationNestedInImportedSibling {
+
+	public static class Inner {
+
+		@TA
+		private final int someVal;
+
+		@java.lang.SuppressWarnings("all")
+		public Inner(@TA final int someVal) {
+			this.someVal = someVal;
+		}
+
+		@TA
+		@java.lang.SuppressWarnings("all")
+		public int getSomeVal() {
+			return this.someVal;
+		}
+	}
+
+	public static class Other {
+
+		public static class OtherNested {
+
+			@Retention(RetentionPolicy.RUNTIME)
+			public @interface TA {
+			}
+		}
+	}
+}

--- a/test/transform/resource/after-delombok/NestedClassAndAnnotationNestedInNonImportedSibling.java
+++ b/test/transform/resource/after-delombok/NestedClassAndAnnotationNestedInNonImportedSibling.java
@@ -1,0 +1,32 @@
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public class NestedClassAndAnnotationNestedInNonImportedSibling {
+
+	public static class Inner {
+		@Other.OtherNested.TA
+		private final int someVal;
+
+		@java.lang.SuppressWarnings("all")
+		public Inner(@Other.OtherNested.TA final int someVal) {
+			this.someVal = someVal;
+		}
+
+		@Other.OtherNested.TA
+		@java.lang.SuppressWarnings("all")
+		public int getSomeVal() {
+			return this.someVal;
+		}
+	}
+
+	public static class Other {
+
+		public static class OtherNested {
+			@Retention(RetentionPolicy.RUNTIME)
+			public @interface TA {
+			}
+		}
+	}
+}

--- a/test/transform/resource/after-delombok/NestedClassAndNestedAnnotation.java
+++ b/test/transform/resource/after-delombok/NestedClassAndNestedAnnotation.java
@@ -1,0 +1,27 @@
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public class NestedClassAndNestedAnnotation {
+
+	public static class Inner {
+		@TA
+		private final int someVal;
+
+		@java.lang.SuppressWarnings("all")
+		public Inner(@TA final int someVal) {
+			this.someVal = someVal;
+		}
+
+		@TA
+		@java.lang.SuppressWarnings("all")
+		public int getSomeVal() {
+			return this.someVal;
+		}
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface TA {
+	}
+}

--- a/test/transform/resource/after-delombok/NestedClassAndNestedAnnotationImported.java
+++ b/test/transform/resource/after-delombok/NestedClassAndNestedAnnotationImported.java
@@ -1,0 +1,33 @@
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import test.lombok.NestedClassAndNestedAnnotationImported.Other.OtherNested.TA;
+
+public class NestedClassAndNestedAnnotationImported {
+
+	public static class Inner {
+		@TA
+		private final int someVal;
+
+		@java.lang.SuppressWarnings("all")
+		public Inner(@TA final int someVal) {
+			this.someVal = someVal;
+		}
+
+		@TA
+		@java.lang.SuppressWarnings("all")
+		public int getSomeVal() {
+			return this.someVal;
+		}
+	}
+
+	public static class Other {
+
+		public static class OtherNested {
+			@Retention(RetentionPolicy.RUNTIME)
+			public @interface TA {
+			}
+		}
+	}
+}

--- a/test/transform/resource/after-delombok/NestedClassAndNestedAnnotationWithConflictingNestedImport.java
+++ b/test/transform/resource/after-delombok/NestedClassAndNestedAnnotationWithConflictingNestedImport.java
@@ -1,0 +1,31 @@
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import test.lombok.other.Other;
+
+public class NestedClassAndNestedAnnotationWithConflictingNestedImport {
+
+	public static class Inner {
+		@Other.TA
+		private final int someVal;
+
+		@java.lang.SuppressWarnings("all")
+		public Inner(@Other.TA final int someVal) {
+			this.someVal = someVal;
+		}
+
+		@Other.TA
+		@java.lang.SuppressWarnings("all")
+		public int getSomeVal() {
+			return this.someVal;
+		}
+	}
+
+	public static class Other {
+
+		@Retention(RetentionPolicy.RUNTIME)
+		public @interface TA {
+		}
+	}
+}

--- a/test/transform/resource/after-delombok/NestedClassAndNestedAnnotationWithOverridingNestedAnnotationImport.java
+++ b/test/transform/resource/after-delombok/NestedClassAndNestedAnnotationWithOverridingNestedAnnotationImport.java
@@ -1,0 +1,31 @@
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import test.lombok.other.Other.TA;
+
+public class NestedClassAndNestedAnnotationWithOverridingNestedAnnotationImport {
+
+	public static class Inner {
+		@TA
+		private final int someVal;
+
+		@java.lang.SuppressWarnings("all")
+		public Inner(@TA final int someVal) {
+			this.someVal = someVal;
+		}
+
+		@TA
+		@java.lang.SuppressWarnings("all")
+		public int getSomeVal() {
+			return this.someVal;
+		}
+	}
+
+	public static class Other {
+
+		@Retention(RetentionPolicy.RUNTIME)
+		public @interface TA {
+		}
+	}
+}

--- a/test/transform/resource/after-delombok/SimpleNestedAnnotation.java
+++ b/test/transform/resource/after-delombok/SimpleNestedAnnotation.java
@@ -1,0 +1,25 @@
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public class SimpleNestedAnnotation {
+
+	@TA
+	private final int someVal;
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface TA {
+	}
+
+	@java.lang.SuppressWarnings("all")
+	public SimpleNestedAnnotation(@TA final int someVal) {
+		this.someVal = someVal;
+	}
+
+	@TA
+	@java.lang.SuppressWarnings("all")
+	public int getSomeVal() {
+		return this.someVal;
+	}
+}

--- a/test/transform/resource/after-delombok/TwiceNestedClassAndSiblingAnnotation.java
+++ b/test/transform/resource/after-delombok/TwiceNestedClassAndSiblingAnnotation.java
@@ -1,0 +1,34 @@
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public class TwiceNestedClassAndSiblingAnnotation {
+
+	public static class Other {
+
+		public static class OtherInner {
+			@TA
+			private final int someVal;
+
+			@java.lang.SuppressWarnings("all")
+			public OtherInner(@TA final int someVal) {
+				this.someVal = someVal;
+			}
+
+			@TA
+			@java.lang.SuppressWarnings("all")
+			public int getSomeVal() {
+				return this.someVal;
+			}
+		}
+
+		@Retention(RetentionPolicy.RUNTIME)
+		public @interface TA {
+		}
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface TA {
+	}
+}

--- a/test/transform/resource/after-delombok/TwiceNestedClassAndUpperAnnotation.java
+++ b/test/transform/resource/after-delombok/TwiceNestedClassAndUpperAnnotation.java
@@ -1,0 +1,30 @@
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public class TwiceNestedClassAndUpperAnnotation {
+
+	public static class Other {
+
+		public static class OtherInner {
+			@TA
+			private final int someVal;
+
+			@java.lang.SuppressWarnings("all")
+			public OtherInner(@TA final int someVal) {
+				this.someVal = someVal;
+			}
+
+			@TA
+			@java.lang.SuppressWarnings("all")
+			public int getSomeVal() {
+				return this.someVal;
+			}
+		}
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface TA {
+	}
+}

--- a/test/transform/resource/after-ecj/NestedClassAndAnnotationNestedInImportedSibling.java
+++ b/test/transform/resource/after-ecj/NestedClassAndAnnotationNestedInImportedSibling.java
@@ -1,0 +1,34 @@
+package test.lombok;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import test.lombok.NestedClassAndAnnotationNestedInImportedSibling.Other.OtherNested.TA;
+public class NestedClassAndAnnotationNestedInImportedSibling {
+  public static @RequiredArgsConstructor @Getter class Inner {
+    private final @TA int someVal;
+
+    public @java.lang.SuppressWarnings("all") Inner(final @TA int someVal) {
+      super();
+      this.someVal = someVal;
+    }
+    public @TA @java.lang.SuppressWarnings("all") int getSomeVal() {
+      return this.someVal;
+    }
+  }
+  public static class Other {
+    public static class OtherNested {
+      public @Retention(RetentionPolicy.RUNTIME) @interface TA {
+      }
+      public OtherNested() {
+        super();
+      }
+    }
+    public Other() {
+      super();
+    }
+  }
+  public NestedClassAndAnnotationNestedInImportedSibling() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/NestedClassAndAnnotationNestedInNonImportedSibling.java
+++ b/test/transform/resource/after-ecj/NestedClassAndAnnotationNestedInNonImportedSibling.java
@@ -1,0 +1,32 @@
+package test.lombok;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+public class NestedClassAndAnnotationNestedInNonImportedSibling {
+  public static @RequiredArgsConstructor @Getter class Inner {
+    private final @Other.OtherNested.TA int someVal;
+    public @java.lang.SuppressWarnings("all") Inner(final @Other.OtherNested.TA int someVal) {
+      super();
+      this.someVal = someVal;
+    }
+    public @Other.OtherNested.TA @java.lang.SuppressWarnings("all") int getSomeVal() {
+      return this.someVal;
+    }
+  }
+  public static class Other {
+    public static class OtherNested {
+      public @Retention(RetentionPolicy.RUNTIME) @interface TA {
+      }
+      public OtherNested() {
+        super();
+      }
+    }
+    public Other() {
+      super();
+    }
+  }
+  public NestedClassAndAnnotationNestedInNonImportedSibling() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/NestedClassAndNestedAnnotation.java
+++ b/test/transform/resource/after-ecj/NestedClassAndNestedAnnotation.java
@@ -1,0 +1,22 @@
+package test.lombok;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+public class NestedClassAndNestedAnnotation {
+  public static @RequiredArgsConstructor @Getter class Inner {
+    private final @TA int someVal;
+    public @java.lang.SuppressWarnings("all") Inner(final @TA int someVal) {
+      super();
+      this.someVal = someVal;
+    }
+    public @TA @java.lang.SuppressWarnings("all") int getSomeVal() {
+      return this.someVal;
+    }
+  }
+  public @Retention(RetentionPolicy.RUNTIME) @interface TA {
+  }
+  public NestedClassAndNestedAnnotation() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/NestedClassAndNestedAnnotationImported.java
+++ b/test/transform/resource/after-ecj/NestedClassAndNestedAnnotationImported.java
@@ -1,0 +1,33 @@
+package test.lombok;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import test.lombok.NestedClassAndNestedAnnotationImported.Other.OtherNested.TA;
+public class NestedClassAndNestedAnnotationImported {
+  public static @RequiredArgsConstructor @Getter class Inner {
+    private final @TA int someVal;
+    public @java.lang.SuppressWarnings("all") Inner(final @TA int someVal) {
+      super();
+      this.someVal = someVal;
+    }
+    public @TA @java.lang.SuppressWarnings("all") int getSomeVal() {
+      return this.someVal;
+    }
+  }
+  public static class Other {
+    public static class OtherNested {
+      public @Retention(RetentionPolicy.RUNTIME) @interface TA {
+      }
+      public OtherNested() {
+        super();
+      }
+    }
+    public Other() {
+      super();
+    }
+  }
+  public NestedClassAndNestedAnnotationImported() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/NestedClassAndNestedAnnotationWithConflictingNestedImport.java
+++ b/test/transform/resource/after-ecj/NestedClassAndNestedAnnotationWithConflictingNestedImport.java
@@ -1,0 +1,28 @@
+package test.lombok;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import test.lombok.other.Other;
+public class NestedClassAndNestedAnnotationWithConflictingNestedImport {
+  public static @RequiredArgsConstructor @Getter class Inner {
+    private final @Other.TA int someVal;
+    public @java.lang.SuppressWarnings("all") Inner(final @Other.TA int someVal) {
+      super();
+      this.someVal = someVal;
+    }
+    public @Other.TA @java.lang.SuppressWarnings("all") int getSomeVal() {
+      return this.someVal;
+    }
+  }
+  public static class Other {
+    public @Retention(RetentionPolicy.RUNTIME) @interface TA {
+    }
+    public Other() {
+      super();
+    }
+  }
+  public NestedClassAndNestedAnnotationWithConflictingNestedImport() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/NestedClassAndNestedAnnotationWithOverridingNestedAnnotationImport.java
+++ b/test/transform/resource/after-ecj/NestedClassAndNestedAnnotationWithOverridingNestedAnnotationImport.java
@@ -1,0 +1,28 @@
+package test.lombok;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import test.lombok.other.Other.TA;
+public class NestedClassAndNestedAnnotationWithOverridingNestedAnnotationImport {
+  public static @RequiredArgsConstructor @Getter class Inner {
+    private final @TA int someVal;
+    public @java.lang.SuppressWarnings("all") Inner(final @TA int someVal) {
+      super();
+      this.someVal = someVal;
+    }
+    public @TA @java.lang.SuppressWarnings("all") int getSomeVal() {
+      return this.someVal;
+    }
+  }
+  public static class Other {
+    public @Retention(RetentionPolicy.RUNTIME) @interface TA {
+    }
+    public Other() {
+      super();
+    }
+  }
+  public NestedClassAndNestedAnnotationWithOverridingNestedAnnotationImport() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/SimpleNestedAnnotation.java
+++ b/test/transform/resource/after-ecj/SimpleNestedAnnotation.java
@@ -1,0 +1,17 @@
+package test.lombok;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+public @RequiredArgsConstructor @Getter class SimpleNestedAnnotation {
+  public @Retention(RetentionPolicy.RUNTIME) @interface TA {
+  }
+  private final @TA int someVal;
+  public @java.lang.SuppressWarnings("all") SimpleNestedAnnotation(final @TA int someVal) {
+    super();
+    this.someVal = someVal;
+  }
+  public @TA @java.lang.SuppressWarnings("all") int getSomeVal() {
+    return this.someVal;
+  }
+}

--- a/test/transform/resource/after-ecj/TwiceNestedClassAndSiblingAnnotation.java
+++ b/test/transform/resource/after-ecj/TwiceNestedClassAndSiblingAnnotation.java
@@ -1,0 +1,29 @@
+package test.lombok;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+public class TwiceNestedClassAndSiblingAnnotation {
+  public static class Other {
+    public static @RequiredArgsConstructor @Getter class OtherInner {
+      private final @TA int someVal;
+      public @java.lang.SuppressWarnings("all") OtherInner(final @TA int someVal) {
+        super();
+        this.someVal = someVal;
+      }
+      public @TA @java.lang.SuppressWarnings("all") int getSomeVal() {
+        return this.someVal;
+      }
+    }
+    public @Retention(RetentionPolicy.RUNTIME) @interface TA {
+    }
+    public Other() {
+      super();
+    }
+  }
+  public @Retention(RetentionPolicy.RUNTIME) @interface TA {
+  }
+  public TwiceNestedClassAndSiblingAnnotation() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/TwiceNestedClassAndUpperAnnotation.java
+++ b/test/transform/resource/after-ecj/TwiceNestedClassAndUpperAnnotation.java
@@ -1,0 +1,27 @@
+package test.lombok;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+public class TwiceNestedClassAndUpperAnnotation {
+  public static class Other {
+    public static @RequiredArgsConstructor @Getter class OtherInner {
+      private final @TA int someVal;
+      public @java.lang.SuppressWarnings("all") OtherInner(final @TA int someVal) {
+        super();
+        this.someVal = someVal;
+      }
+      public @TA @java.lang.SuppressWarnings("all") int getSomeVal() {
+        return this.someVal;
+      }
+    }
+    public Other() {
+      super();
+    }
+  }
+  public @Retention(RetentionPolicy.RUNTIME) @interface TA {
+  }
+  public TwiceNestedClassAndUpperAnnotation() {
+    super();
+  }
+}

--- a/test/transform/resource/before/NestedClassAndAnnotationNestedInImportedSibling.java
+++ b/test/transform/resource/before/NestedClassAndAnnotationNestedInImportedSibling.java
@@ -1,0 +1,26 @@
+//CONF: lombok.copyableAnnotations += test.lombok.NestedClassAndAnnotationNestedInImportedSibling$Other$OtherNested$TA
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import test.lombok.NestedClassAndAnnotationNestedInImportedSibling.Other.OtherNested.TA;
+
+public class NestedClassAndAnnotationNestedInImportedSibling {
+
+	@RequiredArgsConstructor
+	@Getter
+	public static class Inner {
+		@TA
+		private final int someVal;
+	}
+
+	public static class Other {
+
+		public static class OtherNested {
+			@Retention(RetentionPolicy.RUNTIME)
+			public @interface TA {}
+		}
+	}
+}

--- a/test/transform/resource/before/NestedClassAndAnnotationNestedInNonImportedSibling.java
+++ b/test/transform/resource/before/NestedClassAndAnnotationNestedInNonImportedSibling.java
@@ -1,0 +1,25 @@
+//CONF: lombok.copyableAnnotations += test.lombok.NestedClassAndAnnotationNestedInNonImportedSibling$Other$OtherNested$TA
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public class NestedClassAndAnnotationNestedInNonImportedSibling {
+
+	@RequiredArgsConstructor
+	@Getter
+	public static class Inner {
+		@Other.OtherNested.TA
+		private final int someVal;
+	}
+
+	public static class Other {
+
+		public static class OtherNested {
+			@Retention(RetentionPolicy.RUNTIME)
+			public @interface TA {}
+		}
+	}
+}

--- a/test/transform/resource/before/NestedClassAndNestedAnnotation.java
+++ b/test/transform/resource/before/NestedClassAndNestedAnnotation.java
@@ -1,0 +1,20 @@
+//CONF: lombok.copyableAnnotations += test.lombok.NestedClassAndNestedAnnotation$TA
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public class NestedClassAndNestedAnnotation {
+
+	@RequiredArgsConstructor
+	@Getter
+	public static class Inner {
+		@TA
+		private final int someVal;
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface TA {}
+}

--- a/test/transform/resource/before/NestedClassAndNestedAnnotationImported.java
+++ b/test/transform/resource/before/NestedClassAndNestedAnnotationImported.java
@@ -1,0 +1,26 @@
+//CONF: lombok.copyableAnnotations += test.lombok.NestedClassAndNestedAnnotationImported$Other$OtherNested$TA
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import test.lombok.NestedClassAndNestedAnnotationImported.Other.OtherNested.TA;
+
+public class NestedClassAndNestedAnnotationImported {
+
+	@RequiredArgsConstructor
+	@Getter
+	public static class Inner {
+		@TA
+		private final int someVal;
+	}
+
+	public static class Other {
+
+		public static class OtherNested {
+			@Retention(RetentionPolicy.RUNTIME)
+			public @interface TA {}
+		}
+	}
+}

--- a/test/transform/resource/before/NestedClassAndNestedAnnotationWithConflictingNestedImport.java
+++ b/test/transform/resource/before/NestedClassAndNestedAnnotationWithConflictingNestedImport.java
@@ -1,0 +1,23 @@
+//CONF: lombok.copyableAnnotations += test.lombok.NestedClassAndNestedAnnotationWithConflictingNestedImport$Other$TA
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import test.lombok.other.Other;
+
+public class NestedClassAndNestedAnnotationWithConflictingNestedImport {
+
+	@RequiredArgsConstructor
+	@Getter
+	public static class Inner {
+		@Other.TA private final int someVal;
+	}
+
+	public static class Other {
+
+		@Retention(RetentionPolicy.RUNTIME)
+		public @interface TA {}
+	}
+}

--- a/test/transform/resource/before/NestedClassAndNestedAnnotationWithOverridingNestedAnnotationImport.java
+++ b/test/transform/resource/before/NestedClassAndNestedAnnotationWithOverridingNestedAnnotationImport.java
@@ -1,0 +1,23 @@
+//CONF: lombok.copyableAnnotations += test.lombok.other.Other$TA
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import test.lombok.other.Other.TA;
+
+public class NestedClassAndNestedAnnotationWithOverridingNestedAnnotationImport {
+
+	@RequiredArgsConstructor
+	@Getter
+	public static class Inner {
+		@TA private final int someVal;
+	}
+
+	public static class Other {
+
+		@Retention(RetentionPolicy.RUNTIME)
+		public @interface TA {}
+	}
+}

--- a/test/transform/resource/before/SimpleNestedAnnotation.java
+++ b/test/transform/resource/before/SimpleNestedAnnotation.java
@@ -1,0 +1,17 @@
+//CONF: lombok.copyableAnnotations += test.lombok.SimpleNestedAnnotation$TA
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class SimpleNestedAnnotation {
+
+	@TA private final int someVal;
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface TA {}
+}

--- a/test/transform/resource/before/TwiceNestedClassAndSiblingAnnotation.java
+++ b/test/transform/resource/before/TwiceNestedClassAndSiblingAnnotation.java
@@ -1,0 +1,26 @@
+//CONF: lombok.copyableAnnotations += test.lombok.TwiceNestedClassAndSiblingAnnotation.Other$TA
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public class TwiceNestedClassAndSiblingAnnotation {
+
+	public static class Other {
+
+		@RequiredArgsConstructor
+		@Getter
+		public static class OtherInner {
+			@TA
+			private final int someVal;
+		}
+
+		@Retention(RetentionPolicy.RUNTIME)
+		public @interface TA {}
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface TA {}
+}

--- a/test/transform/resource/before/TwiceNestedClassAndUpperAnnotation.java
+++ b/test/transform/resource/before/TwiceNestedClassAndUpperAnnotation.java
@@ -1,0 +1,23 @@
+//CONF: lombok.copyableAnnotations += test.lombok.TwiceNestedClassAndUpperAnnotation$TA
+package test.lombok;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public class TwiceNestedClassAndUpperAnnotation {
+
+	public static class Other {
+
+		@RequiredArgsConstructor
+		@Getter
+		public static class OtherInner {
+			@TA
+			private final int someVal;
+		}
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface TA {}
+}


### PR DESCRIPTION
Fix type detection of annotations that are nested within the same (or other) classes. I came across this bug when trying to copy an annotation from a field to a constructor, where that annotation was an inner class of the field that the annotated class belonged to, eg:

```java
@RequiredArgsConstructor
@Getter
public class SimpleNestedAnnotation {

	@TA private final int someVal;

	@Retention(RetentionPolicy.RUNTIME)
	public @interface TA {}
}
```

Lombok fails to find the annotation and so doesn't copy it to the constructor. There is a test project that reproduces this error too: https://github.com/facboy/lombok-bug