### PR TITLE
Do not concat Arrays with Strings

### DIFF
--- a/src/installer/lombok/installer/eclipse/EclipseProductLocation.java
+++ b/src/installer/lombok/installer/eclipse/EclipseProductLocation.java
@@ -211,7 +211,7 @@ public final class EclipseProductLocation extends IdeLocation {
 						fos.close();
 					}
 				} catch (IOException e) {
-					throw new UninstallException("Cannot uninstall lombok from " + name + generateWriteErrorMessage(), e);
+					throw new UninstallException("Cannot uninstall lombok from " + getName() + generateWriteErrorMessage(), e);
 				}
 			}
 			
@@ -321,7 +321,7 @@ public final class EclipseProductLocation extends IdeLocation {
 							"and use the 'what do I do' link, to manually install lombok. Also, tell us about this at:\n" +
 							"http://groups.google.com/group/project-lombok - Thanks!\n\n[DEBUG INFO] " + e.getClass() + ": " + e.getMessage() + "\nBase: " + OsUtils.class.getResource("OsUtils.class"), e);
 					}
-					throw new InstallException("I can't write to your " + descriptor.getProductName() + " directory at " + name + generateWriteErrorMessage(), e);
+					throw new InstallException("I can't write to your " + descriptor.getProductName() + " directory at " + getName() + generateWriteErrorMessage(), e);
 				}
 			}
 			
@@ -381,7 +381,7 @@ public final class EclipseProductLocation extends IdeLocation {
 				}
 				installSucceeded = true;
 			} catch (IOException e) {
-				throw new InstallException("Cannot install lombok at " + name + generateWriteErrorMessage(), e);
+				throw new InstallException("Cannot install lombok at " + getName() + generateWriteErrorMessage(), e);
 			} finally {
 				if (!installSucceeded) try {
 					lombokJar.delete();


### PR DESCRIPTION
Error message is e.g. `Cannot install lombok at [Ljava.lang.String@cafebabe, probably because...`

There is a `getName` method that describes itself as _Returns the name of this location_, so I asume this returns the correct string (and that the name array never is `null` in the context where it now get called). 