### PR TITLE
[doc] remove unnecessary import in FieldNameConstants example

### DIFF
--- a/website/usageExamples/experimental/FieldNameConstantsExample_pre.jpage
+++ b/website/usageExamples/experimental/FieldNameConstantsExample_pre.jpage
@@ -1,5 +1,4 @@
 import lombok.experimental.FieldNameConstants;
-import lombok.AccessLevel;
 
 @FieldNameConstants
 public class FieldNameConstantsExample {


### PR DESCRIPTION
Just stumbled across this unnecessary import in the snippet: https://projectlombok.org/features/experimental/FieldNameConstants