### PR TITLE
Update onXExample_pre.jpage

### DIFF
--- a/website/usageExamples/experimental/onXExample_pre.jpage
+++ b/website/usageExamples/experimental/onXExample_pre.jpage
@@ -7,7 +7,8 @@ import javax.persistence.Id;
 import javax.persistence.Column;
 import javax.validation.constraints.Max;
 
-@AllArgsConstructor(onConstructor=@__(@Inject))
+// @AllArgsConstructor(onConstructor=@__(@Inject)) //JDK7
+@AllArgsConstructor(onConstructor_=@Inject) //JDK8
 public class OnXExample {
 //	@Getter(onMethod=@__({@Id, @Column(name="unique-id")})) //JDK7
 //	@Setter(onParam=@__(@Max(10000))) //JDK7


### PR DESCRIPTION
Update `onX` example, to make the JDK 8+ `onConstructor` syntax more clear.

Notice, the written documentation is already on point:
> On javac7, to use any of the 3 onX features, you must wrap the annotations to be applied to the constructor / method / parameter in` @__(@AnnotationGoesHere)`. On javac8 and up, you add an underscore after onMethod, onParam, or onConstructor.