### PR TITLE
Set missing source position for receiver annotation

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -100,6 +100,7 @@ jobs:
         - eclipse-202403
         - eclipse-202406
         - eclipse-202409
+        - eclipse-202412
         - eclipse-I-build
         - eclipse-oxygen-full
         - eclipse-2022-03-full
@@ -108,6 +109,7 @@ jobs:
         - eclipse-2024-03-full
         - eclipse-2024-06-full
         - eclipse-2024-09-full
+        - eclipse-2024-12-full
         - eclipse-I-build-full
         - ecj11
         - ecj14

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -119,10 +119,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu'
 
       - name: Cache dependencies

--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -36,6 +36,7 @@
 		<conf name="eclipse-202403" />
 		<conf name="eclipse-202406" />
 		<conf name="eclipse-202409" />
+		<conf name="eclipse-202412" />
 		
 		<conf name="mapstruct" />
 	</configurations>
@@ -188,6 +189,19 @@
 		<dependency org="org.eclipse.platform" name="org.eclipse.core.jobs" rev="3.15.400" conf="eclipse-202409->default" transitive="false" />
 		<dependency org="org.eclipse.platform" name="org.eclipse.osgi" rev="3.21.0" conf="eclipse-202409->default" transitive="false" />
 		<dependency org="org.eclipse.platform" name="org.eclipse.text" rev="3.14.100" conf="eclipse-202409->default" transitive="false" />
+		
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.runtime" rev="3.32.0" conf="eclipse-202412->default" transitive="false" />
+		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.core" rev="3.40.0" conf="eclipse-202412->default" transitive="false" />
+		<dependency org="org.eclipse.jdt" name="org.eclipse.jdt.ui" rev="3.33.200" conf="eclipse-202412->default" transitive="false" />
+		<dependency org="org.eclipse.jdt" name="ecj" rev="3.40.0" conf="eclipse-202412->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.common" rev="3.19.200" conf="eclipse-202412->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.registry" rev="3.12.200" conf="eclipse-202412->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.equinox.app" rev="1.7.200" conf="eclipse-202412->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.resources" rev="3.22.0" conf="eclipse-202412->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.contenttype" rev="3.9.600" conf="eclipse-202412->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.core.jobs" rev="3.15.400" conf="eclipse-202412->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.osgi" rev="3.22.0" conf="eclipse-202412->default" transitive="false" />
+		<dependency org="org.eclipse.platform" name="org.eclipse.text" rev="3.14.200" conf="eclipse-202412->default" transitive="false" />
 		
 		<!-- integration with other libraries -->
 		<dependency org="org.mapstruct" name="mapstruct-processor" rev="1.3.1.Final" conf="mapstruct->default" transitive="false" />

--- a/buildScripts/setup.ant.xml
+++ b/buildScripts/setup.ant.xml
@@ -184,6 +184,10 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 		<fetchdep.eclipse.osgi name="2024-09" version="4.33" />
 	</target>
 	
+	<target name="deps.eclipse.2024-12" depends="deps.rtstubs18, compile.support">
+		<fetchdep.eclipse.osgi name="2024-12" version="4.34" />
+	</target>
+	
 	<target name="deps.eclipse.integration" depends="deps.rtstubs18, compile.support">
 		<fetchdep.eclipse.osgi name="I-build" version="I-builds" />
 	</target>

--- a/buildScripts/tests.ant.xml
+++ b/buildScripts/tests.ant.xml
@@ -242,6 +242,11 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 		<test.eclipse-X version="202409" />
 	</target>
 	
+	<target name="test.eclipse-202412" depends="test.compile, test.formatter.compile" description="runs the tests on your default VM, testing the 2024-12 release of eclipse">
+		<fetchdep.eclipse version="202412" />
+		<test.eclipse-X version="202412" />
+	</target>
+	
 	<target name="test.eclipse-I-build" depends="test.compile, test.formatter.compile, deps.rtstubs18, compile.support" description="runs the tests on your default VM, testing the latest integration build of eclipse">
 		<fetchdep.eclipse.updatesite name="I-build" version="I-builds" target="lib/" resolveDependencies="false">
 			<bundles>
@@ -325,6 +330,10 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 	
 	<target name="test.eclipse-2024-09-full" depends="test.eclipse.compile, test.formatter.compile, deps.eclipse.2024-09" description="runs the full eclipse tests on your default VM, testing the 2024-09 release of eclipse">
 		<test.eclipse-X-full version="2024-09" />
