### PR TITLE
Mark injected fields as generated

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleLockedUtil.java
+++ b/src/core/lombok/eclipse/handlers/HandleLockedUtil.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (C) 2024 The Project Lombok Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 /* Copyright (C) 2021-2023 The Project Lombok Authors.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -117,7 +138,7 @@ public final class HandleLockedUtil {
 			lockAlloc.type = setGeneratedBy(new QualifiedTypeReference(lockImplClass, new long[] { 0, 0, 0, 0, 0 }), source);
 			fieldDecl.type = setGeneratedBy(new QualifiedTypeReference(lockTypeClass, new long[] { 0, 0, 0, 0, 0 }), source);
 			fieldDecl.initialization = lockAlloc;
-			injectField(annotationNode.up().up(), fieldDecl);
+			injectFieldAndMarkGenerated(annotationNode.up().up(), fieldDecl);
 		}
 		
 		return lockName;

--- a/src/core/lombok/eclipse/handlers/HandleLog.java
+++ b/src/core/lombok/eclipse/handlers/HandleLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2021 The Project Lombok Authors.
+ * Copyright (C) 2010-2024 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -109,9 +109,7 @@ public class HandleLog {
 			ClassLiteralAccess loggingType = selfType(owner, source);
 			FieldDeclaration fieldDeclaration = createField(framework, source, loggingType, logFieldName.getName(), useStatic, loggerTopic);
 			fieldDeclaration.traverse(new SetGeneratedByVisitor(source), typeDecl.staticInitializerScope);
-			// TODO temporary workaround for issue 290. https://github.com/projectlombok/lombok/issues/290
-			// injectFieldSuppressWarnings(owner, fieldDeclaration);
-			injectField(owner, fieldDeclaration);
+			injectFieldAndMarkGenerated(owner, fieldDeclaration);
 			owner.rebuild();
 			break;
 		default:

--- a/src/core/lombok/eclipse/handlers/HandleSynchronized.java
+++ b/src/core/lombok/eclipse/handlers/HandleSynchronized.java
@@ -129,9 +129,7 @@ public class HandleSynchronized extends EclipseAnnotationHandler<Synchronized> {
 			fieldDecl.type = new QualifiedTypeReference(TypeConstants.JAVA_LANG_OBJECT, new long[] { 0, 0, 0 });
 			setGeneratedBy(fieldDecl.type, source);
 			fieldDecl.initialization = arrayAlloc;
-			// TODO temporary workaround for issue 290. https://github.com/projectlombok/lombok/issues/290
-			// injectFieldSuppressWarnings(annotationNode.up().up(), fieldDecl);
-			injectField(annotationNode.up().up(), fieldDecl);
+			injectFieldAndMarkGenerated(annotationNode.up().up(), fieldDecl);
 		}
 		
 		return lockName;

--- a/test/transform/resource/after-ecj/InjectField.java
+++ b/test/transform/resource/after-ecj/InjectField.java
@@ -4,9 +4,9 @@ import lombok.Synchronized;
 @Log enum InjectField1 {
   A(),
   B(),
-  private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(InjectField1.class.getName());
-  private final java.lang.Object $lock = new java.lang.Object[0];
-  private static final java.lang.Object $LOCK = new java.lang.Object[0];
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(InjectField1.class.getName());
+  private final @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.Object $lock = new java.lang.Object[0];
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.Object $LOCK = new java.lang.Object[0];
   private static final String LOG_MESSAGE = "static initializer";
   private String fieldA;
   static {
@@ -32,8 +32,8 @@ import lombok.Synchronized;
   }
 }
 @Log class InjectField2 {
-  private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(InjectField2.class.getName());
-  private final java.lang.Object $lock = new java.lang.Object[0];
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(InjectField2.class.getName());
+  private final @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.Object $lock = new java.lang.Object[0];
   private static final String LOG_MESSAGE = "static initializer";
   static {
     log.log(Level.FINE, LOG_MESSAGE);
@@ -51,7 +51,7 @@ import lombok.Synchronized;
   }
 }
 @Log class InjectField3 {
-  private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(InjectField3.class.getName());
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(InjectField3.class.getName());
   static {
     log.log(Level.FINE, "static initializer");
   }

--- a/test/transform/resource/after-ecj/LockedInInitializer.java
+++ b/test/transform/resource/after-ecj/LockedInInitializer.java
@@ -1,7 +1,7 @@
 import lombok.Locked;
 public class LockedInInitializer {
   public static final Runnable LOCKED = new Runnable() {
-    private final java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
+    private final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
     public @Override @Locked void run() {
       this.$lock.lock();
       try
@@ -15,7 +15,7 @@ public class LockedInInitializer {
     }
   };
   public static final Runnable LOCKED_READ = new Runnable() {
-    private final java.util.concurrent.locks.ReadWriteLock $lock = new java.util.concurrent.locks.ReentrantReadWriteLock();
+    private final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.concurrent.locks.ReadWriteLock $lock = new java.util.concurrent.locks.ReentrantReadWriteLock();
     public @Override @Locked.Read void run() {
       this.$lock.readLock().lock();
       try
@@ -29,7 +29,7 @@ public class LockedInInitializer {
     }
   };
   public static final Runnable LOCKED_WRITE = new Runnable() {
-    private final java.util.concurrent.locks.ReadWriteLock $lock = new java.util.concurrent.locks.ReentrantReadWriteLock();
+    private final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.concurrent.locks.ReadWriteLock $lock = new java.util.concurrent.locks.ReentrantReadWriteLock();
     public @Override @Locked.Write void run() {
       this.$lock.writeLock().lock();
       try

--- a/test/transform/resource/after-ecj/LockedInRecord.java
+++ b/test/transform/resource/after-ecj/LockedInRecord.java
@@ -2,7 +2,7 @@ import lombok.Locked;
 public record LockedInRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  private final java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
+  private final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
   public @Locked void foo() {
     String foo = "bar";
   }

--- a/test/transform/resource/after-ecj/LockedPlain.java
+++ b/test/transform/resource/after-ecj/LockedPlain.java
@@ -1,6 +1,6 @@
 import lombok.Locked;
 class LockedPlain {
-  private final java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
+  private final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
   LockedPlain() {
     super();
   }
@@ -28,7 +28,7 @@ class LockedPlain {
   }
 }
 class LockedPlainStatic {
-  private static final java.util.concurrent.locks.Lock $LOCK = new java.util.concurrent.locks.ReentrantLock();
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.concurrent.locks.Lock $LOCK = new java.util.concurrent.locks.ReentrantLock();
   <clinit>() {
   }
   LockedPlainStatic() {
@@ -58,7 +58,7 @@ class LockedPlainStatic {
   }
 }
 class LockedPlainRead {
-  private static final java.util.concurrent.locks.ReadWriteLock $LOCK = new java.util.concurrent.locks.ReentrantReadWriteLock();
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.concurrent.locks.ReadWriteLock $LOCK = new java.util.concurrent.locks.ReentrantReadWriteLock();
   <clinit>() {
   }
   LockedPlainRead() {
@@ -88,7 +88,7 @@ class LockedPlainRead {
   }
 }
 class LockedPlainWrite {
-  private final java.util.concurrent.locks.ReadWriteLock $lock = new java.util.concurrent.locks.ReentrantReadWriteLock();
+  private final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.concurrent.locks.ReadWriteLock $lock = new java.util.concurrent.locks.ReentrantReadWriteLock();
   LockedPlainWrite() {
     super();
   }

--- a/test/transform/resource/after-ecj/LockedStaticMix.java
+++ b/test/transform/resource/after-ecj/LockedStaticMix.java
@@ -1,5 +1,5 @@
 class LockedGeneratedStaticMismatch {
-  private static final java.util.concurrent.locks.Lock $LOCK = new java.util.concurrent.locks.ReentrantLock();
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.concurrent.locks.Lock $LOCK = new java.util.concurrent.locks.ReentrantLock();
   <clinit>() {
   }
   LockedGeneratedStaticMismatch() {

--- a/test/transform/resource/after-ecj/LockedTypeMismatch.java
+++ b/test/transform/resource/after-ecj/LockedTypeMismatch.java
@@ -1,5 +1,5 @@
 class LockedGeneratedTypeMismatch {
-  private final java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
+  private final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
   LockedGeneratedTypeMismatch() {
     super();
   }

--- a/test/transform/resource/after-ecj/LoggerCommons.java
+++ b/test/transform/resource/after-ecj/LoggerCommons.java
@@ -1,6 +1,6 @@
 import lombok.extern.apachecommons.CommonsLog;
 @lombok.extern.apachecommons.CommonsLog class LoggerCommons {
-  private static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommons.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommons.class);
   <clinit>() {
   }
   LoggerCommons() {
@@ -8,7 +8,7 @@ import lombok.extern.apachecommons.CommonsLog;
   }
 }
 @CommonsLog class LoggerCommonsWithImport {
-  private static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsWithImport.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsWithImport.class);
   <clinit>() {
   }
   LoggerCommonsWithImport() {
@@ -16,7 +16,7 @@ import lombok.extern.apachecommons.CommonsLog;
   }
 }
 @CommonsLog(topic = "DifferentName") class LoggerCommonsWithDifferentName {
-  private static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog("DifferentName");
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog("DifferentName");
   <clinit>() {
   }
   LoggerCommonsWithDifferentName() {
@@ -24,7 +24,7 @@ import lombok.extern.apachecommons.CommonsLog;
   }
 }
 @CommonsLog(topic = LoggerCommonsWithStaticField.TOPIC) class LoggerCommonsWithStaticField {
-  private static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsWithStaticField.TOPIC);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsWithStaticField.TOPIC);
   static final String TOPIC = "StaticField";
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerConfig.java
+++ b/test/transform/resource/after-ecj/LoggerConfig.java
@@ -1,5 +1,5 @@
 @lombok.extern.slf4j.Slf4j class LoggerWithConfig {
-  private final org.slf4j.Logger myLogger = org.slf4j.LoggerFactory.getLogger(LoggerWithConfig.class);
+  private final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger myLogger = org.slf4j.LoggerFactory.getLogger(LoggerWithConfig.class);
   LoggerWithConfig() {
     super();
   }

--- a/test/transform/resource/after-ecj/LoggerCustom.java
+++ b/test/transform/resource/after-ecj/LoggerCustom.java
@@ -1,5 +1,5 @@
 @lombok.CustomLog class LoggerCustomLog {
-  private static final MyLogger log = MyLoggerFactory.create(LoggerCustomLog.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomLog.class);
   <clinit>() {
   }
   LoggerCustomLog() {

--- a/test/transform/resource/after-ecj/LoggerCustomWithPackage.java
+++ b/test/transform/resource/after-ecj/LoggerCustomWithPackage.java
@@ -1,6 +1,6 @@
 package before;
 @lombok.CustomLog class LoggerCustomLog {
-  private static final before.MyLogger log = before.MyLoggerFactory.create(LoggerCustomLog.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated before.MyLogger log = before.MyLoggerFactory.create(LoggerCustomLog.class);
   <clinit>() {
   }
   LoggerCustomLog() {

--- a/test/transform/resource/after-ecj/LoggerCustomWithTopicAndName.java
+++ b/test/transform/resource/after-ecj/LoggerCustomWithTopicAndName.java
@@ -1,5 +1,5 @@
 @lombok.CustomLog(topic = "t") class LoggerCustomLog {
-  private static final MyLoggerFactory log = MyLoggerFactory.create(LoggerCustomLog.class.getName(), "t", null, LoggerCustomLog.class, "t");
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLoggerFactory log = MyLoggerFactory.create(LoggerCustomLog.class.getName(), "t", null, LoggerCustomLog.class, "t");
   <clinit>() {
   }
   LoggerCustomLog() {
@@ -7,7 +7,7 @@
   }
 }
 @lombok.CustomLog(topic = LoggerCustomLogWithStaticField.TOPIC) class LoggerCustomLogWithStaticField {
-  private static final MyLoggerFactory log = MyLoggerFactory.create(LoggerCustomLogWithStaticField.class.getName(), LoggerCustomLogWithStaticField.TOPIC, null, LoggerCustomLogWithStaticField.class, LoggerCustomLogWithStaticField.TOPIC);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLoggerFactory log = MyLoggerFactory.create(LoggerCustomLogWithStaticField.class.getName(), LoggerCustomLogWithStaticField.TOPIC, null, LoggerCustomLogWithStaticField.class, LoggerCustomLogWithStaticField.TOPIC);
   static final String TOPIC = "StaticField";
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerFlogger.java
+++ b/test/transform/resource/after-ecj/LoggerFlogger.java
@@ -1,6 +1,6 @@
 import lombok.extern.flogger.Flogger;
 @lombok.extern.flogger.Flogger class LoggerFlogger {
-  private static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
   <clinit>() {
   }
   LoggerFlogger() {
@@ -8,7 +8,7 @@ import lombok.extern.flogger.Flogger;
   }
 }
 @Flogger class LoggerFloggerWithImport {
-  private static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
   <clinit>() {
   }
   LoggerFloggerWithImport() {
@@ -17,7 +17,7 @@ import lombok.extern.flogger.Flogger;
 }
 class LoggerFloggerOuter {
   static @lombok.extern.flogger.Flogger class Inner {
-    private static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
     <clinit>() {
     }
     Inner() {
@@ -30,7 +30,7 @@ class LoggerFloggerOuter {
 }
 @Flogger enum LoggerFloggerWithEnum {
   CONSTANT(),
-  private static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
   <clinit>() {
   }
   LoggerFloggerWithEnum() {
@@ -40,7 +40,7 @@ class LoggerFloggerOuter {
 class LoggerFloggerWithInnerEnum {
   @Flogger enum Inner {
     CONSTANT(),
-    private static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
     <clinit>() {
     }
     Inner() {

--- a/test/transform/resource/after-ecj/LoggerFloggerRecord.java
+++ b/test/transform/resource/after-ecj/LoggerFloggerRecord.java
@@ -1,9 +1,8 @@
-// version 19:
 import lombok.extern.flogger.Flogger;
 class LoggerFloggerRecord {
   public @Flogger record Inner(String x) {
 /* Implicit */    private final String x;
