### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /jvm.locations
 /testenv
 /gpg.keyring
+.DS_Store


### PR DESCRIPTION
I believe we should update .gitignore file to prevent committing macOS folder meta-data.