### PR TITLE
Avoid generate @Delegate method body NPE

### DIFF
--- a/src/core/lombok/experimental/Delegate.java
+++ b/src/core/lombok/experimental/Delegate.java
@@ -65,4 +65,11 @@ public @interface Delegate {
 	 * @return For each method (not already in {@code java.lang.Object}) in these types, skip generating a delegate method (overrides {@code types()}).
 	 */
 	Class<?>[] excludes() default {};
+
+	/**
+	 * If configuration turn to true. When field is null and target type delegate method return as a references type, just return a null instead of throw a NPE
+	 *
+	 * @return Is it needed to avoid NPE make the utmost effort.
+	 */
+	boolean skipAndReturnNullOnNullRef() default false;
 }


### PR DESCRIPTION
Avoid generate @Delegate method body NPE when deletegate target is null on javac's HandleDelegate

Add a null check before delegate call,now is only for javac

before:
```java
    @Generated
    public void asd() {
        this.getSd().asd();
    }

    @Generated
    public String getExt() {
        return this.getSd().getExt();
    }

    @Generated
    public void setExt(final String ext) {
        this.getSd().setExt(ext);
    }
```
after
```java
    @Generated
    public void asd() {
        if (this.getSd() != null) {
            this.getSd().asd();
        }
    }

    @Generated
    public String getExt() {
        return this.getSd() == null ? null : this.getSd().getExt();
    }

    @Generated
    public void setExt(final String ext) {
        if (this.getSd() != null) {
            this.getSd().setExt(ext);
        }
    }
```