### PR TITLE
update gradle syntax to support both `.gradle` and `.gradle.kts`

### DIFF
--- a/website/templates/setup/gradle.html
+++ b/website/templates/setup/gradle.html
@@ -23,11 +23,11 @@ repositories {
 }
 
 dependencies {
-	compileOnly 'org.projectlombok:lombok:${version}'
-	annotationProcessor 'org.projectlombok:lombok:${version}'
+	compileOnly("org.projectlombok:lombok:${version}")
+	annotationProcessor("org.projectlombok:lombok:${version}")
 	
-	testCompileOnly 'org.projectlombok:lombok:${version}'
-	testAnnotationProcessor 'org.projectlombok:lombok:${version}'
+	testCompileOnly("org.projectlombok:lombok:${version}")
+	testAnnotationProcessor("org.projectlombok:lombok:${version}")
 }</pre>
 		</p><p>
 			Remember that you still have to download <code>lombok.jar</code> (or find it in gradle's caches) and run it as a jarfile, if you wish to program in eclipse. The plugin makes that part easier.


### PR DESCRIPTION
`.gradle.kts`, unlike `.gradle`, is using Kotlin instead of Groovy as the base of its scripting language. The old syntax is problematic in `.gradle.kts` becasue:
- Kotlin string cannot be wrapped by single quote, aka `'some string'` is not allowed and should be `"some string"` instead
- Kotlin requires brackets for method calling, aka `f someArg` is not allowed and should be `f(someArg)` instead

So I made some changes to the syntax so that the installation guide is valid for both `.gradle.kts`, unlike `.gradle`

build.gradle.kts:
![example-kotlin](https://github.com/user-attachments/assets/3e22d3fd-859e-4585-b603-7aefb8cb38a2)

build.gradle:
![example-groovy](https://github.com/user-attachments/assets/7ea1d6d9-1989-4614-b893-3ab167c43018)
