### PR TITLE
Remove signature files from eclipse plugin jars

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -108,6 +108,7 @@ jobs:
         - eclipse-202312
         - eclipse-202403
         - eclipse-202406
+        - eclipse-202409
         - eclipse-I-build
         - eclipse-oxygen-full
         - eclipse-2022-03-full
@@ -115,6 +116,7 @@ jobs:
         - eclipse-2023-12-full
         - eclipse-2024-03-full
         - eclipse-2024-06-full
+        - eclipse-2024-09-full
         - eclipse-I-build-full
         - ecj11
         - ecj14

--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -35,6 +35,7 @@
 		<conf name="eclipse-202312" />
 		<conf name="eclipse-202403" />
 		<conf name="eclipse-202406" />
+		<conf name="eclipse-202409" />
 		
 		<conf name="mapstruct" />
 	</configurations>
@@ -148,7 +149,7 @@
 		<dependency org="org.eclipse.platform" name="org.eclipse.core.jobs" rev="3.15.100" conf="eclipse-202312->default" transitive="false" />
 		<dependency org="org.eclipse.platform" name="org.eclipse.osgi" rev="3.18.600" conf="eclipse-202312->default" transitive="false" />
 		<dependency org="org.eclipse.platform" name="org.eclipse.text" rev="3.13.100" conf="eclipse-202312->default" transitive="false" />
-			
+		
 		<dependency org="org.eclipse.platform" name="org.eclipse.core.runtime" rev="3.31.0" conf="eclipse-202403->default" transitive="false" />
 		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.core" rev="3.37.0" conf="eclipse-202403->default" transitive="false" />
 		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.ui" rev="3.32.0" conf="eclipse-202403->default" transitive="false" />
@@ -161,7 +162,7 @@
 		<dependency org="org.eclipse.platform" name="org.eclipse.core.jobs" rev="3.15.200" conf="eclipse-202403->default" transitive="false" />
 		<dependency org="org.eclipse.platform" name="org.eclipse.osgi" rev="3.19.0" conf="eclipse-202403->default" transitive="false" />
 		<dependency org="org.eclipse.platform" name="org.eclipse.text" rev="3.14.0" conf="eclipse-202403->default" transitive="false" />
-			
+		
 		<dependency org="org.eclipse.platform" name="org.eclipse.core.runtime" rev="3.31.100" conf="eclipse-202406->default" transitive="false" />
 		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.core" rev="3.38.0" conf="eclipse-202406->default" transitive="false" />
 		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.ui" rev="3.32.100" conf="eclipse-202406->default" transitive="false" />
@@ -174,6 +175,19 @@
 		<dependency org="org.eclipse.platform" name="org.eclipse.core.jobs" rev="3.15.300" conf="eclipse-202406->default" transitive="false" />
 		<dependency org="org.eclipse.platform" name="org.eclipse.osgi" rev="3.20.0" conf="eclipse-202406->default" transitive="false" />
 		<dependency org="org.eclipse.platform" name="org.eclipse.text" rev="3.14.100" conf="eclipse-202406->default" transitive="false" />
+		
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.runtime" rev="3.31.100" conf="eclipse-202409->default" transitive="false" />
+		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.core" rev="3.39.0" conf="eclipse-202409->default" transitive="false" />
+		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.ui" rev="3.33.0" conf="eclipse-202409->default" transitive="false" />
+		<dependency org="org.eclipse.jdt" name="ecj" rev="3.39.0" conf="eclipse-202409->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.common" rev="3.19.100" conf="eclipse-202409->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.registry" rev="3.12.100" conf="eclipse-202409->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.app" rev="1.7.200" conf="eclipse-202409->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.resources" rev="3.21.0" conf="eclipse-202409->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.contenttype" rev="3.9.500" conf="eclipse-202409->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.jobs" rev="3.15.400" conf="eclipse-202409->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.osgi" rev="3.21.0" conf="eclipse-202409->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.text" rev="3.14.100" conf="eclipse-202409->default" transitive="false" />
 		
 		<!-- integration with other libraries -->
 		<dependency org="org.mapstruct" name="mapstruct-processor" rev="1.3.1.Final" conf="mapstruct->default" transitive="false" />

