### PR TITLE
Skip excluded fields in builder-generated `toString`

### DIFF
--- a/src/core/lombok/eclipse/handlers/HandleBuilder.java
+++ b/src/core/lombok/eclipse/handlers/HandleBuilder.java
@@ -565,8 +565,15 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		}
 		
 		if (methodExists("toString", job.builderType, 0) == MemberExistsResult.NOT_EXISTS) {
+			List<String> oldExcludes = findOldToStringExcludes(job.parentType);
 			List<Included<EclipseNode, ToString.Include>> fieldNodes = new ArrayList<Included<EclipseNode, ToString.Include>>();
 			for (BuilderFieldData bfd : job.builderFields) {
+				if (bfd.originalFieldNode.hasAnnotation(ToString.Exclude.class)) {
+					continue;
+				}
+				if (oldExcludes.contains(bfd.originalFieldNode.getName())) {
+					continue;
+				}
 				for (EclipseNode f : bfd.createdFields) {
 					fieldNodes.add(new Included<EclipseNode, ToString.Include>(f, null, true, false));
 				}
@@ -1136,5 +1143,13 @@ public class HandleBuilder extends EclipseAnnotationHandler<Builder> {
 		}
 		
 		return null;
+	}
+
+	private List<String> findOldToStringExcludes(EclipseNode parentType) {
+		EclipseNode toStringAnnotationNode = findAnnotation(ToString.class, parentType);
+		if (toStringAnnotationNode == null) return Collections.emptyList();
+		
+		AnnotationValues<ToString> toStringAnnotation = createAnnotation(ToString.class, toStringAnnotationNode);
+		return toStringAnnotation.getAsStringList("exclude");
 	}
 }

--- a/src/core/lombok/javac/handlers/HandleToStringExcludeRemove.java
+++ b/src/core/lombok/javac/handlers/HandleToStringExcludeRemove.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.javac.handlers;
+
+import static lombok.javac.handlers.JavacHandlerUtil.*;
+
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+
+import lombok.ToString;
+import lombok.ToString.Exclude;
+import lombok.core.AlreadyHandledAnnotations;
+import lombok.core.AnnotationValues;
+import lombok.core.HandlerPriority;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.spi.Provides;
+
+@Provides
+@HandlerPriority(32768)
+@AlreadyHandledAnnotations
+public class HandleToStringExcludeRemove extends JavacAnnotationHandler<ToString.Exclude> {
+	@Override public void handle(AnnotationValues<Exclude> annotation, JCAnnotation ast, JavacNode annotationNode) {
+		deleteAnnotationIfNeccessary(annotationNode, ToString.Exclude.class);
+		deleteImportFromCompilationUnit(annotationNode, ToString.class);
+		deleteImportFromCompilationUnit(annotationNode, ToString.Exclude.class);
+	}
+}

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -556,17 +556,22 @@ public class JavacHandlerUtil {
 		}
 	}
 	
+	public static void deleteImportFromCompilationUnit(JavacNode node, Class<?> annotationType) {
+		deleteImportFromCompilationUnit(node, annotationType.getName());
+	}
+	
 	public static void deleteImportFromCompilationUnit(JavacNode node, String name) {
 		if (inNetbeansEditor(node)) return;
 		if (!node.shouldDeleteLombokAnnotations()) return;
 		
 		JCCompilationUnit unit = (JCCompilationUnit) node.top().get();
 		
+		String importName = name.replace('$', '.');
 		for (JCTree def : unit.defs) {
 			if (!(def instanceof JCImport)) continue;
 			JCImport imp0rt = (JCImport) def;
 			if (imp0rt.staticImport) continue;
-			if (!Javac.getQualid(imp0rt).toString().equals(name)) continue;
+			if (!Javac.getQualid(imp0rt).toString().equals(importName)) continue;
 			JavacAugments.JCImport_deletable.set(imp0rt, true);
 		}
 	}

