### PR TITLE
Adapt to changes made in the JDT TokenScanner API.

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -332,7 +332,14 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 				.requestExtra(StackRequest.PARAM1)
 				.transplant()
 				.build());
-		
+
+		sm.addScriptIfWitness(new String [] {"org/eclipse/jdt/internal/compiler/parser/TerminalToken"}, ScriptBuilder.replaceMethodCall()
+				.target(new MethodTarget("org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer", "visit"))
+				.methodToReplace(new Hook("org.eclipse.jdt.internal.core.dom.rewrite.TokenScanner", "getTokenEndOffset", "int", "org.eclipse.jdt.internal.compiler.parser.TerminalToken", "int"))
+				.replacementMethod(new Hook("lombok.launch.PatchFixesHider$PatchFixes", "getTokenEndOffsetFixed", "int", "org.eclipse.jdt.internal.core.dom.rewrite.TokenScanner", "java.lang.Object", "int", "java.lang.Object"))
+				.requestExtra(StackRequest.PARAM1)
+				.transplant()
+				.build());
 	}
 	
 	private static void patchPostCompileHookEclipse(ScriptManager sm) {

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -791,7 +791,38 @@ final class PatchFixesHider {
 				// If this fails, better to break some refactor scripts than to crash eclipse.
 			}
 			if (isGenerated) return -1;
-			return scanner.getTokenEndOffset(token, startOffset);
+
+			Object res = -1;
+			try {
+				Method m = Permit.getMethod(TokenScanner.class, "getTokenEndOffset", int.class, int.class);
+				res = Permit.invoke(m, scanner, token, startOffset);
+			} catch (Exception e) {
+				e.printStackTrace();
+				// continue
+			}
+			return (Integer) res;
+		}
+
+		public static int getTokenEndOffsetFixed(TokenScanner scanner, Object token, int startOffset, Object domNode) throws CoreException {
+			boolean isGenerated = false;
+			try {
+				isGenerated = (Boolean) domNode.getClass().getField("$isGenerated").get(domNode);
+			} catch (Exception e) {
+				// If this fails, better to break some refactor scripts than to crash eclipse.
+			}
+			if (isGenerated) return -1;
+
+			Object res = -1;
+			try {
+				// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3303
+				Class<?> TERMINAL_TOKEN_CLASS = Class.forName("org.eclipse.jdt.internal.compiler.parser.TerminalToken");
+				Method m = Permit.getMethod(TokenScanner.class, "getTokenEndOffset", TERMINAL_TOKEN_CLASS, int.class);
+				res = Permit.invoke(m, scanner, token, startOffset);
+			} catch (Exception e) {
+				e.printStackTrace();
+				// continue
+			}
+			return (Integer) res;
 		}
 		
 		public static IMethod[] removeGeneratedMethods(IMethod[] methods) throws Exception {


### PR DESCRIPTION
- See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3303 for API changes (I-build changes)
- Originally filed at https://github.com/redhat-developer/vscode-java/issues/4027
- Support older/newer API depending on the value of the first parameter
- TokenScanner#getTokenEndOffset(int, int) first parameter becomes an enum called TerminalToken

I've tested this PR with `test.eclipse-202503` & `test.eclipse-202503-full` and doesn't break anything there. The I-build tests appear broken even on the main branch, which makes sense (there's API breakage) so can't really test those, but I can confirm the PR resolves the stacktrace mentioned below.

With vscode-java (and even Lombok 1.18.38), create a simple project with a file that contains the `@Builder` annotation and import statement :

**Simple.java**
```
package org.example;

import lombok.Builder;

@Builder
public class Simple {
    private String simpleField;
}
```

vscode-java automatically passes in lombok through `-javaagent`. Simply click anywhere on @Builder and it produces the stacktrace.

<details>
<summary>stacktrace</summary>

```
[Error - 18:26:34] Request textDocument/codeAction failed.
  Message: Internal error.
  Code: -32603 
java.util.concurrent.CompletionException: java.lang.IllegalArgumentException: Document does not match the AST
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: java.lang.IllegalArgumentException: Document does not match the AST
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.handleException(ASTRewriteAnalyzer.java:4973)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.visit(ASTRewriteAnalyzer.java:2585)
	at org.eclipse.jdt.core.dom.ReturnStatement.accept0(ReturnStatement.java:126)
	at org.eclipse.jdt.core.dom.ASTNode.accept(ASTNode.java:3312)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.doVisit(ASTRewriteAnalyzer.java:431)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.voidVisitList(ASTRewriteAnalyzer.java:469)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.voidVisit(ASTRewriteAnalyzer.java:463)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.doVisitUnchangedChildren(ASTRewriteAnalyzer.java:476)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.visit(ASTRewriteAnalyzer.java:2464)
	at org.eclipse.jdt.core.dom.Block.accept0(Block.java:126)
	at org.eclipse.jdt.core.dom.ASTNode.accept(ASTNode.java:3312)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.voidVisit(ASTRewriteAnalyzer.java:455)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.voidVisit(ASTRewriteAnalyzer.java:461)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.doVisitUnchangedChildren(ASTRewriteAnalyzer.java:476)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.visit(ASTRewriteAnalyzer.java:2370)
	at org.eclipse.jdt.core.dom.MethodDeclaration.accept0(MethodDeclaration.java:652)
	at org.eclipse.jdt.core.dom.ASTNode.accept(ASTNode.java:3312)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.doVisit(ASTRewriteAnalyzer.java:431)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.voidVisitList(ASTRewriteAnalyzer.java:469)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.voidVisit(ASTRewriteAnalyzer.java:463)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.doVisitUnchangedChildren(ASTRewriteAnalyzer.java:476)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.visit(ASTRewriteAnalyzer.java:2045)
	at org.eclipse.jdt.core.dom.TypeDeclaration.accept0(TypeDeclaration.java:480)
	at org.eclipse.jdt.core.dom.ASTNode.accept(ASTNode.java:3312)
	at org.eclipse.jdt.core.dom.rewrite.ASTRewrite.internalRewriteAST(ASTRewrite.java:306)
	at org.eclipse.jdt.core.dom.rewrite.ASTRewrite.rewriteAST(ASTRewrite.java:295)
	at org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite.attachChange(CompilationUnitRewrite.java:290)
	at org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite.createChange(CompilationUnitRewrite.java:252)
	at org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.createChange(CompilationUnitRewriteOperationsFixCore.java:126)
	at org.eclipse.jdt.ls.core.internal.text.correction.QuickAssistProcessor.getConvertToStringBufferProposal(QuickAssistProcessor.java:1427)
	at org.eclipse.jdt.ls.core.internal.text.correction.QuickAssistProcessor.getAssists(QuickAssistProcessor.java:231)
	at org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandler.getCodeActionCommands(CodeActionHandler.java:233)
	at org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer.lambda$15(JDTLanguageServer.java:775)
	at org.eclipse.jdt.ls.core.internal.BaseJDTLanguageServer.lambda$0(BaseJDTLanguageServer.java:87)
	... 7 more
Caused by: org.eclipse.core.runtime.CoreException: End Of File
	at org.eclipse.jdt.internal.core.dom.rewrite.TokenScanner.readNext(TokenScanner.java:95)
	at org.eclipse.jdt.internal.core.dom.rewrite.TokenScanner.readToToken(TokenScanner.java:152)
	at org.eclipse.jdt.internal.core.dom.rewrite.TokenScanner.readToToken(TokenScanner.java:165)
	at org.eclipse.jdt.internal.core.dom.rewrite.TokenScanner.getTokenEndOffset(TokenScanner.java:190)
	at org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer.visit(ASTRewriteAnalyzer.java:2575)
	... 39 more
```
</details>