### PR TITLE
Add null check for compilation unit

### DIFF
--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -2838,6 +2838,7 @@ public class EclipseHandlerUtil {
 		if (doc == null) return;
 		
 		ICompilationUnit compilationUnit = cud.compilationResult.compilationUnit;
+		if (compilationUnit == null) return;
 		if (compilationUnit.getClass().equals(COMPILATION_UNIT)) {
 			try {
 				compilationUnit = (ICompilationUnit) Permit.invoke(COMPILATION_UNIT_ORIGINAL_FROM_CLONE, compilationUnit);

--- a/test/eclipse/resource/noerrors/builderJavadoc/BuilderJavadoc.java
+++ b/test/eclipse/resource/noerrors/builderJavadoc/BuilderJavadoc.java
@@ -1,0 +1,14 @@
+package pkg;
+
+import lombok.Builder;
+
+@Builder
+public class BuilderJavadoc {
+	/**
+	 * Javadoc
+	 * 
+	 * @param test ABC
+	 * @return test
+	 */
+	private String test;
+}

--- a/test/eclipse/resource/noerrors/builderJavadoc/Usage.java
+++ b/test/eclipse/resource/noerrors/builderJavadoc/Usage.java
@@ -1,0 +1,7 @@
+package pkg;
+
+public class Usage {
+	public void test() {
+		BuilderJavadoc.builder().test("test").build();
+	}
+}

--- a/test/eclipse/src/lombok/eclipse/compile/NoErrorsTest.java
+++ b/test/eclipse/src/lombok/eclipse/compile/NoErrorsTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IProblemRequestor;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.junit.Rule;
@@ -47,6 +48,19 @@ public class NoErrorsTest {
 	public void fieldNameConstantsInAnnotation() throws Exception {
 		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("Usage.java");
 		
+		List<IProblem> problems = collectProblems(cu);
+		assertTrue(problems.isEmpty());
+	}
+	
+	@Test
+	public void builderJavadoc() throws Exception {
+		ICompilationUnit cu = setup.getPackageFragment().getCompilationUnit("Usage.java");
+		
+		List<IProblem> problems = collectProblems(cu);
+		assertTrue(problems.isEmpty());
+	}
+	
+	private List<IProblem> collectProblems(ICompilationUnit cu) throws JavaModelException {
 		final List<IProblem> problems = new ArrayList<IProblem>();
 		final IProblemRequestor requestor = new IProblemRequestor() {
 			@Override
@@ -83,7 +97,6 @@ public class NoErrorsTest {
 			workingCopy.discardWorkingCopy();
 		}
 		
-		System.out.println(problems);
-		assertTrue(problems.isEmpty());
+		return problems;
 	}
 }


### PR DESCRIPTION
This PR fixes #3706.

I couldn't figure out why it is null in some cases, but added a test to make sure it didn't break again.