--- a/test/transform/resource/after-delombok/BuilderWithToStringExclude.java
+++ b/test/transform/resource/after-delombok/BuilderWithToStringExclude.java
@@ -1,0 +1,58 @@
+public class BuilderWithToStringExclude {
+	private String a;
+	private String secret;
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	BuilderWithToStringExclude(final String a, final String secret) {
+		this.a = a;
+		this.secret = secret;
+	}
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static class BuilderWithToStringExcludeBuilder {
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		private String a;
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		private String secret;
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		BuilderWithToStringExcludeBuilder() {
+		}
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public BuilderWithToStringExclude.BuilderWithToStringExcludeBuilder a(final String a) {
+			this.a = a;
+			return this;
+		}
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public BuilderWithToStringExclude.BuilderWithToStringExcludeBuilder secret(final String secret) {
+			this.secret = secret;
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public BuilderWithToStringExclude build() {
+			return new BuilderWithToStringExclude(this.a, this.secret);
+		}
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public java.lang.String toString() {
+			return "BuilderWithToStringExclude.BuilderWithToStringExcludeBuilder(a=" + this.a + ")";
+		}
+	}
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static BuilderWithToStringExclude.BuilderWithToStringExcludeBuilder builder() {
+		return new BuilderWithToStringExclude.BuilderWithToStringExcludeBuilder();
+	}
+}

--- a/test/transform/resource/after-delombok/BuilderWithToStringExcludeAndToString.java
+++ b/test/transform/resource/after-delombok/BuilderWithToStringExcludeAndToString.java
@@ -1,0 +1,64 @@
+public class BuilderWithToStringExcludeAndToString {
+	private String a;
+	private String secret;
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	BuilderWithToStringExcludeAndToString(final String a, final String secret) {
+		this.a = a;
+		this.secret = secret;
+	}
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static class BuilderWithToStringExcludeAndToStringBuilder {
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		private String a;
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		private String secret;
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		BuilderWithToStringExcludeAndToStringBuilder() {
+		}
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public BuilderWithToStringExcludeAndToString.BuilderWithToStringExcludeAndToStringBuilder a(final String a) {
+			this.a = a;
+			return this;
+		}
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public BuilderWithToStringExcludeAndToString.BuilderWithToStringExcludeAndToStringBuilder secret(final String secret) {
+			this.secret = secret;
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public BuilderWithToStringExcludeAndToString build() {
+			return new BuilderWithToStringExcludeAndToString(this.a, this.secret);
+		}
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public java.lang.String toString() {
+			return "BuilderWithToStringExcludeAndToString.BuilderWithToStringExcludeAndToStringBuilder(a=" + this.a + ")";
+		}
+	}
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static BuilderWithToStringExcludeAndToString.BuilderWithToStringExcludeAndToStringBuilder builder() {
+		return new BuilderWithToStringExcludeAndToString.BuilderWithToStringExcludeAndToStringBuilder();
+	}
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public java.lang.String toString() {
+		return "BuilderWithToStringExcludeAndToString(a=" + this.a + ")";
+	}
+}

--- a/test/transform/resource/after-delombok/BuilderWithToStringExcludeOld.java
+++ b/test/transform/resource/after-delombok/BuilderWithToStringExcludeOld.java
@@ -1,0 +1,64 @@
+public class BuilderWithToStringExcludeOld {
+	private String a;
+	private String secret;
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	BuilderWithToStringExcludeOld(final String a, final String secret) {
+		this.a = a;
+		this.secret = secret;
+	}
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static class BuilderWithToStringExcludeOldBuilder {
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		private String a;
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		private String secret;
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		BuilderWithToStringExcludeOldBuilder() {
+		}
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public BuilderWithToStringExcludeOld.BuilderWithToStringExcludeOldBuilder a(final String a) {
+			this.a = a;
+			return this;
+		}
+		/**
+		 * @return {@code this}.
+		 */
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public BuilderWithToStringExcludeOld.BuilderWithToStringExcludeOldBuilder secret(final String secret) {
+			this.secret = secret;
+			return this;
+		}
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public BuilderWithToStringExcludeOld build() {
+			return new BuilderWithToStringExcludeOld(this.a, this.secret);
+		}
+		@java.lang.Override
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public java.lang.String toString() {
+			return "BuilderWithToStringExcludeOld.BuilderWithToStringExcludeOldBuilder(a=" + this.a + ")";
+		}
+	}
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static BuilderWithToStringExcludeOld.BuilderWithToStringExcludeOldBuilder builder() {
+		return new BuilderWithToStringExcludeOld.BuilderWithToStringExcludeOldBuilder();
+	}
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public java.lang.String toString() {
+		return "BuilderWithToStringExcludeOld(a=" + this.a + ")";
+	}
+}

--- a/test/transform/resource/after-ecj/BuilderWithToStringExclude.java
+++ b/test/transform/resource/after-ecj/BuilderWithToStringExclude.java
@@ -1,0 +1,42 @@
+import lombok.Builder;
+import lombok.ToString;
+import lombok.ToString.Exclude;
+public @Builder class BuilderWithToStringExclude {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated class BuilderWithToStringExcludeBuilder {
+    private @java.lang.SuppressWarnings("all") @lombok.Generated String a;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated String secret;
+    @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeBuilder() {
+      super();
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExclude.BuilderWithToStringExcludeBuilder a(final String a) {
+      this.a = a;
+      return this;
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExclude.BuilderWithToStringExcludeBuilder secret(final String secret) {
+      this.secret = secret;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExclude build() {
+      return new BuilderWithToStringExclude(this.a, this.secret);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+      return (("BuilderWithToStringExclude.BuilderWithToStringExcludeBuilder(a=" + this.a) + ")");
+    }
+  }
+  private String a;
+  private @ToString.Exclude String secret;
+  @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExclude(final String a, final String secret) {
+    super();
+    this.a = a;
+    this.secret = secret;
+  }
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExclude.BuilderWithToStringExcludeBuilder builder() {
+    return new BuilderWithToStringExclude.BuilderWithToStringExcludeBuilder();
+  }
+}

--- a/test/transform/resource/after-ecj/BuilderWithToStringExcludeAndToString.java
+++ b/test/transform/resource/after-ecj/BuilderWithToStringExcludeAndToString.java
@@ -1,0 +1,45 @@
+import lombok.Builder;
+import lombok.ToString;
+import lombok.ToString.Exclude;
+public @Builder @ToString class BuilderWithToStringExcludeAndToString {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated class BuilderWithToStringExcludeAndToStringBuilder {
+    private @java.lang.SuppressWarnings("all") @lombok.Generated String a;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated String secret;
+    @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeAndToStringBuilder() {
+      super();
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeAndToString.BuilderWithToStringExcludeAndToStringBuilder a(final String a) {
+      this.a = a;
+      return this;
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeAndToString.BuilderWithToStringExcludeAndToStringBuilder secret(final String secret) {
+      this.secret = secret;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeAndToString build() {
+      return new BuilderWithToStringExcludeAndToString(this.a, this.secret);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+      return (("BuilderWithToStringExcludeAndToString.BuilderWithToStringExcludeAndToStringBuilder(a=" + this.a) + ")");
+    }
+  }
+  private String a;
+  private @ToString.Exclude String secret;
+  @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeAndToString(final String a, final String secret) {
+    super();
+    this.a = a;
+    this.secret = secret;
+  }
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeAndToString.BuilderWithToStringExcludeAndToStringBuilder builder() {
+    return new BuilderWithToStringExcludeAndToString.BuilderWithToStringExcludeAndToStringBuilder();
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+    return (("BuilderWithToStringExcludeAndToString(a=" + this.a) + ")");
+  }
+}

--- a/test/transform/resource/after-ecj/BuilderWithToStringExcludeOld.java
+++ b/test/transform/resource/after-ecj/BuilderWithToStringExcludeOld.java
@@ -1,0 +1,44 @@
+import lombok.Builder;
+import lombok.ToString;
+public @ToString(exclude = "secret") @Builder class BuilderWithToStringExcludeOld {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated class BuilderWithToStringExcludeOldBuilder {
+    private @java.lang.SuppressWarnings("all") @lombok.Generated String a;
+    private @java.lang.SuppressWarnings("all") @lombok.Generated String secret;
+    @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeOldBuilder() {
+      super();
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeOld.BuilderWithToStringExcludeOldBuilder a(final String a) {
+      this.a = a;
+      return this;
+    }
+    /**
+     * @return {@code this}.
+     */
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeOld.BuilderWithToStringExcludeOldBuilder secret(final String secret) {
+      this.secret = secret;
+      return this;
+    }
+    public @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeOld build() {
+      return new BuilderWithToStringExcludeOld(this.a, this.secret);
+    }
+    public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+      return (("BuilderWithToStringExcludeOld.BuilderWithToStringExcludeOldBuilder(a=" + this.a) + ")");
+    }
+  }
+  private String a;
+  private String secret;
+  @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeOld(final String a, final String secret) {
+    super();
+    this.a = a;
+    this.secret = secret;
+  }
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated BuilderWithToStringExcludeOld.BuilderWithToStringExcludeOldBuilder builder() {
+    return new BuilderWithToStringExcludeOld.BuilderWithToStringExcludeOldBuilder();
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+    return (("BuilderWithToStringExcludeOld(a=" + this.a) + ")");
+  }
+}

--- a/test/transform/resource/before/BuilderWithToStringExclude.java
+++ b/test/transform/resource/before/BuilderWithToStringExclude.java
@@ -1,0 +1,10 @@
+import lombok.Builder;
+import lombok.ToString;
+import lombok.ToString.Exclude;
+
+@Builder
+public class BuilderWithToStringExclude {
+	private String a;
+	@ToString.Exclude
+	private String secret;
+}

--- a/test/transform/resource/before/BuilderWithToStringExcludeAndToString.java
+++ b/test/transform/resource/before/BuilderWithToStringExcludeAndToString.java
@@ -1,0 +1,11 @@
+import lombok.Builder;
+import lombok.ToString;
+import lombok.ToString.Exclude;
+
+@Builder
+@ToString
+public class BuilderWithToStringExcludeAndToString {
+	private String a;
+	@ToString.Exclude
+	private String secret;
+}

--- a/test/transform/resource/before/BuilderWithToStringExcludeOld.java
+++ b/test/transform/resource/before/BuilderWithToStringExcludeOld.java
@@ -1,0 +1,9 @@
+import lombok.Builder;
+import lombok.ToString;
+
+@ToString(exclude = "secret")
+@Builder
+public class BuilderWithToStringExcludeOld {
+	private String a;
+	private String secret;
+}


### PR DESCRIPTION
This PR fixes #2891

`@Builder` now detect `@ToString.Exclude` annotations and does not add these fields to the generated `toString` method.