-    private static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
     <clinit>() {
     }
   }

--- a/test/transform/resource/after-ecj/LoggerJBossLog.java
+++ b/test/transform/resource/after-ecj/LoggerJBossLog.java
@@ -1,6 +1,6 @@
 import lombok.extern.jbosslog.JBossLog;
 @lombok.extern.jbosslog.JBossLog class LoggerJBossLog {
-  private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLog.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLog.class);
   <clinit>() {
   }
   LoggerJBossLog() {
@@ -8,7 +8,7 @@ import lombok.extern.jbosslog.JBossLog;
   }
 }
 @JBossLog class LoggerJBossLogWithImport {
-  private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogWithImport.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogWithImport.class);
   <clinit>() {
   }
   LoggerJBossLogWithImport() {
@@ -17,7 +17,7 @@ import lombok.extern.jbosslog.JBossLog;
 }
 class LoggerJBossLogOuter {
   static @lombok.extern.jbosslog.JBossLog class Inner {
-    private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(Inner.class);
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(Inner.class);
     <clinit>() {
     }
     Inner() {
@@ -30,7 +30,7 @@ class LoggerJBossLogOuter {
 }
 @JBossLog enum LoggerJBossLogWithEnum {
   CONSTANT(),
-  private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogWithEnum.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogWithEnum.class);
   <clinit>() {
   }
   LoggerJBossLogWithEnum() {
@@ -40,7 +40,7 @@ class LoggerJBossLogOuter {
 class LoggerJBossLogWithInnerEnum {
   @JBossLog enum Inner {
     CONSTANT(),
-    private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(Inner.class);
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(Inner.class);
     <clinit>() {
     }
     Inner() {
@@ -52,7 +52,7 @@ class LoggerJBossLogWithInnerEnum {
   }
 }
 @JBossLog(topic = "DifferentLogger") class LoggerJBossLogWithDifferentLoggerName {
-  private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger("DifferentLogger");
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger("DifferentLogger");
   <clinit>() {
   }
   LoggerJBossLogWithDifferentLoggerName() {
@@ -60,7 +60,7 @@ class LoggerJBossLogWithInnerEnum {
   }
 }
 @JBossLog(topic = LoggerJBossLogWithStaticField.TOPIC) class LoggerJBossLogWithStaticField {
-  private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogWithStaticField.TOPIC);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogWithStaticField.TOPIC);
   static final String TOPIC = "StaticField";
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerJul.java
+++ b/test/transform/resource/after-ecj/LoggerJul.java
@@ -1,6 +1,6 @@
 import lombok.extern.java.Log;
 @lombok.extern.java.Log class LoggerJul {
-  private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJul.class.getName());
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJul.class.getName());
   <clinit>() {
   }
   LoggerJul() {
@@ -8,7 +8,7 @@ import lombok.extern.java.Log;
   }
 }
 @Log class LoggerJulWithImport {
-  private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulWithImport.class.getName());
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulWithImport.class.getName());
   <clinit>() {
   }
   LoggerJulWithImport() {
@@ -16,7 +16,7 @@ import lombok.extern.java.Log;
   }
 }
 @Log(topic = "DifferentName") class LoggerJulWithDifferentName {
-  private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger("DifferentName");
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger("DifferentName");
   <clinit>() {
   }
   LoggerJulWithDifferentName() {
@@ -24,7 +24,7 @@ import lombok.extern.java.Log;
   }
 }
 @Log(topic = LoggerJulWithStaticField.TOPIC) class LoggerJulWithStaticField {
-  private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulWithStaticField.TOPIC);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulWithStaticField.TOPIC);
   static final String TOPIC = "StaticField";
   <clinit>() {
   }
@@ -34,7 +34,7 @@ import lombok.extern.java.Log;
 }
 @Log enum LoggerJulWithEnum {
   CONSTANT(),
-  private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulWithEnum.class.getName());
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulWithEnum.class.getName());
   <clinit>() {
   }
   LoggerJulWithEnum() {
@@ -44,7 +44,7 @@ import lombok.extern.java.Log;
 class LoggerJulWithInnerEnum {
   @Log enum Inner {
     CONSTANT(),
-    private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(Inner.class.getName());
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(Inner.class.getName());
     <clinit>() {
     }
     Inner() {

--- a/test/transform/resource/after-ecj/LoggerLog4j.java
+++ b/test/transform/resource/after-ecj/LoggerLog4j.java
@@ -1,6 +1,6 @@
 import lombok.extern.log4j.Log4j;
 @lombok.extern.log4j.Log4j class LoggerLog4j {
-  private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4j.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4j.class);
   <clinit>() {
   }
   LoggerLog4j() {
@@ -8,7 +8,7 @@ import lombok.extern.log4j.Log4j;
   }
 }
 @Log4j class LoggerLog4jWithImport {
-  private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jWithImport.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jWithImport.class);
   <clinit>() {
   }
   LoggerLog4jWithImport() {
@@ -16,7 +16,7 @@ import lombok.extern.log4j.Log4j;
   }
 }
 @Log4j(topic = "DifferentName") class LoggerLog4jWithDifferentName {
-  private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger("DifferentName");
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger("DifferentName");
   <clinit>() {
   }
   LoggerLog4jWithDifferentName() {
@@ -24,7 +24,7 @@ import lombok.extern.log4j.Log4j;
   }
 }
 @Log4j(topic = LoggerLog4jWithStaticField.TOPIC) class LoggerLog4jWithStaticField {
-  private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jWithStaticField.TOPIC);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jWithStaticField.TOPIC);
   static final String TOPIC = "StaticField";
   <clinit>() {
   }
@@ -34,7 +34,7 @@ import lombok.extern.log4j.Log4j;
 }
 @Log4j enum LoggerLog4jWithEnum {
   CONSTANT(),
-  private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jWithEnum.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jWithEnum.class);
   <clinit>() {
   }
   LoggerLog4jWithEnum() {
@@ -44,7 +44,7 @@ import lombok.extern.log4j.Log4j;
 class LoggerLog4jWithInnerEnum {
   @Log4j enum Inner {
     CONSTANT(),
-    private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(Inner.class);
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(Inner.class);
     <clinit>() {
     }
     Inner() {

--- a/test/transform/resource/after-ecj/LoggerLog4j2.java
+++ b/test/transform/resource/after-ecj/LoggerLog4j2.java
@@ -1,6 +1,6 @@
 import lombok.extern.log4j.Log4j2;
 @lombok.extern.log4j.Log4j2 class LoggerLog4j2 {
-  private static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2.class);
   <clinit>() {
   }
   LoggerLog4j2() {
@@ -8,7 +8,7 @@ import lombok.extern.log4j.Log4j2;
   }
 }
 @Log4j2 class LoggerLog4j2WithImport {
-  private static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2WithImport.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2WithImport.class);
   <clinit>() {
   }
   LoggerLog4j2WithImport() {
@@ -16,7 +16,7 @@ import lombok.extern.log4j.Log4j2;
   }
 }
 @Log4j2(topic = "DifferentName") class LoggerLog4j2WithDifferentName {
-  private static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger("DifferentName");
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger("DifferentName");
   <clinit>() {
   }
   LoggerLog4j2WithDifferentName() {
@@ -24,7 +24,7 @@ import lombok.extern.log4j.Log4j2;
   }
 }
 @Log4j2(topic = LoggerLog4j2WithStaticField.TOPIC) class LoggerLog4j2WithStaticField {
-  private static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2WithStaticField.TOPIC);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2WithStaticField.TOPIC);
   static final String TOPIC = "StaticField";
   <clinit>() {
   }
@@ -34,7 +34,7 @@ import lombok.extern.log4j.Log4j2;
 }
 @Log4j2 enum LoggerLog4j2WithEnum {
   CONSTANT(),
-  private static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2WithEnum.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2WithEnum.class);
   <clinit>() {
   }
   LoggerLog4j2WithEnum() {
@@ -44,7 +44,7 @@ import lombok.extern.log4j.Log4j2;
 class LoggerLog4j2WithInnerEnum {
   @Log4j2 enum Inner {
     CONSTANT(),
-    private static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(Inner.class);
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(Inner.class);
     <clinit>() {
     }
     Inner() {

--- a/test/transform/resource/after-ecj/LoggerSlf4j.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4j.java
@@ -1,6 +1,6 @@
 import lombok.extern.slf4j.Slf4j;
 @lombok.extern.slf4j.Slf4j class LoggerSlf4j {
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4j.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4j.class);
   <clinit>() {
   }
   LoggerSlf4j() {
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
   }
 }
 @Slf4j class LoggerSlf4jWithImport {
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jWithImport.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jWithImport.class);
   <clinit>() {
   }
   LoggerSlf4jWithImport() {
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 }
 @Slf4j enum LoggerSlf4jWithEnum {
   CONSTANT(),
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jWithEnum.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jWithEnum.class);
   <clinit>() {
   }
   LoggerSlf4jWithEnum() {
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 class LoggerSlf4jWithInnerEnum {
   @Slf4j enum Inner {
     CONSTANT(),
-    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Inner.class);
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Inner.class);
     <clinit>() {
     }
     Inner() {
@@ -40,7 +40,7 @@ class LoggerSlf4jWithInnerEnum {
 }
 class LoggerSlf4jOuter {
   static @lombok.extern.slf4j.Slf4j class Inner {
-    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Inner.class);
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Inner.class);
     <clinit>() {
     }
     Inner() {
@@ -51,18 +51,16 @@ class LoggerSlf4jOuter {
     super();
   }
 }
-
 @Slf4j(topic = "DifferentLogger") class LoggerSlf4jWithDifferentLoggerName {
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger("DifferentLogger");
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger("DifferentLogger");
   <clinit>() {
   }
   LoggerSlf4jWithDifferentLoggerName() {
     super();
   }
 }
-
 @Slf4j(topic = LoggerSlf4jWithStaticField.TOPIC) class LoggerSlf4jWithStaticField {
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jWithStaticField.TOPIC);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jWithStaticField.TOPIC);
   static final String TOPIC = "StaticField";
   <clinit>() {
   }
@@ -71,7 +69,7 @@ class LoggerSlf4jOuter {
   }
 }
 @Slf4j(topic = (LoggerSlf4jWithTwoStaticFields.TOPIC + LoggerSlf4jWithTwoStaticFields.TOPIC)) class LoggerSlf4jWithTwoStaticFields {
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger((LoggerSlf4jWithTwoStaticFields.TOPIC + LoggerSlf4jWithTwoStaticFields.TOPIC));
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger((LoggerSlf4jWithTwoStaticFields.TOPIC + LoggerSlf4jWithTwoStaticFields.TOPIC));
   static final String TOPIC = "StaticField";
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerSlf4jOnRecord.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4jOnRecord.java
@@ -1,9 +1,8 @@
-// version 14:
 import lombok.extern.slf4j.Slf4j;
 public @Slf4j record LoggerSlf4jOnRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jOnRecord.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jOnRecord.class);
   <clinit>() {
   }
 }

--- a/test/transform/resource/after-ecj/LoggerSlf4jTypes.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4jTypes.java
@@ -3,7 +3,7 @@
 @lombok.extern.slf4j.Slf4j @interface LoggerSlf4jTypesAnnotation {
 }
 @lombok.extern.slf4j.Slf4j enum LoggerSlf4jTypesEnum {
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jTypesEnum.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jTypesEnum.class);
   <clinit>() {
   }
   LoggerSlf4jTypesEnum() {
@@ -12,7 +12,7 @@
 }
 @lombok.extern.slf4j.Slf4j enum LoggerSlf4jTypesEnumWithElement {
   FOO(),
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jTypesEnumWithElement.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jTypesEnumWithElement.class);
   <clinit>() {
   }
   LoggerSlf4jTypesEnumWithElement() {
@@ -21,7 +21,7 @@
 }
 interface LoggerSlf4jTypesInterfaceOuter {
   @lombok.extern.slf4j.Slf4j class Inner {
-    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Inner.class);
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Inner.class);
     <clinit>() {
     }
     Inner() {

--- a/test/transform/resource/after-ecj/LoggerSlf4jWithPackage.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4jWithPackage.java
@@ -1,6 +1,6 @@
 package before;
 @lombok.extern.slf4j.Slf4j class LoggerSlf4jWithPackage {
-  private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jWithPackage.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jWithPackage.class);
   <clinit>() {
   }
   LoggerSlf4jWithPackage() {
@@ -9,7 +9,7 @@ package before;
 }
 class LoggerSlf4jWithPackageOuter {
   static @lombok.extern.slf4j.Slf4j class Inner {
-    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Inner.class);
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Inner.class);
     <clinit>() {
     }
     Inner() {

--- a/test/transform/resource/after-ecj/LoggerXSlf4j.java
+++ b/test/transform/resource/after-ecj/LoggerXSlf4j.java
@@ -1,6 +1,6 @@
 import lombok.extern.slf4j.XSlf4j;
 @lombok.extern.slf4j.XSlf4j class LoggerXSlf4j {
-  private static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXSlf4j.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXSlf4j.class);
   <clinit>() {
   }
   LoggerXSlf4j() {
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.XSlf4j;
   }
 }
 @XSlf4j class LoggerXSlf4jWithImport {
-  private static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXSlf4jWithImport.class);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXSlf4jWithImport.class);
   <clinit>() {
   }
   LoggerXSlf4jWithImport() {
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.XSlf4j;
   }
 }
 @XSlf4j(topic = "DifferentName") class LoggerXSlf4jWithDifferentName {
-  private static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger("DifferentName");
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger("DifferentName");
   <clinit>() {
   }
   LoggerXSlf4jWithDifferentName() {
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.XSlf4j;
   }
 }
 @XSlf4j(topic = LoggerXSlf4jWithStaticField.TOPIC) class LoggerXSlf4jWithStaticField {
-  private static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXSlf4jWithStaticField.TOPIC);
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXSlf4jWithStaticField.TOPIC);
   static final String TOPIC = "StaticField";
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/SynchronizedInAnonymousClass.java
+++ b/test/transform/resource/after-ecj/SynchronizedInAnonymousClass.java
@@ -2,7 +2,7 @@ import lombok.Synchronized;
 public class SynchronizedInAnonymousClass {
   Object annonymous = new Object() {
     class Inner {
-      private final java.lang.Object $lock = new java.lang.Object[0];
+      private final @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.Object $lock = new java.lang.Object[0];
       Inner() {
         super();
       }

--- a/test/transform/resource/after-ecj/SynchronizedInInitializer.java
+++ b/test/transform/resource/after-ecj/SynchronizedInInitializer.java
@@ -1,7 +1,7 @@
 import lombok.Synchronized;
 public class SynchronizedInInitializer {
   public static final Runnable SYNCHRONIZED = new Runnable() {
-    private final java.lang.Object $lock = new java.lang.Object[0];
+    private final @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.Object $lock = new java.lang.Object[0];
     public @Override @Synchronized void run() {
       synchronized (this.$lock)
         {

--- a/test/transform/resource/after-ecj/SynchronizedInRecord.java
+++ b/test/transform/resource/after-ecj/SynchronizedInRecord.java
@@ -2,7 +2,7 @@ import lombok.Synchronized;
 public record SynchronizedInRecord(String a, String b) {
 /* Implicit */  private final String a;
 /* Implicit */  private final String b;
-  private final java.lang.Object $lock = new java.lang.Object[0];
+  private final @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.Object $lock = new java.lang.Object[0];
   public @Synchronized void foo() {
     String foo = "bar";
   }

--- a/test/transform/resource/after-ecj/SynchronizedPlain.java
+++ b/test/transform/resource/after-ecj/SynchronizedPlain.java
@@ -1,6 +1,6 @@
 import lombok.Synchronized;
 class SynchronizedPlain1 {
-  private final java.lang.Object $lock = new java.lang.Object[0];
+  private final @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.Object $lock = new java.lang.Object[0];
   SynchronizedPlain1() {
     super();
   }
@@ -18,7 +18,7 @@ class SynchronizedPlain1 {
   }
 }
 class SynchronizedPlain2 {
-  private static final java.lang.Object $LOCK = new java.lang.Object[0];
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.Object $LOCK = new java.lang.Object[0];
   <clinit>() {
   }
   SynchronizedPlain2() {


### PR DESCRIPTION
This PR enables marking for fields generated by `@Log`, `@Synchronized` and `@Locked`. It was disabled years ago to fix a bug but it was never enabled again.