### PR TITLE
[fixes #3116] Add multi round support for mapstruct

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Lombok contributors in alphabetical order:
 
 Adam Juraszek <juriad@gmail.com>
+Aleksandar Kanchev <136312841+kanchev1@users.noreply.github.com>
 Aleksandr Zhelezniak <lekan1992@gmail.com>
 Amine Touzani <ttzn.dev@gmail.com>
 Andre Brait <andrebrait@gmail.com>

--- a/src/bindings/mapstruct/lombok/mapstruct/NotifierHider.java
+++ b/src/bindings/mapstruct/lombok/mapstruct/NotifierHider.java
@@ -1,35 +1,37 @@
 package lombok.mapstruct;
 
-import java.lang.reflect.Field;
-
-import javax.lang.model.type.TypeMirror;
-
 import org.mapstruct.ap.spi.AstModifyingAnnotationProcessor;
 
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.type.TypeMirror;
+import java.util.List;
+
+/**
+ * Report to MapStruct that a type is completed when there aren't any Lombok annotations left on it. Lombok annotations
+ * are removed whenever a class is processed. This way, annotations which require multiple rounds to process are also
+ * correctly handled, and MapStruct processing will be delayed until Lombok completely finishes processing required types.
+ */
 class NotifierHider {
 	
 	public static class AstModificationNotifier implements AstModifyingAnnotationProcessor {
-		private static Field lombokInvoked;
-		
-		@Override public boolean isTypeComplete(TypeMirror type) {
-			if (System.getProperty("lombok.disable") != null) return true;
-			return isLombokInvoked();
-		}
-		
-		private static boolean isLombokInvoked() {
-			if (lombokInvoked != null) {
-				try {
-					return lombokInvoked.getBoolean(null);
-				} catch (Exception e) {}
+
+		@Override
+		public boolean isTypeComplete(final TypeMirror typeMirror) {
+			final List<? extends AnnotationMirror> annotationMirrors = typeMirror.getAnnotationMirrors();
+			if (annotationMirrors == null || annotationMirrors.isEmpty()) {
 				return true;
 			}
-			
-			try {
-				Class<?> data = Class.forName("lombok.launch.AnnotationProcessorHider$AstModificationNotifierData");
-				lombokInvoked = data.getField("lombokInvoked");
-				return lombokInvoked.getBoolean(null);
-			} catch (Exception e) {}
+
+			for (final AnnotationMirror annotationMirror : annotationMirrors) {
+				final String annotationName = String.valueOf(annotationMirror);
+				// check for ClaimingProcessor's SupportedAnnotationTypes
+				if (annotationName.startsWith("@lombok.")) {
+					return false;
+				}
+			}
+
 			return true;
+
 		}
 	}
 }

--- a/src/launch/lombok/launch/AnnotationProcessor.java
+++ b/src/launch/lombok/launch/AnnotationProcessor.java
@@ -39,10 +39,6 @@ import sun.misc.Unsafe;
 
 class AnnotationProcessorHider {
 
-	public static class AstModificationNotifierData {
-		public volatile static boolean lombokInvoked = false;
-	}
-	
 	public static class AnnotationProcessor extends AbstractProcessor {
 		private final AbstractProcessor instance = createWrappedInstance();
 		
@@ -60,7 +56,6 @@ class AnnotationProcessorHider {
 		
 		@Override public void init(ProcessingEnvironment processingEnv) {
 			disableJava9SillyWarning();
-			AstModificationNotifierData.lombokInvoked = true;
 			instance.init(processingEnv);
 			super.init(processingEnv);
 		}


### PR DESCRIPTION
Report to MapStruct that a type is completed when there aren't any Lombok annotations left on it. Lombok annotations are removed whenever a class is processed. This way, annotations which require multiple rounds to process are also correctly handled, and MapStruct processing will be delayed until Lombok completely finishes processing required types.

Fixes issues with e.g. @FieldNameConstants and @Builder (see #3116)