### PR TITLE
[POC]  @Builder.Exclude for a field in cases where @Builder/@SuperBuilder is on a type

### DIFF
--- a/src/core/lombok/Builder.java
+++ b/src/core/lombok/Builder.java
@@ -120,6 +120,13 @@ public @interface Builder {
 	@Retention(SOURCE)
 	public @interface Default {}
 
+	/**
+	 * The field annotated with {@code @Exclude} will be excluded from the builder;
+	 */
+	@Target(FIELD)
+	@Retention(SOURCE)
+	public @interface Exclude {}
+
 	/** @return Name of the method that creates a new builder instance. Default: {@code builder}. If the empty string, suppress generating the {@code builder} method. */
 	String builderMethodName() default "builder";
 	

--- a/src/core/lombok/Builder.java
+++ b/src/core/lombok/Builder.java
@@ -121,7 +121,7 @@ public @interface Builder {
 	public @interface Default {}
 
 	/**
-	 * The field annotated with {@code @Exclude} will be excluded from the builder;
+	 * The field annotated with {@code @Exclude} will be excluded from the builder.
 	 */
 	@Target(FIELD)
 	@Retention(SOURCE)

--- a/src/core/lombok/Builder.java
+++ b/src/core/lombok/Builder.java
@@ -121,11 +121,12 @@ public @interface Builder {
 	public @interface Default {}
 
 	/**
-	 * The field annotated with {@code @Exclude} will be excluded from the builder.
+	 * The field annotated with {@code @Exclude} will be excluded from the builder. Excluded objects will be initialized as null
+	 * and primitives with their default value.
 	 */
 	@Target(FIELD)
 	@Retention(SOURCE)
-	public @interface Exclude {}
+	@interface Exclude {}
 
 	/** @return Name of the method that creates a new builder instance. Default: {@code builder}. If the empty string, suppress generating the {@code builder} method. */
 	String builderMethodName() default "builder";

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -311,6 +311,10 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 			List<EclipseNode> allFields = new ArrayList<EclipseNode>();
 			boolean valuePresent = (hasAnnotation(lombok.Value.class, parent) || hasAnnotation("lombok.experimental.Value", parent));
 			for (EclipseNode fieldNode : HandleConstructor.findAllFields(parent, true)) {
+				EclipseNode isExcluded = findAnnotation(Builder.Exclude.class, fieldNode);
+				if (isExcluded != null) {
+					continue;
+				}
 				FieldDeclaration fd = (FieldDeclaration) fieldNode.get();
 				EclipseNode isDefault = findAnnotation(Builder.Default.class, fieldNode);
 				boolean isFinal = ((fd.modifiers & ClassFileConstants.AccFinal) != 0) || (valuePresent && !hasAnnotation(NonFinal.class, fieldNode));

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -313,6 +313,7 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 			for (EclipseNode fieldNode : HandleConstructor.findAllFields(parent, true)) {
 				EclipseNode isExcluded = findAnnotation(Builder.Exclude.class, fieldNode);
 				if (isExcluded != null) {
+					//if the field is excluded, it will not be in the generated constructor used for the builder
 					continue;
 				}
 				FieldDeclaration fd = (FieldDeclaration) fieldNode.get();

--- a/src/core/lombok/eclipse/handlers/HandleBuilderExclude.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilderExclude.java
@@ -1,0 +1,26 @@
+package lombok.eclipse.handlers;
+
+import lombok.Builder;
+import lombok.core.AST;
+import lombok.core.AnnotationValues;
+import lombok.core.HandlerPriority;
+import lombok.eclipse.EclipseAnnotationHandler;
+import lombok.eclipse.EclipseNode;
+import lombok.experimental.SuperBuilder;
+import lombok.spi.Provides;
+import org.eclipse.jdt.internal.compiler.ast.Annotation;
+
+@Provides
+@HandlerPriority(-1025) //HandleBuilder's level, minus one.
+public class HandleBuilderExclude extends EclipseAnnotationHandler<Builder.Exclude> {
+    @Override
+    public void handle(AnnotationValues<Builder.Exclude> annotation, Annotation ast, EclipseNode annotationNode) {
+        EclipseNode annotatedField = annotationNode.up();
+        if (annotatedField.getKind() != AST.Kind.FIELD) return;
+        EclipseNode classWithAnnotatedField = annotatedField.up();
+        if (!EclipseHandlerUtil.hasAnnotation(Builder.class, classWithAnnotatedField) && !EclipseHandlerUtil.hasAnnotation("lombok.experimental.Builder", classWithAnnotatedField)
+                && !EclipseHandlerUtil.hasAnnotation(SuperBuilder.class, classWithAnnotatedField)) {
+            annotationNode.addWarning("@Builder.Exclude requires @Builder or @SuperBuilder on the class for it to mean anything.");
+        }
+    }
+}

--- a/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleSuperBuilder.java
@@ -198,6 +198,11 @@ public class HandleSuperBuilder extends EclipseAnnotationHandler<SuperBuilder> {
 		
 		boolean valuePresent = (hasAnnotation(lombok.Value.class, parent) || hasAnnotation("lombok.experimental.Value", parent));
 		for (EclipseNode fieldNode : HandleConstructor.findAllFields(parent, true)) {
+			EclipseNode isExcluded = findAnnotation(Builder.Exclude.class, fieldNode);
+			if (isExcluded != null) {
+				//if the field is excluded, it will not be in the generated constructor used for the builder
+				continue;
+			}
 			FieldDeclaration fd = (FieldDeclaration) fieldNode.get();
 			EclipseNode isDefault = findAnnotation(Builder.Default.class, fieldNode);
 			boolean isFinal = ((fd.modifiers & ClassFileConstants.AccFinal) != 0) || (valuePresent && !hasAnnotation(NonFinal.class, fieldNode));

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -254,7 +254,8 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 			for (JavacNode fieldNode : HandleConstructor.findAllFields(parent, true)) {
 				JavacNode isExcluded = findAnnotation(Builder.Exclude.class, fieldNode, false);
 				if (isExcluded != null) {
-					continue; // skip field if marked with exclude
+					//if the field is excluded, it will not be in the generated constructor used for the builder
+					continue;
 				}
 				JCVariableDecl fd = (JCVariableDecl) fieldNode.get();
 				JavacNode isDefault = findAnnotation(Builder.Default.class, fieldNode, false);

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -252,6 +252,10 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 			ListBuffer<JavacNode> allFields = new ListBuffer<JavacNode>();
 			boolean valuePresent = (hasAnnotation(lombok.Value.class, parent) || hasAnnotation("lombok.experimental.Value", parent));
 			for (JavacNode fieldNode : HandleConstructor.findAllFields(parent, true)) {
+				JavacNode isExcluded = findAnnotation(Builder.Exclude.class, fieldNode, false);
+				if (isExcluded != null) {
+					continue;
+				}
 				JCVariableDecl fd = (JCVariableDecl) fieldNode.get();
 				JavacNode isDefault = findAnnotation(Builder.Default.class, fieldNode, false);
 				boolean isFinal = (fd.mods.flags & Flags.FINAL) != 0 || (valuePresent && !hasAnnotation(NonFinal.class, fieldNode));

--- a/src/core/lombok/javac/handlers/HandleBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleBuilder.java
@@ -254,7 +254,7 @@ public class HandleBuilder extends JavacAnnotationHandler<Builder> {
 			for (JavacNode fieldNode : HandleConstructor.findAllFields(parent, true)) {
 				JavacNode isExcluded = findAnnotation(Builder.Exclude.class, fieldNode, false);
 				if (isExcluded != null) {
-					continue;
+					continue; // skip field if marked with exclude
 				}
 				JCVariableDecl fd = (JCVariableDecl) fieldNode.get();
 				JavacNode isDefault = findAnnotation(Builder.Default.class, fieldNode, false);

--- a/src/core/lombok/javac/handlers/HandleBuilderExclude.java
+++ b/src/core/lombok/javac/handlers/HandleBuilderExclude.java
@@ -1,0 +1,29 @@
+package lombok.javac.handlers;
+
+import com.sun.tools.javac.tree.JCTree;
+import lombok.Builder;
+import lombok.core.AST;
+import lombok.core.AnnotationValues;
+import lombok.core.HandlerPriority;
+import lombok.experimental.SuperBuilder;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.spi.Provides;
+
+import static lombok.javac.handlers.JavacHandlerUtil.deleteAnnotationIfNeccessary;
+import static lombok.javac.handlers.JavacHandlerUtil.hasAnnotation;
+
+@Provides
+@HandlerPriority(-1025) //HandleBuilder's level, minus one.
+public class HandleBuilderExclude extends JavacAnnotationHandler<Builder.Exclude> {
+    @Override public void handle(AnnotationValues<Builder.Exclude> annotation, JCTree.JCAnnotation ast, JavacNode annotationNode) {
+        JavacNode annotatedField = annotationNode.up();
+        if (annotatedField.getKind() != AST.Kind.FIELD) return;
+        JavacNode classWithAnnotatedField = annotatedField.up();
+        if (!hasAnnotation(Builder.class, classWithAnnotatedField) && !hasAnnotation("lombok.experimental.Builder", classWithAnnotatedField)
+                && !hasAnnotation(SuperBuilder.class, classWithAnnotatedField)) {
+            annotationNode.addWarning("@Builder.Exclude requires @Builder or @SuperBuilder on the class for it to mean anything.");
+            deleteAnnotationIfNeccessary(annotationNode, Builder.Exclude.class);
+        }
+    }
+}

--- a/src/core/lombok/javac/handlers/HandleBuilderExclude.java
+++ b/src/core/lombok/javac/handlers/HandleBuilderExclude.java
@@ -14,7 +14,7 @@ import static lombok.javac.handlers.JavacHandlerUtil.deleteAnnotationIfNeccessar
 import static lombok.javac.handlers.JavacHandlerUtil.hasAnnotation;
 
 @Provides
-@HandlerPriority(-1025) //HandleBuilder's level, minus one.
+@HandlerPriority(-1026) //HandleBuilder's level, minus one.
 public class HandleBuilderExclude extends JavacAnnotationHandler<Builder.Exclude> {
     @Override public void handle(AnnotationValues<Builder.Exclude> annotation, JCTree.JCAnnotation ast, JavacNode annotationNode) {
         JavacNode annotatedField = annotationNode.up();

--- a/src/core/lombok/javac/handlers/HandleBuilderExcludeRemove.java
+++ b/src/core/lombok/javac/handlers/HandleBuilderExcludeRemove.java
@@ -1,0 +1,25 @@
+package lombok.javac.handlers;
+
+import static lombok.javac.handlers.JavacHandlerUtil.*;
+
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+
+import lombok.Builder;
+import lombok.Builder.Exclude;
+import lombok.core.AlreadyHandledAnnotations;
+import lombok.core.AnnotationValues;
+import lombok.core.HandlerPriority;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.spi.Provides;
+
+@Provides
+@HandlerPriority(32768)
+@AlreadyHandledAnnotations
+public class HandleBuilderExcludeRemove extends JavacAnnotationHandler<Builder.Exclude> {
+    @Override public void handle(AnnotationValues<Exclude> annotation, JCAnnotation ast, JavacNode annotationNode) {
+        deleteAnnotationIfNeccessary(annotationNode, Builder.Exclude.class);
+        deleteImportFromCompilationUnit(annotationNode, Builder.class.getName());
+        deleteImportFromCompilationUnit(annotationNode, Builder.Exclude.class.getName());
+    }
+}

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -181,6 +181,7 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		for (JavacNode fieldNode : HandleConstructor.findAllFields(parent, true)) {
 			JavacNode isExcluded = findAnnotation(Builder.Exclude.class, fieldNode, false);
 			if (isExcluded != null) {
+				//if the field is excluded, it will not be in the generated constructor used for the builder
 				continue;
 			}
 			JCVariableDecl fd = (JCVariableDecl) fieldNode.get();

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -179,6 +179,10 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 		
 		boolean valuePresent = (hasAnnotation(lombok.Value.class, parent) || hasAnnotation("lombok.experimental.Value", parent));
 		for (JavacNode fieldNode : HandleConstructor.findAllFields(parent, true)) {
+			JavacNode isExcluded = findAnnotation(Builder.Exclude.class, fieldNode, false);
+			if (isExcluded != null) {
+				continue;
+			}
 			JCVariableDecl fd = (JCVariableDecl) fieldNode.get();
 			JavacNode isDefault = findAnnotation(Builder.Default.class, fieldNode, false);
 			boolean isFinal = (fd.mods.flags & Flags.FINAL) != 0 || (valuePresent && !hasAnnotation(NonFinal.class, fieldNode));

--- a/test/transform/resource/after-delombok/BuilderExcludes.java
+++ b/test/transform/resource/after-delombok/BuilderExcludes.java
@@ -1,0 +1,68 @@
+public class BuilderExcludes {
+    long x;
+    int y;
+    int z;
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    BuilderExcludes(final long x, final int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    public static class BuilderExcludesBuilder {
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private long x;
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private int y;
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        BuilderExcludesBuilder() {
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludes.BuilderExcludesBuilder x(final long x) {
+            this.x = x;
+            return this;
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludes.BuilderExcludesBuilder y(final int y) {
+            this.y = y;
+            return this;
+        }
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludes build() {
+            return new BuilderExcludes(this.x, this.y);
+        }
+
+        @java.lang.Override
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public java.lang.String toString() {
+            return "BuilderExcludes.BuilderExcludesBuilder(x=" + this.x + ", y=" + this.y + ")";
+        }
+    }
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    public static BuilderExcludes.BuilderExcludesBuilder builder() {
+        return new BuilderExcludes.BuilderExcludesBuilder();
+    }
+}

--- a/test/transform/resource/after-delombok/BuilderExcludes.java
+++ b/test/transform/resource/after-delombok/BuilderExcludes.java
@@ -5,9 +5,10 @@ public class BuilderExcludes {
 
     @java.lang.SuppressWarnings("all")
     @lombok.Generated
-    BuilderExcludes(final long x, final int y) {
+    BuilderExcludes(final long x, final int y, final int z) {
         this.x = x;
         this.y = y;
+        this.z = z;
     }
 
 
@@ -20,6 +21,9 @@ public class BuilderExcludes {
         @java.lang.SuppressWarnings("all")
         @lombok.Generated
         private int y;
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private int z;
 
         @java.lang.SuppressWarnings("all")
         @lombok.Generated
@@ -49,14 +53,14 @@ public class BuilderExcludes {
         @java.lang.SuppressWarnings("all")
         @lombok.Generated
         public BuilderExcludes build() {
-            return new BuilderExcludes(this.x, this.y);
+            return new BuilderExcludes(this.x, this.y, this.z);
         }
 
         @java.lang.Override
         @java.lang.SuppressWarnings("all")
         @lombok.Generated
         public java.lang.String toString() {
-            return "BuilderExcludes.BuilderExcludesBuilder(x=" + this.x + ", y=" + this.y + ")";
+            return "BuilderExcludes.BuilderExcludesBuilder(x=" + this.x + ", y=" + this.y + ", z=" + this.z + ")";
         }
     }
 

--- a/test/transform/resource/after-delombok/BuilderExcludesWarnings.java
+++ b/test/transform/resource/after-delombok/BuilderExcludesWarnings.java
@@ -1,0 +1,149 @@
+public class BuilderExcludesWarnings {
+    long x;
+    int y;
+    int z;
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    BuilderExcludesWarnings(final long x, final int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    public static class BuilderExcludesWarningsBuilder {
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private long x;
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private int y;
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        BuilderExcludesWarningsBuilder() {
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludesWarnings.BuilderExcludesWarningsBuilder x(final long x) {
+            this.x = x;
+            return this;
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludesWarnings.BuilderExcludesWarningsBuilder y(final int y) {
+            this.y = y;
+            return this;
+        }
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludesWarnings build() {
+            return new BuilderExcludesWarnings(this.x, this.y);
+        }
+
+        @java.lang.Override
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public java.lang.String toString() {
+            return "BuilderExcludesWarnings.BuilderExcludesWarningsBuilder(x=" + this.x + ", y=" + this.y + ")";
+        }
+    }
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    public static BuilderExcludesWarnings.BuilderExcludesWarningsBuilder builder() {
+        return new BuilderExcludesWarnings.BuilderExcludesWarningsBuilder();
+    }
+}
+
+class NoBuilderButHasExcludes {
+    long x;
+    int y;
+    int z;
+
+    public NoBuilderButHasExcludes(long x, int y, int z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    public static class NoBuilderButHasExcludesBuilder {
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private long x;
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private int y;
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private int z;
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        NoBuilderButHasExcludesBuilder() {
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder x(final long x) {
+            this.x = x;
+            return this;
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder y(final int y) {
+            this.y = y;
+            return this;
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder z(final int z) {
+            this.z = z;
+            return this;
+        }
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public NoBuilderButHasExcludes build() {
+            return new NoBuilderButHasExcludes(this.x, this.y, this.z);
+        }
+
+        @java.lang.Override
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public java.lang.String toString() {
+            return "NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder(x=" + this.x + ", y=" + this.y + ", z=" + this.z + ")";
+        }
+    }
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    public static NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder builder() {
+        return new NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder();
+    }
+}

--- a/test/transform/resource/after-delombok/BuilderExcludesWarnings.java
+++ b/test/transform/resource/after-delombok/BuilderExcludesWarnings.java
@@ -5,9 +5,10 @@ public class BuilderExcludesWarnings {
 
     @java.lang.SuppressWarnings("all")
     @lombok.Generated
-    BuilderExcludesWarnings(final long x, final int y) {
+    BuilderExcludesWarnings(final long x, final int y, final int z) {
         this.x = x;
         this.y = y;
+        this.z = z;
     }
 
 
@@ -20,6 +21,9 @@ public class BuilderExcludesWarnings {
         @java.lang.SuppressWarnings("all")
         @lombok.Generated
         private int y;
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private int z;
 
         @java.lang.SuppressWarnings("all")
         @lombok.Generated
@@ -49,14 +53,14 @@ public class BuilderExcludesWarnings {
         @java.lang.SuppressWarnings("all")
         @lombok.Generated
         public BuilderExcludesWarnings build() {
-            return new BuilderExcludesWarnings(this.x, this.y);
+            return new BuilderExcludesWarnings(this.x, this.y, this.z);
         }
 
         @java.lang.Override
         @java.lang.SuppressWarnings("all")
         @lombok.Generated
         public java.lang.String toString() {
-            return "BuilderExcludesWarnings.BuilderExcludesWarningsBuilder(x=" + this.x + ", y=" + this.y + ")";
+            return "BuilderExcludesWarnings.BuilderExcludesWarningsBuilder(x=" + this.x + ", y=" + this.y + ", z=" + this.z + ")";
         }
     }
 

--- a/test/transform/resource/after-delombok/BuilderExcludesWithAllArgsConstructor.java
+++ b/test/transform/resource/after-delombok/BuilderExcludesWithAllArgsConstructor.java
@@ -1,0 +1,73 @@
+public class BuilderExcludesWithAllArgsConstructor {
+    long x;
+    int y;
+    int z;
+
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    public static class BuilderExcludesWithAllArgsConstructorBuilder {
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private long x;
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private int y;
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private int z;
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        BuilderExcludesWithAllArgsConstructorBuilder() {
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludesWithAllArgsConstructor.BuilderExcludesWithAllArgsConstructorBuilder x(final long x) {
+            this.x = x;
+            return this;
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludesWithAllArgsConstructor.BuilderExcludesWithAllArgsConstructorBuilder y(final int y) {
+            this.y = y;
+            return this;
+        }
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludesWithAllArgsConstructor build() {
+            return new BuilderExcludesWithAllArgsConstructor(this.x, this.y, this.z);
+        }
+
+        @java.lang.Override
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public java.lang.String toString() {
+            return "BuilderExcludesWithAllArgsConstructor.BuilderExcludesWithAllArgsConstructorBuilder(x=" + this.x + ", y=" + this.y + ", z=" + this.z + ")";
+        }
+    }
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    public static BuilderExcludesWithAllArgsConstructor.BuilderExcludesWithAllArgsConstructorBuilder builder() {
+        return new BuilderExcludesWithAllArgsConstructor.BuilderExcludesWithAllArgsConstructorBuilder();
+    }
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    public BuilderExcludesWithAllArgsConstructor(final long x, final int y, final int z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+}
+  

--- a/test/transform/resource/after-delombok/BuilderExcludesWithDefault.java
+++ b/test/transform/resource/after-delombok/BuilderExcludesWithDefault.java
@@ -1,0 +1,83 @@
+public class BuilderExcludesWithDefault {
+    long x;
+    int y;
+    int z;
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    private static int $default$z() {
+        return 5;
+    }
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    BuilderExcludesWithDefault(final long x, final int y, final int z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    public static class BuilderExcludesWithDefaultBuilder {
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private long x;
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private int y;
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private boolean z$set;
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private int z$value;
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        BuilderExcludesWithDefaultBuilder() {
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludesWithDefault.BuilderExcludesWithDefaultBuilder x(final long x) {
+            this.x = x;
+            return this;
+        }
+
+        /**
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludesWithDefault.BuilderExcludesWithDefaultBuilder y(final int y) {
+            this.y = y;
+            return this;
+        }
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public BuilderExcludesWithDefault build() {
+            int z$value = this.z$value;
+            if (!this.z$set) z$value = BuilderExcludesWithDefault.$default$z();
+            return new BuilderExcludesWithDefault(this.x, this.y, z$value);
+        }
+
+        @java.lang.Override
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public java.lang.String toString() {
+            return "BuilderExcludesWithDefault.BuilderExcludesWithDefaultBuilder(x=" + this.x + ", y=" + this.y + ", z$value=" + this.z$value + ")";
+        }
+    }
+
+    @java.lang.SuppressWarnings("all")
+    @lombok.Generated
+    public static BuilderExcludesWithDefault.BuilderExcludesWithDefaultBuilder builder() {
+        return new BuilderExcludesWithDefault.BuilderExcludesWithDefaultBuilder();
+    }
+}

--- a/test/transform/resource/after-delombok/SuperBuilderWithExcludes.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithExcludes.java
@@ -11,6 +11,9 @@ public class SuperBuilderWithExcludes {
         public static abstract class ParentBuilder<N extends Number, C extends SuperBuilderWithExcludes.Parent<N>, B extends SuperBuilderWithExcludes.Parent.ParentBuilder<N, C, B>> {
             @java.lang.SuppressWarnings("all")
             @lombok.Generated
+            private long excludedParentField;
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
             private N numberField;
             @java.lang.SuppressWarnings("all")
             @lombok.Generated
@@ -48,7 +51,7 @@ public class SuperBuilderWithExcludes {
             @java.lang.SuppressWarnings("all")
             @lombok.Generated
             public java.lang.String toString() {
-                return "SuperBuilderWithExcludes.Parent.ParentBuilder(numberField=" + this.numberField + ", randomFieldP=" + this.randomFieldP + ")";
+                return "SuperBuilderWithExcludes.Parent.ParentBuilder(excludedParentField=" + this.excludedParentField + ", numberField=" + this.numberField + ", randomFieldP=" + this.randomFieldP + ")";
             }
         }
 
@@ -79,6 +82,7 @@ public class SuperBuilderWithExcludes {
         @java.lang.SuppressWarnings("all")
         @lombok.Generated
         protected Parent(final SuperBuilderWithExcludes.Parent.ParentBuilder<N, ?, ?> b) {
+            this.excludedParentField = b.excludedParentField;
             this.numberField = b.numberField;
             this.randomFieldP = b.randomFieldP;
         }
@@ -103,6 +107,9 @@ public class SuperBuilderWithExcludes {
             @java.lang.SuppressWarnings("all")
             @lombok.Generated
             private double doubleField;
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            private long excludedChildField;
             @java.lang.SuppressWarnings("all")
             @lombok.Generated
             private long randomFieldC;
@@ -141,7 +148,7 @@ public class SuperBuilderWithExcludes {
             @java.lang.SuppressWarnings("all")
             @lombok.Generated
             public java.lang.String toString() {
-                return "SuperBuilderWithExcludes.Child.ChildBuilder(super=" + super.toString() + ", doubleField=" + this.doubleField + ", randomFieldC=" + this.randomFieldC + ")";
+                return "SuperBuilderWithExcludes.Child.ChildBuilder(super=" + super.toString() + ", doubleField=" + this.doubleField + ", excludedChildField=" + this.excludedChildField + ", randomFieldC=" + this.randomFieldC + ")";
             }
         }
 
@@ -174,6 +181,7 @@ public class SuperBuilderWithExcludes {
         protected Child(final SuperBuilderWithExcludes.Child.ChildBuilder<?, ?> b) {
             super(b);
             this.doubleField = b.doubleField;
+            this.excludedChildField = b.excludedChildField;
             this.randomFieldC = b.randomFieldC;
         }
 

--- a/test/transform/resource/after-delombok/SuperBuilderWithExcludes.java
+++ b/test/transform/resource/after-delombok/SuperBuilderWithExcludes.java
@@ -1,0 +1,186 @@
+public class SuperBuilderWithExcludes {
+
+    public static class Parent<N extends Number> {
+        private long excludedParentField;
+        private N numberField;
+        private long randomFieldP;
+
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public static abstract class ParentBuilder<N extends Number, C extends SuperBuilderWithExcludes.Parent<N>, B extends SuperBuilderWithExcludes.Parent.ParentBuilder<N, C, B>> {
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            private N numberField;
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            private long randomFieldP;
+
+            /**
+             * @return {@code this}.
+             */
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            public B numberField(final N numberField) {
+                this.numberField = numberField;
+                return self();
+            }
+
+            /**
+             * @return {@code this}.
+             */
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            public B randomFieldP(final long randomFieldP) {
+                this.randomFieldP = randomFieldP;
+                return self();
+            }
+
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            protected abstract B self();
+
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            public abstract C build();
+
+            @java.lang.Override
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            public java.lang.String toString() {
+                return "SuperBuilderWithExcludes.Parent.ParentBuilder(numberField=" + this.numberField + ", randomFieldP=" + this.randomFieldP + ")";
+            }
+        }
+
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private static final class ParentBuilderImpl<N extends Number> extends SuperBuilderWithExcludes.Parent.ParentBuilder<N, SuperBuilderWithExcludes.Parent<N>, SuperBuilderWithExcludes.Parent.ParentBuilderImpl<N>> {
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            private ParentBuilderImpl() {
+            }
+
+            @java.lang.Override
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            protected SuperBuilderWithExcludes.Parent.ParentBuilderImpl<N> self() {
+                return this;
+            }
+
+            @java.lang.Override
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            public SuperBuilderWithExcludes.Parent<N> build() {
+                return new SuperBuilderWithExcludes.Parent<N>(this);
+            }
+        }
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        protected Parent(final SuperBuilderWithExcludes.Parent.ParentBuilder<N, ?, ?> b) {
+            this.numberField = b.numberField;
+            this.randomFieldP = b.randomFieldP;
+        }
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public static <N extends Number> SuperBuilderWithExcludes.Parent.ParentBuilder<N, ?, ?> builder() {
+            return new SuperBuilderWithExcludes.Parent.ParentBuilderImpl<N>();
+        }
+    }
+
+
+    public static class Child extends Parent<Integer> {
+        private double doubleField;
+        private long excludedChildField;
+        private long randomFieldC;
+
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public static abstract class ChildBuilder<C extends SuperBuilderWithExcludes.Child, B extends SuperBuilderWithExcludes.Child.ChildBuilder<C, B>> extends Parent.ParentBuilder<Integer, C, B> {
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            private double doubleField;
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            private long randomFieldC;
+
+            /**
+             * @return {@code this}.
+             */
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            public B doubleField(final double doubleField) {
+                this.doubleField = doubleField;
+                return self();
+            }
+
+            /**
+             * @return {@code this}.
+             */
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            public B randomFieldC(final long randomFieldC) {
+                this.randomFieldC = randomFieldC;
+                return self();
+            }
+
+            @java.lang.Override
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            protected abstract B self();
+
+            @java.lang.Override
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            public abstract C build();
+
+            @java.lang.Override
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            public java.lang.String toString() {
+                return "SuperBuilderWithExcludes.Child.ChildBuilder(super=" + super.toString() + ", doubleField=" + this.doubleField + ", randomFieldC=" + this.randomFieldC + ")";
+            }
+        }
+
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        private static final class ChildBuilderImpl extends SuperBuilderWithExcludes.Child.ChildBuilder<SuperBuilderWithExcludes.Child, SuperBuilderWithExcludes.Child.ChildBuilderImpl> {
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            private ChildBuilderImpl() {
+            }
+
+            @java.lang.Override
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            protected SuperBuilderWithExcludes.Child.ChildBuilderImpl self() {
+                return this;
+            }
+
+            @java.lang.Override
+            @java.lang.SuppressWarnings("all")
+            @lombok.Generated
+            public SuperBuilderWithExcludes.Child build() {
+                return new SuperBuilderWithExcludes.Child(this);
+            }
+        }
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        protected Child(final SuperBuilderWithExcludes.Child.ChildBuilder<?, ?> b) {
+            super(b);
+            this.doubleField = b.doubleField;
+            this.randomFieldC = b.randomFieldC;
+        }
+
+        @java.lang.SuppressWarnings("all")
+        @lombok.Generated
+        public static SuperBuilderWithExcludes.Child.ChildBuilder<?, ?> builder() {
+            return new SuperBuilderWithExcludes.Child.ChildBuilderImpl();
+        }
+    }
+}

--- a/test/transform/resource/after-ecj/BuilderExcludes.java
+++ b/test/transform/resource/after-ecj/BuilderExcludes.java
@@ -4,6 +4,7 @@ public @Builder class BuilderExcludes {
   public static @java.lang.SuppressWarnings("all") @lombok.Generated class BuilderExcludesBuilder {
     private @java.lang.SuppressWarnings("all") @lombok.Generated long x;
     private @java.lang.SuppressWarnings("all") @lombok.Generated int y;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated int z;
 
     @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesBuilder() {
       super();
@@ -26,11 +27,11 @@ public @Builder class BuilderExcludes {
     }
 
     public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludes build() {
-      return new BuilderExcludes(this.x, this.y);
+      return new BuilderExcludes(this.x, this.y, this.z);
     }
 
     public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
-      return (((("BuilderExcludes.BuilderExcludesBuilder(x=" + this.x) + ", y=") + this.y) + ")");
+      return (((((("BuilderExcludes.BuilderExcludesBuilder(x=" + this.x) + ", y=") + this.y) + ", z=") + this.z) + ")");
     }
   }
 
@@ -38,10 +39,11 @@ public @Builder class BuilderExcludes {
   int y;
   @Builder.Exclude int z;
 
-  @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludes(final long x, final int y) {
+  @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludes(final long x, final int y, final int z) {
     super();
     this.x = x;
     this.y = y;
+    this.z = z;
   }
 
   public static @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludes.BuilderExcludesBuilder builder() {

--- a/test/transform/resource/after-ecj/BuilderExcludes.java
+++ b/test/transform/resource/after-ecj/BuilderExcludes.java
@@ -1,0 +1,50 @@
+import lombok.Builder;
+
+public @Builder class BuilderExcludes {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated class BuilderExcludesBuilder {
+    private @java.lang.SuppressWarnings("all") @lombok.Generated long x;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated int y;
+
+    @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesBuilder() {
+      super();
+    }
+
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludes.BuilderExcludesBuilder x(final long x) {
+      this.x = x;
+      return this;
+    }
+
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludes.BuilderExcludesBuilder y(final int y) {
+      this.y = y;
+      return this;
+    }
+
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludes build() {
+      return new BuilderExcludes(this.x, this.y);
+    }
+
+    public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+      return (((("BuilderExcludes.BuilderExcludesBuilder(x=" + this.x) + ", y=") + this.y) + ")");
+    }
+  }
+
+  long x;
+  int y;
+  @Builder.Exclude int z;
+
+  @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludes(final long x, final int y) {
+    super();
+    this.x = x;
+    this.y = y;
+  }
+
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludes.BuilderExcludesBuilder builder() {
+    return new BuilderExcludes.BuilderExcludesBuilder();
+  }
+}

--- a/test/transform/resource/after-ecj/BuilderExcludesWarnings.java
+++ b/test/transform/resource/after-ecj/BuilderExcludesWarnings.java
@@ -4,6 +4,7 @@ public @Builder class BuilderExcludesWarnings {
   public static @java.lang.SuppressWarnings("all") @lombok.Generated class BuilderExcludesWarningsBuilder {
     private @java.lang.SuppressWarnings("all") @lombok.Generated long x;
     private @java.lang.SuppressWarnings("all") @lombok.Generated int y;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated int z;
 
     @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWarningsBuilder() {
       super();
@@ -26,11 +27,11 @@ public @Builder class BuilderExcludesWarnings {
     }
 
     public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWarnings build() {
-      return new BuilderExcludesWarnings(this.x, this.y);
+      return new BuilderExcludesWarnings(this.x, this.y, this.z);
     }
 
     public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
-      return (((("BuilderExcludesWarnings.BuilderExcludesWarningsBuilder(x=" + this.x) + ", y=") + this.y) + ")");
+      return (((((("BuilderExcludesWarnings.BuilderExcludesWarningsBuilder(x=" + this.x) + ", y=") + this.y) + ", z=") + this.z) + ")");
     }
   }
 
@@ -38,10 +39,11 @@ public @Builder class BuilderExcludesWarnings {
   int y;
   @Builder.Exclude int z;
 
-  @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWarnings(final long x, final int y) {
+  @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWarnings(final long x, final int y, final int z) {
     super();
     this.x = x;
     this.y = y;
+    this.z = z;
   }
 
   public static @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWarnings.BuilderExcludesWarningsBuilder builder() {

--- a/test/transform/resource/after-ecj/BuilderExcludesWarnings.java
+++ b/test/transform/resource/after-ecj/BuilderExcludesWarnings.java
@@ -1,0 +1,109 @@
+import lombok.Builder;
+
+public @Builder class BuilderExcludesWarnings {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated class BuilderExcludesWarningsBuilder {
+    private @java.lang.SuppressWarnings("all") @lombok.Generated long x;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated int y;
+
+    @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWarningsBuilder() {
+      super();
+    }
+
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWarnings.BuilderExcludesWarningsBuilder x(final long x) {
+      this.x = x;
+      return this;
+    }
+
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWarnings.BuilderExcludesWarningsBuilder y(final int y) {
+      this.y = y;
+      return this;
+    }
+
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWarnings build() {
+      return new BuilderExcludesWarnings(this.x, this.y);
+    }
+
+    public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+      return (((("BuilderExcludesWarnings.BuilderExcludesWarningsBuilder(x=" + this.x) + ", y=") + this.y) + ")");
+    }
+  }
+
+  long x;
+  int y;
+  @Builder.Exclude int z;
+
+  @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWarnings(final long x, final int y) {
+    super();
+    this.x = x;
+    this.y = y;
+  }
+
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWarnings.BuilderExcludesWarningsBuilder builder() {
+    return new BuilderExcludesWarnings.BuilderExcludesWarningsBuilder();
+  }
+}
+
+class NoBuilderButHasExcludes {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated class NoBuilderButHasExcludesBuilder {
+    private @java.lang.SuppressWarnings("all") @lombok.Generated long x;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated int y;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated int z;
+
+    @java.lang.SuppressWarnings("all") @lombok.Generated NoBuilderButHasExcludesBuilder() {
+      super();
+    }
+
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder x(final long x) {
+      this.x = x;
+      return this;
+    }
+
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder y(final int y) {
+      this.y = y;
+      return this;
+    }
+
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder z(final int z) {
+      this.z = z;
+      return this;
+    }
+
+    public @java.lang.SuppressWarnings("all") @lombok.Generated NoBuilderButHasExcludes build() {
+      return new NoBuilderButHasExcludes(this.x, this.y, this.z);
+    }
+
+    public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+      return (((((("NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder(x=" + this.x) + ", y=") + this.y) + ", z=") + this.z) + ")");
+    }
+  }
+
+  long x;
+  int y;
+  @Builder.Exclude int z;
+
+  public @Builder NoBuilderButHasExcludes(long x, int y, int z) {
+    super();
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder builder() {
+    return new NoBuilderButHasExcludes.NoBuilderButHasExcludesBuilder();
+  }
+}

--- a/test/transform/resource/after-ecj/BuilderExcludesWithAllArgsConstructor.java
+++ b/test/transform/resource/after-ecj/BuilderExcludesWithAllArgsConstructor.java
@@ -1,0 +1,53 @@
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+
+public @Builder @AllArgsConstructor class BuilderExcludesWithAllArgsConstructor {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated class BuilderExcludesWithAllArgsConstructorBuilder {
+    private @java.lang.SuppressWarnings("all") @lombok.Generated long x;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated int y;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated int z;
+
+    @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithAllArgsConstructorBuilder() {
+      super();
+    }
+
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithAllArgsConstructor.BuilderExcludesWithAllArgsConstructorBuilder x(final long x) {
+      this.x = x;
+      return this;
+    }
+
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithAllArgsConstructor.BuilderExcludesWithAllArgsConstructorBuilder y(final int y) {
+      this.y = y;
+      return this;
+    }
+
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithAllArgsConstructor build() {
+      return new BuilderExcludesWithAllArgsConstructor(this.x, this.y, this.z);
+    }
+
+    public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+      return (((((("BuilderExcludesWithAllArgsConstructor.BuilderExcludesWithAllArgsConstructorBuilder(x=" + this.x) + ", y=") + this.y) + ", z=") + this.z) + ")");
+    }
+  }
+
+  long x;
+  int y;
+  @Builder.Exclude int z;
+
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithAllArgsConstructor.BuilderExcludesWithAllArgsConstructorBuilder builder() {
+    return new BuilderExcludesWithAllArgsConstructor.BuilderExcludesWithAllArgsConstructorBuilder();
+  }
+
+  public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithAllArgsConstructor(final long x, final int y, final int z) {
+    super();
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+}

--- a/test/transform/resource/after-ecj/BuilderExcludesWithDefault.java
+++ b/test/transform/resource/after-ecj/BuilderExcludesWithDefault.java
@@ -1,0 +1,60 @@
+import lombok.Builder;
+
+public @Builder class BuilderExcludesWithDefault {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated class BuilderExcludesWithDefaultBuilder {
+    private @java.lang.SuppressWarnings("all") @lombok.Generated long x;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated int y;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated int z$value;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated boolean z$set;
+
+    @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithDefaultBuilder() {
+      super();
+    }
+
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithDefault.BuilderExcludesWithDefaultBuilder x(final long x) {
+      this.x = x;
+      return this;
+    }
+
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithDefault.BuilderExcludesWithDefaultBuilder y(final int y) {
+      this.y = y;
+      return this;
+    }
+
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithDefault build() {
+      int z$value = this.z$value;
+      if ((! this.z$set))
+          z$value = BuilderExcludesWithDefault.$default$z();
+      return new BuilderExcludesWithDefault(this.x, this.y, z$value);
+    }
+
+    public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+      return (((((("BuilderExcludesWithDefault.BuilderExcludesWithDefaultBuilder(x=" + this.x) + ", y=") + this.y) + ", z$value=") + this.z$value) + ")");
+    }
+  }
+
+  long x;
+  int y;
+  @Builder.Exclude @Builder.Default int z;
+
+  private static @java.lang.SuppressWarnings("all") @lombok.Generated int $default$z() {
+    return 5;
+  }
+
+  @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithDefault(final long x, final int y, final int z) {
+    super();
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated BuilderExcludesWithDefault.BuilderExcludesWithDefaultBuilder builder() {
+    return new BuilderExcludesWithDefault.BuilderExcludesWithDefaultBuilder();
+  }
+}

--- a/test/transform/resource/after-ecj/SuperBuilderWithExcludes.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithExcludes.java
@@ -1,6 +1,7 @@
 public class SuperBuilderWithExcludes {
   public static @lombok.experimental.SuperBuilder class Parent<N extends Number> {
     public static abstract @java.lang.SuppressWarnings("all") @lombok.Generated class ParentBuilder<N extends Number, C extends SuperBuilderWithExcludes.Parent<N>, B extends SuperBuilderWithExcludes.Parent.ParentBuilder<N, C, B>> {
+      private @java.lang.SuppressWarnings("all") @lombok.Generated long excludedParentField;
       private @java.lang.SuppressWarnings("all") @lombok.Generated N numberField;
       private @java.lang.SuppressWarnings("all") @lombok.Generated long randomFieldP;
 
@@ -29,7 +30,7 @@ public class SuperBuilderWithExcludes {
       public abstract @java.lang.SuppressWarnings("all") @lombok.Generated C build();
 
       public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
-        return (((("SuperBuilderWithExcludes.Parent.ParentBuilder(numberField=" + this.numberField) + ", randomFieldP=") + this.randomFieldP) + ")");
+        return (((((("SuperBuilderWithExcludes.Parent.ParentBuilder(excludedParentField=" + this.excludedParentField) + ", numberField=") + this.numberField) + ", randomFieldP=") + this.randomFieldP) + ")");
       }
     }
 
@@ -53,6 +54,7 @@ public class SuperBuilderWithExcludes {
 
     protected @java.lang.SuppressWarnings("all") @lombok.Generated Parent(final SuperBuilderWithExcludes.Parent.ParentBuilder<N, ?, ?> b) {
       super();
+      this.excludedParentField = b.excludedParentField;
       this.numberField = b.numberField;
       this.randomFieldP = b.randomFieldP;
     }
@@ -65,6 +67,7 @@ public class SuperBuilderWithExcludes {
   public static @lombok.experimental.SuperBuilder class Child extends Parent<Integer> {
     public static abstract @java.lang.SuppressWarnings("all") @lombok.Generated class ChildBuilder<C extends SuperBuilderWithExcludes.Child, B extends SuperBuilderWithExcludes.Child.ChildBuilder<C, B>> extends Parent.ParentBuilder<Integer, C, B> {
       private @java.lang.SuppressWarnings("all") @lombok.Generated double doubleField;
+      private @java.lang.SuppressWarnings("all") @lombok.Generated long excludedChildField;
       private @java.lang.SuppressWarnings("all") @lombok.Generated long randomFieldC;
 
       public ChildBuilder() {
@@ -92,7 +95,7 @@ public class SuperBuilderWithExcludes {
       public abstract @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated C build();
 
       public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
-        return (((((("SuperBuilderWithExcludes.Child.ChildBuilder(super=" + super.toString()) + ", doubleField=") + this.doubleField) + ", randomFieldC=") + this.randomFieldC) + ")");
+        return (((((((("SuperBuilderWithExcludes.Child.ChildBuilder(super=" + super.toString()) + ", doubleField=") + this.doubleField) + ", excludedChildField=") + this.excludedChildField) + ", randomFieldC=") + this.randomFieldC) + ")");
       }
     }
 
@@ -117,6 +120,7 @@ public class SuperBuilderWithExcludes {
     protected @java.lang.SuppressWarnings("all") @lombok.Generated Child(final SuperBuilderWithExcludes.Child.ChildBuilder<?, ?> b) {
       super(b);
       this.doubleField = b.doubleField;
+      this.excludedChildField = b.excludedChildField;
       this.randomFieldC = b.randomFieldC;
     }
 

--- a/test/transform/resource/after-ecj/SuperBuilderWithExcludes.java
+++ b/test/transform/resource/after-ecj/SuperBuilderWithExcludes.java
@@ -1,0 +1,131 @@
+public class SuperBuilderWithExcludes {
+  public static @lombok.experimental.SuperBuilder class Parent<N extends Number> {
+    public static abstract @java.lang.SuppressWarnings("all") @lombok.Generated class ParentBuilder<N extends Number, C extends SuperBuilderWithExcludes.Parent<N>, B extends SuperBuilderWithExcludes.Parent.ParentBuilder<N, C, B>> {
+      private @java.lang.SuppressWarnings("all") @lombok.Generated N numberField;
+      private @java.lang.SuppressWarnings("all") @lombok.Generated long randomFieldP;
+
+      public ParentBuilder() {
+        super();
+      }
+
+      /**
+       * @return {@code this}.
+       */
+      public @java.lang.SuppressWarnings("all") @lombok.Generated B numberField(final N numberField) {
+        this.numberField = numberField;
+        return self();
+      }
+
+      /**
+       * @return {@code this}.
+       */
+      public @java.lang.SuppressWarnings("all") @lombok.Generated B randomFieldP(final long randomFieldP) {
+        this.randomFieldP = randomFieldP;
+        return self();
+      }
+
+      protected abstract @java.lang.SuppressWarnings("all") @lombok.Generated B self();
+
+      public abstract @java.lang.SuppressWarnings("all") @lombok.Generated C build();
+
+      public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+        return (((("SuperBuilderWithExcludes.Parent.ParentBuilder(numberField=" + this.numberField) + ", randomFieldP=") + this.randomFieldP) + ")");
+      }
+    }
+
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated class ParentBuilderImpl<N extends Number> extends SuperBuilderWithExcludes.Parent.ParentBuilder<N, SuperBuilderWithExcludes.Parent<N>, SuperBuilderWithExcludes.Parent.ParentBuilderImpl<N>> {
+      private ParentBuilderImpl() {
+        super();
+      }
+
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated SuperBuilderWithExcludes.Parent.ParentBuilderImpl<N> self() {
+        return this;
+      }
+
+      public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated SuperBuilderWithExcludes.Parent<N> build() {
+        return new SuperBuilderWithExcludes.Parent<N>(this);
+      }
+    }
+
+    private @lombok.Builder.Exclude long excludedParentField;
+    private N numberField;
+    private long randomFieldP;
+
+    protected @java.lang.SuppressWarnings("all") @lombok.Generated Parent(final SuperBuilderWithExcludes.Parent.ParentBuilder<N, ?, ?> b) {
+      super();
+      this.numberField = b.numberField;
+      this.randomFieldP = b.randomFieldP;
+    }
+
+    public static @java.lang.SuppressWarnings("all") @lombok.Generated <N extends Number>SuperBuilderWithExcludes.Parent.ParentBuilder<N, ?, ?> builder() {
+      return new SuperBuilderWithExcludes.Parent.ParentBuilderImpl<N>();
+    }
+  }
+
+  public static @lombok.experimental.SuperBuilder class Child extends Parent<Integer> {
+    public static abstract @java.lang.SuppressWarnings("all") @lombok.Generated class ChildBuilder<C extends SuperBuilderWithExcludes.Child, B extends SuperBuilderWithExcludes.Child.ChildBuilder<C, B>> extends Parent.ParentBuilder<Integer, C, B> {
+      private @java.lang.SuppressWarnings("all") @lombok.Generated double doubleField;
+      private @java.lang.SuppressWarnings("all") @lombok.Generated long randomFieldC;
+
+      public ChildBuilder() {
+        super();
+      }
+
+      /**
+       * @return {@code this}.
+       */
+      public @java.lang.SuppressWarnings("all") @lombok.Generated B doubleField(final double doubleField) {
+        this.doubleField = doubleField;
+        return self();
+      }
+
+      /**
+       * @return {@code this}.
+       */
+      public @java.lang.SuppressWarnings("all") @lombok.Generated B randomFieldC(final long randomFieldC) {
+        this.randomFieldC = randomFieldC;
+        return self();
+      }
+
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated B self();
+
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated C build();
+
+      public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+        return (((((("SuperBuilderWithExcludes.Child.ChildBuilder(super=" + super.toString()) + ", doubleField=") + this.doubleField) + ", randomFieldC=") + this.randomFieldC) + ")");
+      }
+    }
+
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated class ChildBuilderImpl extends SuperBuilderWithExcludes.Child.ChildBuilder<SuperBuilderWithExcludes.Child, SuperBuilderWithExcludes.Child.ChildBuilderImpl> {
+      private ChildBuilderImpl() {
+        super();
+      }
+
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated SuperBuilderWithExcludes.Child.ChildBuilderImpl self() {
+        return this;
+      }
+
+      public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated SuperBuilderWithExcludes.Child build() {
+        return new SuperBuilderWithExcludes.Child(this);
+      }
+    }
+
+    private double doubleField;
+    private @lombok.Builder.Exclude long excludedChildField;
+    private long randomFieldC;
+
+    protected @java.lang.SuppressWarnings("all") @lombok.Generated Child(final SuperBuilderWithExcludes.Child.ChildBuilder<?, ?> b) {
+      super(b);
+      this.doubleField = b.doubleField;
+      this.randomFieldC = b.randomFieldC;
+    }
+
+    public static @java.lang.SuppressWarnings("all") @lombok.Generated SuperBuilderWithExcludes.Child.ChildBuilder<?, ?> builder() {
+      return new SuperBuilderWithExcludes.Child.ChildBuilderImpl();
+    }
+  }
+
+  public SuperBuilderWithExcludes() {
+    super();
+  }
+}

--- a/test/transform/resource/before/BuilderExcludes.java
+++ b/test/transform/resource/before/BuilderExcludes.java
@@ -1,0 +1,8 @@
+import lombok.Builder;
+
+@Builder
+public class BuilderExcludes {
+    long x = System.currentTimeMillis();
+    final int y = 5;
+    @Builder.Exclude int z;
+}

--- a/test/transform/resource/before/BuilderExcludes.java
+++ b/test/transform/resource/before/BuilderExcludes.java
@@ -2,7 +2,7 @@ import lombok.Builder;
 
 @Builder
 public class BuilderExcludes {
-    long x = System.currentTimeMillis();
-    final int y = 5;
+    long x;
+    int y;
     @Builder.Exclude int z;
 }

--- a/test/transform/resource/before/BuilderExcludesWarnings.java
+++ b/test/transform/resource/before/BuilderExcludesWarnings.java
@@ -1,7 +1,22 @@
 import lombok.Builder;
 
+@Builder
 public class BuilderExcludesWarnings {
-    long x = System.currentTimeMillis();
-    final int y = 5;
+    long x;
+    int y;
     @Builder.Exclude int z;
 }
+
+class NoBuilderButHasExcludes {
+    long x;
+    int y;
+    @Builder.Exclude int z;
+
+    @Builder
+    public NoBuilderButHasExcludes(long x, int y, int z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+}
+

--- a/test/transform/resource/before/BuilderExcludesWarnings.java
+++ b/test/transform/resource/before/BuilderExcludesWarnings.java
@@ -1,0 +1,7 @@
+import lombok.Builder;
+
+public class BuilderExcludesWarnings {
+    long x = System.currentTimeMillis();
+    final int y = 5;
+    @Builder.Exclude int z;
+}

--- a/test/transform/resource/before/BuilderExcludesWithAllArgsConstructor.java
+++ b/test/transform/resource/before/BuilderExcludesWithAllArgsConstructor.java
@@ -1,0 +1,10 @@
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+public class BuilderExcludesWithAllArgsConstructor {
+    long x;
+    int y;
+    @Builder.Exclude int z;
+}

--- a/test/transform/resource/before/BuilderExcludesWithDefault.java
+++ b/test/transform/resource/before/BuilderExcludesWithDefault.java
@@ -1,0 +1,8 @@
+import lombok.Builder;
+
+@Builder
+public class BuilderExcludesWithDefault {
+    long x;
+    int y;
+    @Builder.Exclude @Builder.Default int z = 5;
+}

--- a/test/transform/resource/before/SuperBuilderWithExcludes.java
+++ b/test/transform/resource/before/SuperBuilderWithExcludes.java
@@ -1,0 +1,17 @@
+public class SuperBuilderWithExcludes {
+    @lombok.experimental.SuperBuilder
+    public static class Parent<N extends Number> {
+        @lombok.Builder.Exclude
+        private long excludedParentField;
+        private N numberField;
+        private long randomFieldP;
+    }
+
+    @lombok.experimental.SuperBuilder
+    public static class Child extends Parent<Integer> {
+        private double doubleField;
+        @lombok.Builder.Exclude
+        private long excludedChildField;
+        private long randomFieldC;
+    }
+}

--- a/test/transform/resource/messages-delombok/BuilderExcludesWarnings.java.messages
+++ b/test/transform/resource/messages-delombok/BuilderExcludesWarnings.java.messages
@@ -1,0 +1,1 @@
+13 @Builder.Exclude requires @Builder or @SuperBuilder on the class for it to mean anything.

--- a/test/transform/resource/messages-ecj/BuilderExcludesWarnings.java.messages
+++ b/test/transform/resource/messages-ecj/BuilderExcludesWarnings.java.messages
@@ -1,0 +1,1 @@
+13 @Builder.Exclude requires @Builder or @SuperBuilder on the class for it to mean anything.


### PR DESCRIPTION
relates to #2307 , #3283 , #3713 

## Motivation
I know that #2307 has been closed but from the discussion thread I realized that many others were having the same issues I was: that some fields need not be part of a builder (or whatever creation pattern the class is using).

I understand that there is the option of creating a static method/constructor and annotating it with `@Builder` to achieve exclusion of field(s). However, I would argue that a similar argument could have been made for default values as well. Yet, we have a `@Builder.Default` which is a super useful feature to have!

My use cases specifically was with regards to JPA Entity classes where I wanted to hide certain non-insertable/non-updatable fields in a JPA Entity from users attempting to build an Entity object. While using `@Setter`, this was simple enough with `@Setter(AccessLevel.PRIVATE)`, but I wanted to use `@Builder` since the entities were large and complex. There I had no options with regards to excluding these fields. Not excluding them would mislead the users since such fields are not persisted in the database even when initialized so I was forced to use Setters.


I did not want to badger the maintainers with excessive argumentation so I thought a "POC" might better demonstrate what such an idea would like and would take the discussion forward more constructively. I would greatly appreciate any and all feedback.

## Implementation 
The basic idea is that if the `@Builder`/`@SuperBuilder` annotation is on a type, no setter methods will be generated in the builder for the fields marked with `@Builder.Exclude`.  This means that although the builder class will contain all the fields(so as not to break any existing logic of mapping the builder class to the annotated class through a constructor, generated for builder or maybe through `@AllAgsConstructor`). However,  it will not be possible to set the value of the excluded field before calling the build() method.
It is somewhat similar in use(not implementation) to `@Builder.Default`:
```
@Builder
public class User {

    // field setter method will not be generated in builder
    @Builder.Exclude
    private int id;

    private String name;

}
```
The builder for this class will not contain a `User.UserBuilder id(int id)` method.

 I've added a warning similar to the one for `@Builder.Default` for when the annotation is not on type.  As is the case with `@Builder.Default`, the `@Builder.Exclude` annotation holds no meaning when used without a `@Builder` on the type. if the `@Builder` is on a constructor or a static method, the exclusion will not take place

I've added a few test cases to demonstrate its working. 

I'll add more test cases to the PR if the direction looks promising! 