--- a/buildScripts/setup.ant.xml
+++ b/buildScripts/setup.ant.xml
@@ -180,6 +180,10 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 		<fetchdep.eclipse.osgi name="2024-06" version="4.32" />
 	</target>
 	
+	<target name="deps.eclipse.2024-09" depends="deps.rtstubs18, compile.support">
+		<fetchdep.eclipse.osgi name="2024-09" version="4.33" />
+	</target>
+	
 	<target name="deps.eclipse.integration" depends="deps.rtstubs18, compile.support">
 		<fetchdep.eclipse.osgi name="I-build" version="I-builds" />
 	</target>

--- a/buildScripts/tests.ant.xml
+++ b/buildScripts/tests.ant.xml
@@ -233,6 +233,11 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 		<test.eclipse-X version="202406" />
 	</target>
 	
+	<target name="test.eclipse-202409" depends="test.compile, test.formatter.compile" description="runs the tests on your default VM, testing the 2024-09 release of eclipse">
+		<fetchdep.eclipse version="202409" />
+		<test.eclipse-X version="202409" />
+	</target>
+	
 	<target name="test.eclipse-I-build" depends="test.compile, test.formatter.compile, deps.rtstubs18, compile.support" description="runs the tests on your default VM, testing the latest integration build of eclipse">
 		<fetchdep.eclipse.updatesite name="I-build" version="I-builds" target="lib/" resolveDependencies="false">
 			<bundles>
@@ -311,6 +316,10 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 	
 	<target name="test.eclipse-2024-06-full" depends="test.eclipse.compile, test.formatter.compile, deps.eclipse.2024-06" description="runs the full eclipse tests on your default VM, testing the 2024-06 release of eclipse">
 		<test.eclipse-X-full version="2024-06" />
+	</target>
+	
+	<target name="test.eclipse-2024-09-full" depends="test.eclipse.compile, test.formatter.compile, deps.eclipse.2024-09" description="runs the full eclipse tests on your default VM, testing the 2024-09 release of eclipse">
+		<test.eclipse-X-full version="2024-09" />
 	</target>
 	
 	<target name="test.eclipse-I-build-full" depends="test.eclipse.compile, test.formatter.compile, deps.eclipse.integration" description="runs the full eclipse tests on your default VM, testing the latest integration build of eclipse">

--- a/test/core/src/lombok/RunTestsViaEcj.java
+++ b/test/core/src/lombok/RunTestsViaEcj.java
@@ -95,6 +95,7 @@ public class RunTestsViaEcj extends AbstractRunTests {
 		warnings.put(CompilerOptions.OPTION_ReportNonStaticAccessToStatic, "warning");
 		warnings.put("org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures", "ignore");
 		warnings.put(CompilerOptions.OPTION_Source, (ecjCompilerVersion < 9 ? "1." : "") + ecjCompilerVersion);
+		warnings.put(CompilerOptions.OPTION_TargetPlatform, (ecjCompilerVersion < 9 ? "1." : "") + ecjCompilerVersion);
 		warnings.put("org.eclipse.jdt.core.compiler.codegen.useStringConcatFactory", "disabled");
 		options.set(warnings);
 		return options;

--- a/test/core/src/lombok/RunTestsViaEcj.java
+++ b/test/core/src/lombok/RunTestsViaEcj.java
@@ -79,7 +79,6 @@ public class RunTestsViaEcj extends AbstractRunTests {
 		options.targetJDK = ecjCompilerVersionConstant;
 		options.docCommentSupport = false;
 		options.parseLiteralExpressionsAsConstants = true;
-		options.inlineJsrBytecode = true;
 		options.reportUnusedDeclaredThrownExceptionExemptExceptionAndThrowable = false;
 		options.reportUnusedDeclaredThrownExceptionIncludeDocCommentReference = false;
 		options.reportUnusedDeclaredThrownExceptionWhenOverriding = false;


### PR DESCRIPTION
This PR fixes #3728

I also added test targets for eclipse 2024-09 and removed the deprecated `inlineJsrBytecode` parameter.