+	</target>
+	
+	<target name="test.eclipse-2024-12-full" depends="test.eclipse.compile, test.formatter.compile, deps.eclipse.2024-12" description="runs the full eclipse tests on your default VM, testing the 2024-12 release of eclipse">
+		<test.eclipse-X-full version="2024-12" />
 	</target>
 	
 	<target name="test.eclipse-I-build-full" depends="test.eclipse.compile, test.formatter.compile, deps.eclipse.integration" description="runs the full eclipse tests on your default VM, testing the latest integration build of eclipse">

--- a/buildScripts/tests.ant.xml
+++ b/buildScripts/tests.ant.xml
@@ -257,6 +257,7 @@ This buildfile is part of projectlombok.org. It takes care of compiling and runn
 				<arg value="osgi.bundle:org.eclipse.core.jobs" />
 				<arg value="osgi.bundle:org.eclipse.osgi" />
 				<arg value="osgi.bundle:org.eclipse.text" />
+				<arg value="osgi.bundle:org.osgi.service.prefs" />
 			</bundles>
 		</fetchdep.eclipse.updatesite>
 		<path id="cp.eclipse-I-build">

--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2024 The Project Lombok Authors.
+ * Copyright (C) 2013-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -59,7 +59,6 @@ import org.eclipse.jdt.internal.compiler.ast.QualifiedThisReference;
 import org.eclipse.jdt.internal.compiler.ast.QualifiedTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.Receiver;
 import org.eclipse.jdt.internal.compiler.ast.ReturnStatement;
-import org.eclipse.jdt.internal.compiler.ast.SingleMemberAnnotation;
 import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;
 import org.eclipse.jdt.internal.compiler.ast.SingleTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.Statement;
@@ -778,27 +777,23 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		
 		if (mandatories.size() == 0) return null;
 		
-		int pS = job.source.sourceStart, pE = job.source.sourceEnd;
-		
 		char[][] nameCalled = fromQualifiedName(CheckerFrameworkVersion.NAME__CALLED);
-		SingleMemberAnnotation ann = new SingleMemberAnnotation(new QualifiedTypeReference(nameCalled, poss(job.source, nameCalled.length)), pS);
+		Expression memberValue;
 		if (mandatories.size() == 1) {
-			ann.memberValue = new StringLiteral(mandatories.get(0), 0, 0, 0);
+			memberValue = new StringLiteral(mandatories.get(0), 0, 0, 0);
 		} else {
 			ArrayInitializer arr = new ArrayInitializer();
-			arr.sourceStart = pS;
-			arr.sourceEnd =  pE;
 			arr.expressions = new Expression[mandatories.size()];
 			for (int i = 0; i < arr.expressions.length; i++) {
-				arr.expressions[i] = new StringLiteral(mandatories.get(i), pS, pE, 0);
+				arr.expressions[i] = new StringLiteral(mandatories.get(i), job.source.sourceStart, job.source.sourceEnd, 0);
 			}
-			ann.memberValue = arr;
+			memberValue = arr;
 		}
 		
 		TypeReference typeReference = job.createBuilderTypeReference();
 		int len = typeReference.getTypeName().length;
 		typeReference.annotations = new Annotation[len][];
-		typeReference.annotations[len - 1] = new Annotation[] {ann};
+		typeReference.annotations[len - 1] = EclipseHandlerUtil.addAnnotation(job.source, null, nameCalled, memberValue);
 		return new Receiver(new char[] { 't', 'h', 'i', 's' }, 0, typeReference, null, 0);
 	}
 	

--- a/test/core/src/lombok/RunTestsViaEcj.java
+++ b/test/core/src/lombok/RunTestsViaEcj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2024 The Project Lombok Authors.
+ * Copyright (C) 2010-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -242,7 +242,7 @@ public class RunTestsViaEcj extends AbstractRunTests {
 					return source;
 				}
 			};
-			return AST.convertCompilationUnit(4, cud, options, false, ccu, 0, null);
+			return AST.convertCompilationUnit(8, cud, options, false, ccu, 0, null);
 		}
 	}
 	


### PR DESCRIPTION
This PR fixes #3823

The position was missing for a long time but was never noticed because our test system was using an old JLS version that doesn't support receivers. I also bumped the java version we use to run the full eclipse tests because the upcoming version requires JDK21 or newer. I also added the missing eclipse 2024-12 test target.