### PR TITLE
fix: Don't alter the AST node positions of original code.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@ Adam Juraszek <juriad@gmail.com>
 Aleksandr Zhelezniak <lekan1992@gmail.com>
 Amine Touzani <ttzn.dev@gmail.com>
 Andre Brait <andrebrait@gmail.com>
+Anshuman Mishra <a.mishra@uber.com>
 Bulgakov Alexander <buls@yandex.ru>
 Caleb Brinkman <floralvikings@gmail.com>
 Christian Nüssgens <christian@nuessgens.com>

--- a/src/core/lombok/javac/handlers/HandleConstructor.java
+++ b/src/core/lombok/javac/handlers/HandleConstructor.java
@@ -364,7 +364,7 @@ public class HandleConstructor {
 		if (addConstructorProperties && !isLocalType(typeNode) && LombokOptionsFactory.getDelombokOptions(typeNode.getContext()).getFormatPreferences().generateConstructorProperties()) {
 			addConstructorProperties(mods, typeNode, fieldsToParam);
 		}
-		if (onConstructor != null) mods.annotations = mods.annotations.appendList(copyAnnotations(onConstructor));
+		if (onConstructor != null) mods.annotations = mods.annotations.appendList(copyAnnotations(onConstructor, maker));
 		return recursiveSetGeneratedBy(maker.MethodDef(mods, typeNode.toName("<init>"),
 			null, List.<JCTypeParameter>nil(), params.toList(), List.<JCExpression>nil(),
 			maker.Block(0L, nullChecks.appendList(assigns).toList()), null), source);

--- a/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
+++ b/src/core/lombok/javac/handlers/HandleEqualsAndHashCode.java
@@ -190,7 +190,7 @@ public class HandleEqualsAndHashCode extends JavacAnnotationHandler<EqualsAndHas
 		injectMethod(typeNode, equalsMethod);
 		
 		if (needsCanEqual && canEqualExists == MemberExistsResult.NOT_EXISTS) {
-			JCMethodDecl canEqualMethod = createCanEqual(typeNode, source, copyAnnotations(onParam));
+			JCMethodDecl canEqualMethod = createCanEqual(typeNode, source, copyAnnotations(onParam, typeNode.getTreeMaker()));
 			injectMethod(typeNode, canEqualMethod);
 		}
 		

--- a/src/core/lombok/javac/handlers/HandleGetter.java
+++ b/src/core/lombok/javac/handlers/HandleGetter.java
@@ -250,7 +250,7 @@ public class HandleGetter extends JavacAnnotationHandler<Getter> {
 		
 		List<JCAnnotation> copyableAnnotations = findCopyableAnnotations(field);
 		List<JCAnnotation> delegates = findDelegatesAndRemoveFromField(field);
-		List<JCAnnotation> annsOnMethod = copyAnnotations(onMethod).appendList(copyableAnnotations);
+		List<JCAnnotation> annsOnMethod = copyAnnotations(onMethod, field.getTreeMaker()).appendList(copyableAnnotations);
 		if (field.isFinal()) {
 			if (getCheckerFrameworkVersion(field).generatePure()) annsOnMethod = annsOnMethod.prepend(treeMaker.Annotation(genTypeRef(field, CheckerFrameworkVersion.NAME__PURE), List.<JCExpression>nil()));
 		} else {

--- a/src/core/lombok/javac/handlers/HandleGetter.java
+++ b/src/core/lombok/javac/handlers/HandleGetter.java
@@ -250,7 +250,7 @@ public class HandleGetter extends JavacAnnotationHandler<Getter> {
 		
 		List<JCAnnotation> copyableAnnotations = findCopyableAnnotations(field);
 		List<JCAnnotation> delegates = findDelegatesAndRemoveFromField(field);
-		List<JCAnnotation> annsOnMethod = copyAnnotations(onMethod, field.getTreeMaker()).appendList(copyableAnnotations);
+		List<JCAnnotation> annsOnMethod = copyAnnotations(onMethod, treeMaker).appendList(copyableAnnotations);
 		if (field.isFinal()) {
 			if (getCheckerFrameworkVersion(field).generatePure()) annsOnMethod = annsOnMethod.prepend(treeMaker.Annotation(genTypeRef(field, CheckerFrameworkVersion.NAME__PURE), List.<JCExpression>nil()));
 		} else {

--- a/src/core/lombok/javac/handlers/HandleJacksonized.java
+++ b/src/core/lombok/javac/handlers/HandleJacksonized.java
@@ -136,7 +136,7 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 		
 		// Copy annotations from the class to the builder class.
 		List<JCAnnotation> copyableAnnotations = findJacksonAnnotationsOnClass(tdNode);
-		List<JCAnnotation> copiedAnnotations = copyAnnotations(copyableAnnotations);
+		List<JCAnnotation> copiedAnnotations = copyAnnotations(copyableAnnotations, maker);
 		for (JCAnnotation anno : copiedAnnotations) {
 			recursiveSetGeneratedBy(anno, annotationNode);
 		}

--- a/src/core/lombok/javac/handlers/HandleSetter.java
+++ b/src/core/lombok/javac/handlers/HandleSetter.java
@@ -241,7 +241,7 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 		List<JCAnnotation> copyableAnnotations = findCopyableAnnotations(field);
 		
 		Name methodName = field.toName(setterName);
-		List<JCAnnotation> annsOnParam = copyAnnotations(onParam).appendList(copyableAnnotations);
+		List<JCAnnotation> annsOnParam = copyAnnotations(onParam, treeMaker).appendList(copyableAnnotations);
 		
 		long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, field.getContext());
 		JCExpression pType = cloneType(treeMaker, fieldDecl.vartype, source);
@@ -274,7 +274,7 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 		List<JCExpression> throwsClauses = List.nil();
 		JCExpression annotationMethodDefaultValue = null;
 		
-		List<JCAnnotation> annsOnMethod = mergeAnnotations(copyAnnotations(onMethod), findCopyableToSetterAnnotations(field));
+		List<JCAnnotation> annsOnMethod = mergeAnnotations(copyAnnotations(onMethod, treeMaker), findCopyableToSetterAnnotations(field));
 		if (isFieldDeprecated(field) || deprecate) {
 			annsOnMethod = annsOnMethod.prepend(treeMaker.Annotation(genJavaLangTypeRef(field, "Deprecated"), List.<JCExpression>nil()));
 		}

--- a/src/core/lombok/javac/handlers/HandleWith.java
+++ b/src/core/lombok/javac/handlers/HandleWith.java
@@ -229,7 +229,7 @@ public class HandleWith extends JavacAnnotationHandler<With> {
 		
 		JCBlock methodBody = null;
 		long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, field.getContext());
-		List<JCAnnotation> annsOnParam = copyAnnotations(onParam).appendList(copyableAnnotations);
+		List<JCAnnotation> annsOnParam = copyAnnotations(onParam, maker).appendList(copyableAnnotations);
 		
 		JCExpression pType = cloneType(maker, fieldDecl.vartype, source);
 		JCVariableDecl param = maker.VarDef(maker.Modifiers(flags, annsOnParam), fieldDecl.name, pType, null);
@@ -278,7 +278,7 @@ public class HandleWith extends JavacAnnotationHandler<With> {
 		List<JCExpression> throwsClauses = List.nil();
 		JCExpression annotationMethodDefaultValue = null;
 		
-		List<JCAnnotation> annsOnMethod = copyAnnotations(onMethod);
+		List<JCAnnotation> annsOnMethod = copyAnnotations(onMethod, maker);
 		CheckerFrameworkVersion checkerFramework = getCheckerFrameworkVersion(source);
 		if (checkerFramework.generateSideEffectFree()) annsOnMethod = annsOnMethod.prepend(maker.Annotation(genTypeRef(source, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE), List.<JCExpression>nil()));
 		

--- a/src/core/lombok/javac/handlers/HandleWithBy.java
+++ b/src/core/lombok/javac/handlers/HandleWithBy.java
@@ -321,7 +321,7 @@ public class HandleWithBy extends JavacAnnotationHandler<WithBy> {
 		List<JCExpression> throwsClauses = List.nil();
 		JCExpression annotationMethodDefaultValue = null;
 		
-		List<JCAnnotation> annsOnMethod = copyAnnotations(onMethod);
+		List<JCAnnotation> annsOnMethod = copyAnnotations(onMethod, maker);
 		CheckerFrameworkVersion checkerFramework = getCheckerFrameworkVersion(source);
 		if (checkerFramework.generateSideEffectFree()) annsOnMethod = annsOnMethod.prepend(maker.Annotation(genTypeRef(source, CheckerFrameworkVersion.NAME__SIDE_EFFECT_FREE), List.<JCExpression>nil()));
 		

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import com.sun.source.tree.TreeVisitor;
 import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.BoundKind;
 import com.sun.tools.javac.code.Flags;
@@ -75,6 +76,7 @@ import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.tree.JCTree.JCWildcard;
 import com.sun.tools.javac.tree.JCTree.TypeBoundKind;
+import com.sun.tools.javac.tree.TreeCopier;
 import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.tree.TreeScanner;
 import com.sun.tools.javac.util.Context;
@@ -2117,9 +2119,10 @@ public class JavacHandlerUtil {
 		}
 		return out.toList();
 	}
-
+	
 	static JCAnnotation copyAnnotation(JCAnnotation annotation, JavacTreeMaker maker) {
-		return maker.Annotation(annotation.annotationType, annotation.args);
+		TreeVisitor<JCTree, Void> visitor = new TreeCopier<Void>(maker.getUnderlyingTreeMaker());
+		return (JCAnnotation) visitor.visitAnnotation(annotation, null);
 	}
 	
 	static List<JCAnnotation> mergeAnnotations(List<JCAnnotation> a, List<JCAnnotation> b) {

--- a/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
+++ b/src/core/lombok/javac/handlers/JavacSingularsRecipes.java
@@ -315,7 +315,7 @@ public class JavacSingularsRecipes {
 			if (!setterPrefix.isEmpty()) name = builderType.toName(HandlerUtil.buildAccessorName(source, setterPrefix, name.toString()));
 			
 			statements.prepend(createConstructBuilderVarIfNeeded(maker, data, builderType, source));
-			List<JCAnnotation> methodAnnotations = copyAnnotations(findCopyableToBuilderSingularSetterAnnotations(data.annotation.up()));
+			List<JCAnnotation> methodAnnotations = copyAnnotations(findCopyableToBuilderSingularSetterAnnotations(data.annotation.up()), maker);
 			finishAndInjectMethod(cfv, maker, returnType, returnStatement, data, builderType, source, deprecate, statements, name, params, methodAnnotations, access, null);
 		}
 		
@@ -362,7 +362,7 @@ public class JavacSingularsRecipes {
 				statements.prepend(JavacHandlerUtil.generateNullCheck(maker, null, data.getPluralName(), builderType, "%s cannot be null"));
 			}
 
-			List<JCAnnotation> methodAnnotations = copyAnnotations(findCopyableToSetterAnnotations(data.annotation.up()));
+			List<JCAnnotation> methodAnnotations = copyAnnotations(findCopyableToSetterAnnotations(data.annotation.up()), maker);
 			
 			finishAndInjectMethod(cfv, maker, returnType, returnStatement, data, builderType, source, deprecate, statements, name, List.of(param), methodAnnotations, access, ignoreNullCollections);
 		}

--- a/src/delombok/lombok/delombok/Delombok.java
+++ b/src/delombok/lombok/delombok/Delombok.java
@@ -103,6 +103,7 @@ public class Delombok {
 	private LinkedHashMap<File, File> fileToBase = new LinkedHashMap<File, File>();
 	private List<File> filesToParse = new ArrayList<File>();
 	private Map<String, String> formatPrefs = new HashMap<String, String>();
+	private List<AbstractProcessor> preLombokProcessors = new ArrayList<AbstractProcessor>();
 	private List<AbstractProcessor> additionalAnnotationProcessors = new ArrayList<AbstractProcessor>();
 	
 	/** If null, output to standard out. */
@@ -653,6 +654,10 @@ public class Delombok {
 		fileToBase.put(f, base);
 	}
 	
+	public void addPreLombokProcessors(AbstractProcessor processor) {
+		preLombokProcessors.add(processor);
+	}
+
 	public void addAdditionalAnnotationProcessor(AbstractProcessor processor) {
 		additionalAnnotationProcessors.add(processor);
 	}
@@ -735,6 +740,7 @@ public class Delombok {
 		Map<JCCompilationUnit, File> baseMap = new IdentityHashMap<JCCompilationUnit, File>();
 		
 		Set<AbstractProcessor> processors = new LinkedHashSet<AbstractProcessor>();
+		processors.addAll(preLombokProcessors);
 		processors.add(new lombok.javac.apt.LombokProcessor());
 		processors.addAll(additionalAnnotationProcessors);
 		

--- a/test/core/src/lombok/RunTestsViaDelombok.java
+++ b/test/core/src/lombok/RunTestsViaDelombok.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -342,14 +341,6 @@ public class RunTestsViaDelombok extends AbstractRunTests {
 					parents.push(tree);
 					super.scan(tree);
 					parents.pop();
-				}
-				
-				/**
-				 * We always generate shallow copies for annotations
-				 */
-				@Override
-				public void visitAnnotation(JCAnnotation tree) {
-					return;
 				}
 			});
 		}

--- a/test/core/src/lombok/RunTestsViaDelombok.java
+++ b/test/core/src/lombok/RunTestsViaDelombok.java
@@ -112,7 +112,7 @@ public class RunTestsViaDelombok extends AbstractRunTests {
 	}
 	
 	public static class NodePositionMapper extends TreeProcessor {
-		Map<JCTree, Integer> nodePositions = new HashMap<>();
+		Map<JCTree, Integer> nodePositions = new HashMap<JCTree, Integer>();
 		
 		@Override void processCompilationUnit(final JCCompilationUnit unit) {
 			unit.accept(new TreeScanner() {


### PR DESCRIPTION
fixes: #3799 

## Changes:
### Deep Copy for Annotations:
1. Replaced the usage of the clone method (which performed a shallow copy) with [TreeCopier](https://github.com/openjdk/jdk/blob/807f6f7fb868240cba5ba117c7059216f69a53f9/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeCopier.java). This ensures a deep copy of annotations, preventing updates to copied annotations from affecting the original ones.
2. Updated instances in the codebase (e.g., [this location](https://github.com/projectlombok/lombok/blob/master/src/core/lombok/javac/handlers/JavacHandlerUtil.java#L1787)) where annotations were not being copied, ensuring the use of copyAnnotations.

### Testing
Added a unit test using Delombok to verify that AST node positions remain unchanged before and after the Lombok annotation processor is applied, across all existing test files.
1. Introduced a preLombokProcessors (purely for testing purpose) field in Delombok to run processors before Lombok annotation processing. List is empty by default except for RunTestViaDelombok unit tests.
2. Created a NodePositionMapper processor within preLombokProcessors to capture the original AST node positions before Lombok processing.
3. Updated the existing ValidatePositionProcessor to validate node positions before and after Lombok processing.
4. Ignored validation for positions of nodes generated by Lombok, to handles cases like:
  - @NonNull on record fields, where Lombok replaces GENERATEDCONSTR and modifies node positions. Also the GENERATEDCONSTR was never part of original code.
 
Note: Without this change, 43 tests under [test/transform/resource/before](https://github.com/projectlombok/lombok/tree/master/test/transform/resource/before) failed for the above unit test.