### PR TITLE
Exclude the classloader for jasperreports-maven-plugin due to a classloader conflict with ECJ

### DIFF
--- a/doc/changelog.markdown
+++ b/doc/changelog.markdown
@@ -3,6 +3,8 @@ Lombok Changelog
 
 ### v1.18.35 "Edgy Guinea Pig"
 * We recently released v1.18.34; there is no edge release since then.
+* BUGFIX: Eclipse projects using the `com.pro-crafting.tools:jasperreports-maven-plugin` will now compile.
+
 
 ### v1.18.34 (June 28th, 2024)
 * PLATFORM: Added support for Eclipse 2024-06; you'd get some `NoSuchMethodError` traces in your logs if using `@Builder` or `@Singular` prior to this fix. [Issue #3638](https://github.com/projectlombok/lombok/issues/3638).

--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -63,6 +63,7 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 					if (loader.getClass().getName().startsWith("org.sonar.classloader.")) return false; // Relevant to bug #2351
 					if (loader.toString().contains("com.alexnederlof:jasperreports-plugin")) return false; //Relevant to bug #1036
 					if (loader.toString().contains("com.pro-crafting.tools:jasperreports-plugin")) return false; //Relevant to bug #1036
+					if (loader.toString().contains("com.pro-crafting.tools:jasperreports-maven-plugin")) return false; //Relevant to bug #1036
 				}
 				if (!(loader instanceof URLClassLoader)) return true;
 				ClassLoader parent = loader.getParent();


### PR DESCRIPTION
I am currently in the process of renaming the plugin from jasperreports-plugin to jasperreports-maven-plugin.