### PR TITLE
Standardize @Retention usage in Lombok annotationsfix: Standardize @Retention usage in annotations

### DIFF
--- a/src/core/lombok/Builder.java
+++ b/src/core/lombok/Builder.java
@@ -111,7 +111,7 @@ import java.lang.annotation.Target;
  * @see Singular
  */
 @Target({TYPE, METHOD, CONSTRUCTOR})
-@Retention(SOURCE)
+@Retention(RetentionPolicy.SOURCE)
 public @interface Builder {
 	/**
 	 * The field annotated with {@code @Default} must have an initializing expression; that expression is taken as the default to be used if not explicitly set during building.


### PR DESCRIPTION
### Description
This pull request standardizes the usage of the @Retention annotation across Lombok's annotations. Specifically, it changes the usage in the @Builder annotation from `@Retention(SOURCE)` to `@Retention(RetentionPolicy.SOURCE)`. 

### Reason for Change
The other annotations in the Lombok project, such as @Getter and @Setter, use `@Retention(RetentionPolicy.SOURCE)`. For the sake of consistency and readability, this change ensures that all annotations follow the same convention.

### Changes Made
- Updated `@Retention(SOURCE)` to `@Retention(RetentionPolicy.SOURCE)` in the @Builder annotation.

### Impact
This change does not affect the functionality of the annotations but improves the consistency and maintainability of the codebase.

### Verification
No additional tests are needed as this change only affects the annotation declaration style.

Please review and let me know if there are any concerns or further changes needed.

Thank you!
