### PR TITLE
Update Javadoc for @Data

### DIFF
--- a/src/core/lombok/Data.java
+++ b/src/core/lombok/Data.java
@@ -28,7 +28,8 @@ import java.lang.annotation.Target;
 
 /**
  * Generates getters for all fields, a useful toString method, and hashCode and equals implementations that check
- * all non-transient fields. Will also generate setters for all non-final fields, as well as a constructor.
+ * all non-transient fields. Will also generate setters for all non-final fields, as well as a constructor
+ * (except that no constructor will be generated if any explicitly written constructors already exist).
  * <p>
  * Equivalent to {@code @Getter @Setter @RequiredArgsConstructor @ToString @EqualsAndHashCode}.
  * <p>


### PR DESCRIPTION
The javadoc on Data.java says it generates a constructor, which is the equivalent of `@RequiredArgsConstructor` behavior. In reality though, the constructor is only generated if no explicitly defined constructors (including explicit Lombok constructors) already exist. The behavior is expected and documented [here](https://projectlombok.org/features/Data).

The javadoc alone, however, often causes confusions, since there is no clear explanation on why the constructor in `@Data` may or may not be generated, which leads to a need of additional digging in Lombok documentation.