### PR TITLE
Add support for @ExtendsRecord annotation

### DIFF
--- a/src/core/lombok/ExtendsRecord.java
+++ b/src/core/lombok/ExtendsRecord.java
@@ -1,0 +1,15 @@
+package lombok;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to generate a composite record from another specified record.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface ExtendsRecord {
+    Class<?> value();
+}

--- a/src/core/lombok/javac/handlers/HandleExtendsRecord.java
+++ b/src/core/lombok/javac/handlers/HandleExtendsRecord.java
@@ -1,0 +1,71 @@
+package lombok.javac.handlers;
+
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.*;
+import com.sun.tools.javac.util.List;
+import lombok.ExtendsRecord;
+import lombok.core.AnnotationValues;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.javac.JavacTreeMaker;
+import lombok.spi.Provides;
+
+@Provides
+public class HandleExtendsRecord extends JavacAnnotationHandler<ExtendsRecord> {
+
+    @Override
+    public void handle(AnnotationValues<ExtendsRecord> annotation, JCAnnotation ast, JavacNode annotationNode) {
+        JavacNode typeNode = annotationNode.up();
+        if (!(typeNode.get() instanceof JCClassDecl)) {
+            annotationNode.addError("@ExtendsRecord can only be used on records.");
+            return;
+        }
+
+        JCClassDecl classDecl = (JCClassDecl) typeNode.get();
+        if ((classDecl.mods.flags & Flags.RECORD) == 0) {
+            annotationNode.addError("@ExtendsRecord can only be used on records.");
+            return;
+        }
+
+        Class<?> baseRecordClass = annotation.getInstance().value();
+        String baseRecordClassName = baseRecordClass.getSimpleName();
+
+        JavacTreeMaker maker = typeNode.getTreeMaker();
+        List<JCVariableDecl> baseRecordFields = getBaseRecordFields(baseRecordClass, maker, annotationNode);
+
+        List<JCVariableDecl> newFields = List.nil();
+        for (JCVariableDecl field : baseRecordFields) {
+            newFields = newFields.append(field);
+        }
+        for (JCTree member : classDecl.defs) {
+            if (member instanceof JCVariableDecl) {
+                newFields = newFields.append((JCVariableDecl) member);
+            }
+        }
+
+        JCClassDecl newClassDecl = maker.ClassDef(
+                classDecl.mods,
+                classDecl.name,
+                classDecl.typarams,
+                classDecl.extending,
+                classDecl.implementing,
+                newFields
+        );
+
+        typeNode.replace(newClassDecl);
+    }
+
+    private List<JCVariableDecl> getBaseRecordFields(Class<?> baseRecordClass, JavacTreeMaker maker, JavacNode annotationNode) {
+        List<JCVariableDecl> fields = List.nil();
+        for (java.lang.reflect.RecordComponent component : baseRecordClass.getRecordComponents()) {
+            JCVariableDecl field = maker.VarDef(
+                    maker.Modifiers(Flags.PUBLIC | Flags.FINAL),
+                    annotationNode.toName(component.getName()),
+                    maker.Type(annotationNode.getTreeMaker().Ident(annotationNode.toName(component.getType().getSimpleName()))),
+                    null
+            );
+            fields = fields.append(field);
+        }
+        return fields;
+    }
+}

--- a/src/core/lombok/javac/handlers/HandleSuperBuilderRemove.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilderRemove.java
@@ -32,6 +32,7 @@ import lombok.experimental.SuperBuilder;
 import lombok.javac.JavacAnnotationHandler;
 import lombok.javac.JavacNode;
 import lombok.spi.Provides;
+import lombok.ExtendsRecord;
 
 @Provides
 @HandlerPriority(32768)
@@ -39,5 +40,14 @@ import lombok.spi.Provides;
 public class HandleSuperBuilderRemove extends JavacAnnotationHandler<SuperBuilder> {
 	@Override public void handle(AnnotationValues<SuperBuilder> annotation, JCAnnotation ast, JavacNode annotationNode) {
 		deleteAnnotationIfNeccessary(annotationNode, SuperBuilder.class);
+	}
+}
+
+@Provides
+@HandlerPriority(32768)
+@AlreadyHandledAnnotations
+public class HandleExtendsRecordRemove extends JavacAnnotationHandler<ExtendsRecord> {
+	@Override public void handle(AnnotationValues<ExtendsRecord> annotation, JCAnnotation ast, JavacNode annotationNode) {
+		deleteAnnotationIfNeccessary(annotationNode, ExtendsRecord.class);
 	}
 }

--- a/src/core/lombok/javac/handlers/HandleValue.java
+++ b/src/core/lombok/javac/handlers/HandleValue.java
@@ -52,6 +52,7 @@ public class HandleValue extends JavacAnnotationHandler<Value> {
 	private HandleGetter handleGetter = new HandleGetter();
 	private HandleEqualsAndHashCode handleEqualsAndHashCode = new HandleEqualsAndHashCode();
 	private HandleToString handleToString = new HandleToString();
+	private HandleExtendsRecord handleExtendsRecord = new HandleExtendsRecord();
 	
 	@Override public void handle(AnnotationValues<Value> annotation, JCAnnotation ast, JavacNode annotationNode) {
 		handleFlagUsage(annotationNode, ConfigurationKeys.VALUE_FLAG_USAGE, "@Value");
@@ -79,5 +80,6 @@ public class HandleValue extends JavacAnnotationHandler<Value> {
 		handleGetter.generateGetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true, List.<JCAnnotation>nil());
 		handleEqualsAndHashCode.generateEqualsAndHashCodeForType(typeNode, annotationNode);
 		handleToString.generateToStringForType(typeNode, annotationNode);
+		handleExtendsRecord.handle(annotation, ast, annotationNode);
 	}
 }

--- a/src/core/lombok/javac/handlers/JavacResolver.java
+++ b/src/core/lombok/javac/handlers/JavacResolver.java
@@ -80,6 +80,29 @@ public enum JavacResolver {
 			}
 			return true;
 		}
+	},
+	EXTENDS_RECORD {
+		@Override
+		public Type resolveMember(JavacNode node, JCExpression expr) {
+			Type type = CLASS_AND_METHOD.resolveMember(node, expr);
+			if (type == null) {
+				JavacNode classNode = node;
+				while (classNode != null && noneOf(classNode.get(), JCBlock.class, JCMethodDecl.class, JCVariableDecl.class)) {
+					classNode = classNode.up();
+				}
+				if (classNode != null) {
+					type = CLASS.resolveMember(classNode, expr);
+				}
+			}
+			return type;
+		}
+		
+		private boolean noneOf(Object o, Class<?>... clazzes) {
+			for (Class<?> clazz : clazzes) {
+				if (clazz.isInstance(o)) return false;
+			}
+			return true;
+		}
 	};
 	
 	


### PR DESCRIPTION
Fixes #3718

Add support for generating composite records using the `@ExtendsRecord` annotation.

* Add `src/core/lombok/ExtendsRecord.java` to define the `@ExtendsRecord` annotation.
* Add `src/core/lombok/javac/handlers/HandleExtendsRecord.java` to handle the `@ExtendsRecord` annotation.
* Modify `src/core/lombok/javac/handlers/HandleSuperBuilderRemove.java` to include `HandleExtendsRecordRemove` class.
* Modify `src/core/lombok/javac/handlers/HandleValue.java` to handle the `@ExtendsRecord` annotation.
* Modify `src/core/lombok/javac/handlers/JavacResolver.java` to add `EXTENDS_RECORD` enum value and its implementation.