### PR TITLE
docs(locked): fix introduced version

### DIFF
--- a/website/templates/features/Locked.html
+++ b/website/templates/features/Locked.html
@@ -3,7 +3,7 @@
 <@f.scaffold title="@Locked" logline="Pop it and <strong>lock</strong> it! <code>ReentrantLock</code>, now with less hassle.">
 	<@f.history>
 		<p>
-			<code>@Locked</code> was introduced in lombok v1.20.
+			<code>@Locked</code> was introduced in lombok v1.18.32.
 		</p>
 	</@f.history>
 


### PR DESCRIPTION
`@Locked` was introduced in lombok v1.18.32, but it's v1.20 in the docs and website