### PR TITLE
Update annotation value index

### DIFF
--- a/src/core/lombok/core/AnnotationValues.java
+++ b/src/core/lombok/core/AnnotationValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2022 The Project Lombok Authors.
+ * Copyright (C) 2009-2024 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -182,6 +182,7 @@ public class AnnotationValues<A extends Annotation> {
 					"I can't make sense of this annotation value. Try using a fully qualified literal.", idx);
 			}
 			out.add((String) result);
+			idx++;
 		}
 		
 		return Collections.unmodifiableList(out);

--- a/test/core/src/lombok/CompilerMessageMatcher.java
+++ b/test/core/src/lombok/CompilerMessageMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 The Project Lombok Authors.
+ * Copyright (C) 2012-2024 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -67,8 +67,7 @@ public class CompilerMessageMatcher {
 	public boolean matches(CompilerMessage message) {
 		outer:
 		for (int i = 0; i < lineNumbers.size(); i++) {
-			//Allow an off-by-1 in line numbers; when running tests that sometimes happens for as yet unknown reasons.
-			if (message.getLine() != lineNumbers.get(i) && message.getLine() -1 != lineNumbers.get(i)) continue;
+			if (message.getLine() != lineNumbers.get(i)) continue;
 			for (String token : messages.get(i)) {
 				if (!message.getMessage().contains(token)) continue outer;
 			}

--- a/test/core/src/lombok/CompilerMessageMatcher.java
+++ b/test/core/src/lombok/CompilerMessageMatcher.java
@@ -36,6 +36,7 @@ import lombok.javac.CapturingDiagnosticListener.CompilerMessage;
 public class CompilerMessageMatcher {
 	/** Line Number (starting at 1) */
 	private final List<Integer> lineNumbers = new ArrayList<Integer>();
+	private final List<Long> positions = new ArrayList<Long>();
 	private final List<List<String>> messages = new ArrayList<List<String>>();
 	private boolean optional;
 	
@@ -48,6 +49,7 @@ public class CompilerMessageMatcher {
 	public static CompilerMessageMatcher asCompilerMessageMatcher(CompilerMessage message) {
 		CompilerMessageMatcher cmm = new CompilerMessageMatcher();
 		cmm.lineNumbers.add((int) message.getLine());
+		cmm.positions.add(message.getPosition());
 		cmm.messages.add(Arrays.asList(message.getMessage().split("\\s+")));
 		return cmm;
 	}
@@ -55,7 +57,9 @@ public class CompilerMessageMatcher {
 	@Override public String toString() {
 		StringBuilder out = new StringBuilder();
 		for (int i = 0; i < lineNumbers.size(); i++) {
-			out.append(lineNumbers.get(i)).append(" ");
+			out.append(lineNumbers.get(i));
+			if (positions.get(i) != null) out.append(":").append(positions.get(i));
+			out.append(" ");
 			for (String part : messages.get(i)) out.append(part).append(" ");
 			if (out.length() > 0) out.setLength(out.length() - 1);
 			out.append(" |||| ");
@@ -68,6 +72,7 @@ public class CompilerMessageMatcher {
 		outer:
 		for (int i = 0; i < lineNumbers.size(); i++) {
 			if (message.getLine() != lineNumbers.get(i)) continue;
+			if (positions.get(i) != null && !positions.get(i).equals(message.getPosition())) continue;
 			for (String token : messages.get(i)) {
 				if (!message.getMessage().contains(token)) continue outer;
 			}
@@ -87,7 +92,7 @@ public class CompilerMessageMatcher {
 		return out;
 	}
 	
-	private static final Pattern PATTERN = Pattern.compile("^(-?\\d+) (.*)$");
+	private static final Pattern PATTERN = Pattern.compile("^(-?\\d+)(?::(\\d+))? (.*)$");
 	
 	private static CompilerMessageMatcher read(String line) {
 		line = line.trim();
@@ -107,7 +112,8 @@ public class CompilerMessageMatcher {
 			Matcher m = PATTERN.matcher(part);
 			if (!m.matches()) throw new IllegalArgumentException("Typo in test file: " + line);
 			cmm.lineNumbers.add(Integer.parseInt(m.group(1)));
-			cmm.messages.add(Arrays.asList(m.group(2).split("\\s+")));
+			cmm.positions.add(m.group(2) != null ? Long.parseLong(m.group(2)) : null);
+			cmm.messages.add(Arrays.asList(m.group(3).split("\\s+")));
 		}
 		
 		return cmm;

--- a/test/transform/resource/before/EqualsAndHashCodeOfAndExcludeError.java
+++ b/test/transform/resource/before/EqualsAndHashCodeOfAndExcludeError.java
@@ -1,0 +1,14 @@
+// skip-compare-contents
+@lombok.EqualsAndHashCode(of={"x", Const.A})
+final class EqualsAndHashCodeErrorOf {
+	int x;
+}
+
+@lombok.EqualsAndHashCode(exclude={"x", Const.A})
+final class EqualsAndHashCodeErrorExclude {
+	int x;
+}
+
+class Const {
+	static final String A = "A";
+}

--- a/test/transform/resource/messages-delombok/DelegateFlagUsage.java.messages
+++ b/test/transform/resource/messages-delombok/DelegateFlagUsage.java.messages
@@ -1,1 +1,1 @@
-4 Use of @Delegate is flagged according to lombok configuration.
+5 Use of @Delegate is flagged according to lombok configuration.

--- a/test/transform/resource/messages-delombok/DelegateOnStatic.java.messages
+++ b/test/transform/resource/messages-delombok/DelegateOnStatic.java.messages
@@ -1,2 +1,2 @@
-6 @Delegate is legal only on instance fields or no-argument instance methods.
-10 @Delegate is legal only on instance fields or no-argument instance methods.
+7 @Delegate is legal only on instance fields or no-argument instance methods.
+11 @Delegate is legal only on instance fields or no-argument instance methods.

--- a/test/transform/resource/messages-delombok/DelegateRecursion.java.messages
+++ b/test/transform/resource/messages-delombok/DelegateRecursion.java.messages
@@ -1,1 +1,1 @@
-4 @Delegate does not support recursion (delegating to a type that itself has @Delegate members). Member "inner" is @Delegate in type "DelegateRecursionCenter"
+5 @Delegate does not support recursion (delegating to a type that itself has @Delegate members). Member "inner" is @Delegate in type "DelegateRecursionCenter"

--- a/test/transform/resource/messages-delombok/EqualsAndHashCodeOfAndExcludeError.java.messages
+++ b/test/transform/resource/messages-delombok/EqualsAndHashCodeOfAndExcludeError.java.messages
@@ -1,0 +1,2 @@
+2:60 You must use constant literals in lombok annotations; they cannot be references to (static) fields.
+7:160 You must use constant literals in lombok annotations; they cannot be references to (static) fields.

--- a/test/transform/resource/messages-delombok/EqualsAndHashCodeOfAndExcludeWarn.java.messages
+++ b/test/transform/resource/messages-delombok/EqualsAndHashCodeOfAndExcludeWarn.java.messages
@@ -1,2 +1,2 @@
-1 This field does not exist.
-6 This field does not exist, or would have been excluded anyway.
+2 This field does not exist.
+7 This field does not exist, or would have been excluded anyway.

--- a/test/transform/resource/messages-delombok/ExtensionMethodAmbiguousFunctional.java.messages
+++ b/test/transform/resource/messages-delombok/ExtensionMethodAmbiguousFunctional.java.messages
@@ -1,1 +1,1 @@
-9 reference to ambiguous is ambiguous both method <T,R>ambiguous(T,java.util.function.Function<T,R>) in ExtensionMethodAmbiguousFunctional.Extensions and method <T>ambiguous(T,java.util.function.Consumer<T>) in ExtensionMethodAmbiguousFunctional.Extensions match
+10 reference to ambiguous is ambiguous both method <T,R>ambiguous(T,java.util.function.Function<T,R>) in ExtensionMethodAmbiguousFunctional.Extensions and method <T>ambiguous(T,java.util.function.Consumer<T>) in ExtensionMethodAmbiguousFunctional.Extensions match

--- a/test/transform/resource/messages-delombok/JacksonizedSuperBuilderWithJsonDeserialize.java.messages
+++ b/test/transform/resource/messages-delombok/JacksonizedSuperBuilderWithJsonDeserialize.java.messages
@@ -1,1 +1,1 @@
-1 @JsonDeserialize already exists on class. Either delete @JsonDeserialize, or remove @Jacksonized and manually configure Jackson.
+2 @JsonDeserialize already exists on class. Either delete @JsonDeserialize, or remove @Jacksonized and manually configure Jackson.

--- a/test/transform/resource/messages-delombok/LockedInRecord.java.messages
+++ b/test/transform/resource/messages-delombok/LockedInRecord.java.messages
@@ -1,1 +1,1 @@
-5 @Locked is legal only on methods in classes and enums.
+6 @Locked is legal only on methods in classes and enums.

--- a/test/transform/resource/messages-delombok/NonNullOnParameter.java.messages
+++ b/test/transform/resource/messages-delombok/NonNullOnParameter.java.messages
@@ -1,1 +1,1 @@
-22 @NonNull is meaningless on a primitive.
+23 @NonNull is meaningless on a primitive.

--- a/test/transform/resource/messages-delombok/OnXFlagUsage.java.messages
+++ b/test/transform/resource/messages-delombok/OnXFlagUsage.java.messages
@@ -1,6 +1,6 @@
-9 Use of @Getter(onMethod=...) is flagged according to lombok configuration.
-10 Use of @Setter(onMethod=...) is flagged according to lombok configuration.
-10 Use of @Setter(onParam=...) is flagged according to lombok configuration.
-11 Use of @NoArgsConstructor(onConstructor=...) is flagged according to lombok configuration.
-12 Use of @AllArgsConstructor(onConstructor=...) is flagged according to lombok configuration.
-18 Use of @RequiredArgsConstructor(onConstructor=...) is flagged according to lombok configuration.
+10 Use of @Getter(onMethod=...) is flagged according to lombok configuration.
+11 Use of @Setter(onMethod=...) is flagged according to lombok configuration.
+11 Use of @Setter(onParam=...) is flagged according to lombok configuration.
+12 Use of @NoArgsConstructor(onConstructor=...) is flagged according to lombok configuration.
+13 Use of @AllArgsConstructor(onConstructor=...) is flagged according to lombok configuration.
+19 Use of @RequiredArgsConstructor(onConstructor=...) is flagged according to lombok configuration.

--- a/test/transform/resource/messages-delombok/SynchronizedInRecord.java.messages
+++ b/test/transform/resource/messages-delombok/SynchronizedInRecord.java.messages
@@ -1,1 +1,1 @@
-5 @Synchronized is legal only on methods in classes and enums.
+6 @Synchronized is legal only on methods in classes and enums.

--- a/test/transform/resource/messages-delombok/ValErrors.java.messages
+++ b/test/transform/resource/messages-delombok/ValErrors.java.messages
@@ -1,2 +1,2 @@
-6 Cannot use 'val' here because initializer expression does not have a representable type: Type cannot be resolved
-10 'val' is not compatible with array initializer expressions. Use the full form (new int[] { ... } instead of just { ... })
+7 Cannot use 'val' here because initializer expression does not have a representable type: Type cannot be resolved
+11 'val' is not compatible with array initializer expressions. Use the full form (new int[] { ... } instead of just { ... })

--- a/test/transform/resource/messages-delombok/ValInBasicFor.java.messages
+++ b/test/transform/resource/messages-delombok/ValInBasicFor.java.messages
@@ -1,1 +1,1 @@
-7 'val' is not allowed in old-style for loops
+8 'val' is not allowed in old-style for loops

--- a/test/transform/resource/messages-delombok/VarInForOldMulti.java.messages
+++ b/test/transform/resource/messages-delombok/VarInForOldMulti.java.messages
@@ -1,1 +1,1 @@
-6 'var' is not allowed in old-style for loops if there is more than 1 initializer
+7 'var' is not allowed in old-style for loops if there is more than 1 initializer

--- a/test/transform/resource/messages-delombok/VarNullInit.java.messages
+++ b/test/transform/resource/messages-delombok/VarNullInit.java.messages
@@ -1,1 +1,1 @@
-5 variable initializer is 'null'
+6 variable initializer is 'null'

--- a/test/transform/resource/messages-delombok/VarWarning.java.messages
+++ b/test/transform/resource/messages-delombok/VarWarning.java.messages
@@ -1,1 +1,1 @@
-6 Use of var is flagged according to lombok configuration
+7 Use of var is flagged according to lombok configuration.

--- a/test/transform/resource/messages-ecj/DelegateFlagUsage.java.messages
+++ b/test/transform/resource/messages-ecj/DelegateFlagUsage.java.messages
@@ -1,1 +1,1 @@
-4 Use of @Delegate is flagged according to lombok configuration.
+5 Use of @Delegate is flagged according to lombok configuration.

--- a/test/transform/resource/messages-ecj/DelegateOnGetter.java.messages
+++ b/test/transform/resource/messages-ecj/DelegateOnGetter.java.messages
@@ -1,2 +1,2 @@
-1 The type Delegate is deprecated
-6 The type Delegate is deprecated
+2 The type Delegate is deprecated
+7 The type Delegate is deprecated

--- a/test/transform/resource/messages-ecj/DelegateOnStatic.java.messages
+++ b/test/transform/resource/messages-ecj/DelegateOnStatic.java.messages
@@ -1,2 +1,2 @@
-6 @Delegate is legal only on instance fields or no-argument instance methods.
-10 @Delegate is legal only on instance fields or no-argument instance methods.
+7 @Delegate is legal only on instance fields or no-argument instance methods.
+11 @Delegate is legal only on instance fields or no-argument instance methods.

--- a/test/transform/resource/messages-ecj/DelegateRecursion.java.messages
+++ b/test/transform/resource/messages-ecj/DelegateRecursion.java.messages
@@ -1,1 +1,1 @@
-4 @Delegate does not support recursion (delegating to a type that itself has @Delegate members). Member "inner" is @Delegate in type "DelegateRecursionCenter"
+5 @Delegate does not support recursion (delegating to a type that itself has @Delegate members). Member "inner" is @Delegate in type "DelegateRecursionCenter"

--- a/test/transform/resource/messages-ecj/EqualsAndHashCodeOfAndExcludeError.java.messages
+++ b/test/transform/resource/messages-ecj/EqualsAndHashCodeOfAndExcludeError.java.messages
@@ -1,0 +1,2 @@
+2:60 You must use constant literals in lombok annotations; they cannot be references to (static) fields.
+7:160 You must use constant literals in lombok annotations; they cannot be references to (static) fields.

--- a/test/transform/resource/messages-ecj/EqualsAndHashCodeOfAndExcludeWarn.java.messages
+++ b/test/transform/resource/messages-ecj/EqualsAndHashCodeOfAndExcludeWarn.java.messages
@@ -1,2 +1,2 @@
-1 This field does not exist.
-6 This field does not exist, or would have been excluded anyway.
+2 This field does not exist.
+7 This field does not exist, or would have been excluded anyway.

--- a/test/transform/resource/messages-ecj/JacksonizedSuperBuilderWithJsonDeserialize.java.messages
+++ b/test/transform/resource/messages-ecj/JacksonizedSuperBuilderWithJsonDeserialize.java.messages
@@ -1,1 +1,1 @@
-1 @JsonDeserialize already exists on class. Either delete @JsonDeserialize, or remove @Jacksonized and manually configure Jackson.
+2 @JsonDeserialize already exists on class. Either delete @JsonDeserialize, or remove @Jacksonized and manually configure Jackson.

--- a/test/transform/resource/messages-ecj/NonNullOnParameter.java.messages
+++ b/test/transform/resource/messages-ecj/NonNullOnParameter.java.messages
@@ -1,3 +1,3 @@
-15 Dead code
-22 @NonNull is meaningless on a primitive.
-28 Dead code
+16 Dead code
+23 @NonNull is meaningless on a primitive.
+29 Dead code

--- a/test/transform/resource/messages-ecj/NonNullPlain.java.messages
+++ b/test/transform/resource/messages-ecj/NonNullPlain.java.messages
@@ -1,1 +1,1 @@
-7 @NonNull is meaningless on a primitive.
+8 @NonNull is meaningless on a primitive.

--- a/test/transform/resource/messages-ecj/OnXFlagUsage.java.messages
+++ b/test/transform/resource/messages-ecj/OnXFlagUsage.java.messages
@@ -1,6 +1,6 @@
-9 Use of @Getter(onMethod=...) is flagged according to lombok configuration.
-10 Use of @Setter(onMethod=...) is flagged according to lombok configuration.
-10 Use of @Setter(onParam=...) is flagged according to lombok configuration.
-11 Use of @NoArgsConstructor(onConstructor=...) is flagged according to lombok configuration.
-12 Use of @AllArgsConstructor(onConstructor=...) is flagged according to lombok configuration.
-18 Use of @RequiredArgsConstructor(onConstructor=...) is flagged according to lombok configuration.
+10 Use of @Getter(onMethod=...) is flagged according to lombok configuration.
+11 Use of @Setter(onMethod=...) is flagged according to lombok configuration.
+11 Use of @Setter(onParam=...) is flagged according to lombok configuration.
+12 Use of @NoArgsConstructor(onConstructor=...) is flagged according to lombok configuration.
+13 Use of @AllArgsConstructor(onConstructor=...) is flagged according to lombok configuration.
+19 Use of @RequiredArgsConstructor(onConstructor=...) is flagged according to lombok configuration.

--- a/test/transform/resource/messages-ecj/ValAnonymousSubclassWithGenerics.java.messages
+++ b/test/transform/resource/messages-ecj/ValAnonymousSubclassWithGenerics.java.messages
@@ -1,1 +1,1 @@
-17 The serializable class  does not declare a static final serialVersionUID field of type long
+18 The serializable class  does not declare a static final serialVersionUID field of type long

--- a/test/transform/resource/messages-ecj/ValInvalidParameter.java.messages
+++ b/test/transform/resource/messages-ecj/ValInvalidParameter.java.messages
@@ -1,9 +1,9 @@
-5 NonExistingClass cannot be resolved to a type
 6 NonExistingClass cannot be resolved to a type
-7 The method nonExisitingMethod(Integer) is undefined for the type ValInvalidParameter
-8 nonExistingObject cannot be resolved
-9 The method nonExistingMethod() is undefined for the type Integer
-10 NonExistingClass cannot be resolved to a type
-11 The method b2(int, int) in the type ValInvalidParameter is not applicable for the arguments (int)
-12 The method a(String) is ambiguous for the type ValInvalidParameter
+7 NonExistingClass cannot be resolved to a type
+8 The method nonExisitingMethod(Integer) is undefined for the type ValInvalidParameter
+9 nonExistingObject cannot be resolved
+10 The method nonExistingMethod() is undefined for the type Integer
+11 NonExistingClass cannot be resolved to a type
+12 The method b2(int, int) in the type ValInvalidParameter is not applicable for the arguments (int)
 13 The method a(String) is ambiguous for the type ValInvalidParameter
+14 The method a(String) is ambiguous for the type ValInvalidParameter

--- a/test/transform/resource/messages-ecj/ValLambda.java.messages
+++ b/test/transform/resource/messages-ecj/ValLambda.java.messages
@@ -1,2 +1,2 @@
-24 Function is a raw type. References to generic type Function<T,R> should be parameterized
 25 Function is a raw type. References to generic type Function<T,R> should be parameterized
+26 Function is a raw type. References to generic type Function<T,R> should be parameterized

--- a/test/transform/resource/messages-ecj/ValRawType.java.messages
+++ b/test/transform/resource/messages-ecj/ValRawType.java.messages
@@ -1,1 +1,1 @@
-13 List is a raw type. References to generic type List<E> should be parameterized
+14 List is a raw type. References to generic type List<E> should be parameterized

--- a/test/transform/resource/messages-ecj/VarInForOldMulti.java.messages
+++ b/test/transform/resource/messages-ecj/VarInForOldMulti.java.messages
@@ -1,1 +1,1 @@
-6 'var' is not allowed in old-style for loops if there is more than 1 initializer
+7 'var' is not allowed in old-style for loops if there is more than 1 initializer

--- a/test/transform/resource/messages-ecj/VarModifier.java.messages
+++ b/test/transform/resource/messages-ecj/VarModifier.java.messages
@@ -1,3 +1,3 @@
-1 The type var is deprecated
-7 The type var is deprecated
+2 The type var is deprecated
 8 The type var is deprecated
+9 The type var is deprecated

--- a/test/transform/resource/messages-ecj/VarNullInit.java.messages
+++ b/test/transform/resource/messages-ecj/VarNullInit.java.messages
@@ -1,1 +1,1 @@
-5 variable initializer is 'null'
+6 variable initializer is 'null'

--- a/test/transform/resource/messages-ecj/VarWarning.java.messages
+++ b/test/transform/resource/messages-ecj/VarWarning.java.messages
@@ -1,1 +1,1 @@
-6 Use of var is flagged according to lombok configuration.
+7 Use of var is flagged according to lombok configuration.

--- a/test/transform/resource/messages-idempotent/LockedTypeMismatch.java.messages
+++ b/test/transform/resource/messages-idempotent/LockedTypeMismatch.java.messages
@@ -1,2 +1,2 @@
-27 cannot find symbol
-31 cannot find symbol
+28 cannot find symbol method readLock() location: java.util.concurrent.locks.Lock
+32 cannot find symbol method readLock() location: java.util.concurrent.locks.Lock

--- a/test/transform/resource/messages-idempotent/NonNullOnParameter.java.messages
+++ b/test/transform/resource/messages-idempotent/NonNullOnParameter.java.messages
@@ -1,1 +1,1 @@
-33 @NonNull is meaningless on a primitive.
+34 @NonNull is meaningless on a primitive.

--- a/test/transform/resource/messages-idempotent/ValInvalidParameter.java.messages
+++ b/test/transform/resource/messages-idempotent/ValInvalidParameter.java.messages
@@ -1,9 +1,9 @@
-3 cannot find symbol
-4 cannot find symbol
-5 cannot find symbol
-6 cannot find symbol
-7 cannot find symbol
-8 cannot find symbol
-9 method b2 in class ValInvalidParameter cannot be applied to given types;
-10 reference to a is ambiguous
-11 reference to a is ambiguous
+4 cannot find symbol symbol: class NonExistingClass location: class ValInvalidParameter
+5 cannot find symbol symbol: class NonExistingClass location: class ValInvalidParameter
+6 cannot find symbol symbol: method nonExisitingMethod(java.lang.Integer) location: class ValInvalidParameter
+7 cannot find symbol symbol: variable nonExistingObject location: class ValInvalidParameter
+8 cannot find symbol symbol: method nonExistingMethod() location: class java.lang.Integer
+9 cannot find symbol symbol: class NonExistingClass location: class ValInvalidParameter
+10 method b2 in class ValInvalidParameter cannot be applied to given types; required: int,int found: int reason: actual and formal argument lists differ in length
+11 reference to a is ambiguous both method a(java.lang.String) in ValInvalidParameter and method a(java.lang.Integer) in ValInvalidParameter match
+12 reference to a is ambiguous both method a(java.lang.String) in ValInvalidParameter and method a(java.lang.Integer) in ValInvalidParameter match


### PR DESCRIPTION
This PR fixes #3761

I also removed the off-by-1 message matching because all out tests pass without it. And I added support for exact message position matches to test my fix.