### PR TITLE
Support records in upcoming eclipse version

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -94,6 +94,9 @@ jobs:
           - eclipse-oxygen
           - eclipse-202006
           - eclipse-202006-jdk8
+          - eclipse-202403
+          - eclipse-202503
+          - eclipse-I-build
           - eclipse-oxygen-full
           - eclipse-202403-full
           - eclipse-202503-full

--- a/buildScripts/setup.ant.xml
+++ b/buildScripts/setup.ant.xml
@@ -205,6 +205,8 @@ This buildfile is part of projectlombok.org. It sets up the build itself.
 					<!-- osgi.extender dependecies -->
 					<arg value="osgi.bundle:org.apache.felix.scr" />
 					<arg value="osgi.bundle:org.apache.aries.spifly.dynamic.bundle" />
+					<!-- Unresolvable until we add property based dependency resolution -->
+					<arg value="osgi.bundle:org.eclipse.swt.svg" />
 					<!-- Real dependencies -->
 					<arg value="osgi.bundle:org.eclipse.jdt.core" />
 					<arg value="osgi.bundle:org.eclipse.jdt.ui" />

--- a/src/core/lombok/eclipse/handlers/HandleLockedUtil.java
+++ b/src/core/lombok/eclipse/handlers/HandleLockedUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The Project Lombok Authors.
+ * Copyright (C) 2024-2025 The Project Lombok Authors.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -87,6 +87,8 @@ public final class HandleLockedUtil {
 		if (methodNode == null || methodNode.getKind() != AST.Kind.METHOD || !(methodNode.get() instanceof MethodDeclaration)) return;
 		MethodDeclaration method = (MethodDeclaration) methodNode.get();
 		if (method.isAbstract()) return;
+		EclipseNode typeNode = upToTypeNode(annotationNode);
+		if (isRecord(typeNode)) return;
 		
 		createLockField(annotationValue, annotationNode, lockTypeClass, lockImplClass, new AtomicBoolean(method.isStatic()), false);
 	}

--- a/src/core/lombok/eclipse/handlers/HandleSynchronized.java
+++ b/src/core/lombok/eclipse/handlers/HandleSynchronized.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2024 The Project Lombok Authors.
+ * Copyright (C) 2009-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -69,6 +69,8 @@ public class HandleSynchronized extends EclipseAnnotationHandler<Synchronized> {
 		if (methodNode == null || methodNode.getKind() != Kind.METHOD || !(methodNode.get() instanceof MethodDeclaration)) return;
 		MethodDeclaration method = (MethodDeclaration) methodNode.get();
 		if (method.isAbstract()) return;
+		EclipseNode typeNode = upToTypeNode(annotationNode);
+		if (isRecord(typeNode)) return;
 		
 		createLockField(annotation, annotationNode, new boolean[] {method.isStatic()}, false);
 		

--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2024 The Project Lombok Authors.
+ * Copyright (C) 2009-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1152,6 +1152,23 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 		sm.addScriptIfWitness(ECLIPSE_TEST_CLASSES, ScriptBuilder.exitEarly()
 				.target(new MethodTarget("org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration", "print", "java.lang.StringBuffer", "int", "java.lang.StringBuffer"))
 				.decisionMethod(new Hook("lombok.launch.PatchFixesHider$Tests", "isImplicitCanonicalConstructor", "boolean", "org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration", "java.lang.Object"))
+				.valueMethod(new Hook("lombok.launch.PatchFixesHider$Tests", "returnStringBuffer", "java.lang.StringBuffer", "java.lang.Object", "java.lang.StringBuffer"))
+				.request(StackRequest.THIS, StackRequest.PARAM2)
+				.transplant()
+				.build());
+		
+		// Remove implicit record fields in tests
+		sm.addScriptIfWitness(ECLIPSE_TEST_CLASSES, ScriptBuilder.exitEarly()
+				.target(new MethodTarget("org.eclipse.jdt.internal.compiler.ast.FieldDeclaration", "print", "java.lang.StringBuilder", "int", "java.lang.StringBuilder"))
+				.decisionMethod(new Hook("lombok.launch.PatchFixesHider$Tests", "isRecordComponent", "boolean", "org.eclipse.jdt.internal.compiler.ast.FieldDeclaration", "java.lang.Object"))
+				.valueMethod(new Hook("lombok.launch.PatchFixesHider$Tests", "returnStringBuilder", "java.lang.StringBuilder", "java.lang.Object", "java.lang.StringBuilder"))
+				.request(StackRequest.THIS, StackRequest.PARAM2)
+				.transplant()
+				.build());
+		
+		sm.addScriptIfWitness(ECLIPSE_TEST_CLASSES, ScriptBuilder.exitEarly()
+				.target(new MethodTarget("org.eclipse.jdt.internal.compiler.ast.FieldDeclaration", "print", "java.lang.StringBuffer", "int", "java.lang.StringBuffer"))
+				.decisionMethod(new Hook("lombok.launch.PatchFixesHider$Tests", "isRecordComponent", "boolean", "org.eclipse.jdt.internal.compiler.ast.FieldDeclaration", "java.lang.Object"))
 				.valueMethod(new Hook("lombok.launch.PatchFixesHider$Tests", "returnStringBuffer", "java.lang.StringBuffer", "java.lang.Object", "java.lang.StringBuffer"))
 				.request(StackRequest.THIS, StackRequest.PARAM2)
 				.transplant()

--- a/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/EclipsePatcher.java
@@ -333,7 +333,7 @@ public class EclipsePatcher implements AgentLauncher.AgentLaunchable {
 				.transplant()
 				.build());
 		
-		sm.addScriptIfComplexWitness(new String[][] {OSGI_TYPES, new String[] {"org/eclipse/jdt/internal/compiler/parser/TerminalToken"}}, ScriptBuilder.replaceMethodCall()
+		sm.addScriptIfWitness(OSGI_TYPES, ScriptBuilder.replaceMethodCall()
 				.target(new MethodTarget("org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer", "visit"))
 				.methodToReplace(new Hook("org.eclipse.jdt.internal.core.dom.rewrite.TokenScanner", "getTokenEndOffset", "int", "org.eclipse.jdt.internal.compiler.parser.TerminalToken", "int"))
 				.replacementMethod(new Hook("lombok.launch.PatchFixesHider$PatchFixes", "getTokenEndOffsetFixed", "int", "org.eclipse.jdt.internal.core.dom.rewrite.TokenScanner", "java.lang.Object", "int", "java.lang.Object"))

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2024 The Project Lombok Authors.
+ * Copyright (C) 2010-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1115,6 +1115,10 @@ final class PatchFixesHider {
 		
 		public static boolean isImplicitCanonicalConstructor(AbstractMethodDeclaration method, Object parameter) {
 			return (method.bits & IsCanonicalConstructor) != 0 && (method.bits & IsImplicit) != 0;
+		}
+		
+		public static boolean isRecordComponent(FieldDeclaration field, Object parameter) {
+			return (field.modifiers & AccRecord) != 0;
 		}
 		
 		public static StringBuffer returnStringBuffer(Object p1, StringBuffer buffer) {

--- a/src/support/lombok/eclipse/dependencies/DownloadEclipseDependencies.java
+++ b/src/support/lombok/eclipse/dependencies/DownloadEclipseDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 The Project Lombok Authors.
+ * Copyright (C) 2022-2025 The Project Lombok Authors.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ public class DownloadEclipseDependencies {
 		String updateSiteUrl = args[2];
 		boolean resolveDependencies = Boolean.parseBoolean(args[3]);
 		List<String> bundles = Arrays.asList(Arrays.copyOfRange(args, 4, args.length));
+		boolean isCi = "true".equalsIgnoreCase(System.getenv("CI"));
 		
 		UpdateSite updateSite = new UpdateSite();
 		updateSite.read(updateSiteUrl);
@@ -69,14 +70,16 @@ public class DownloadEclipseDependencies {
 			// Download artifact
 			downloadFile(artifact, pluginSource, pluginTarget);
 			
-			// Download artifact source
-			int index = artifact.lastIndexOf("_");
-			String source = artifact.substring(0, index) + ".source" + artifact.substring(index);
-			try {
-				downloadFile(source, pluginSource, pluginTarget);
-			} catch (Exception e) {
-				// It's just the source; sometimes these aren't present (specifically, `org.eclipse.swt` doesn't currently appear to have the sources, at least not using the `_sources` naming scheme). Don't fail, just skip them.
-				System.out.println("[failed]");
+			// Download artifact source for local development
+			if (!isCi) {
+				int index = artifact.lastIndexOf("_");
+				String source = artifact.substring(0, index) + ".source" + artifact.substring(index);
+				try {
+					downloadFile(source, pluginSource, pluginTarget);
+				} catch (Exception e) {
+					// It's just the source; sometimes these aren't present (specifically, `org.eclipse.swt` doesn't currently appear to have the sources, at least not using the `_sources` naming scheme). Don't fail, just skip them.
+					System.out.println("[failed]");
+				}
 			}
 		}
 		

--- a/test/transform/resource/after-ecj/BuilderOnNestedRecord.java
+++ b/test/transform/resource/after-ecj/BuilderOnNestedRecord.java
@@ -19,10 +19,8 @@ public record BuilderOnNestedRecord(T t)<T> {
         return (("BuilderOnNestedRecord.Nested.NestedBuilder(a=" + this.a) + ")");
       }
     }
-/* Implicit */    private final String a;
     public static @java.lang.SuppressWarnings("all") @lombok.Generated BuilderOnNestedRecord.Nested.NestedBuilder builder() {
       return new BuilderOnNestedRecord.Nested.NestedBuilder();
     }
   }
-/* Implicit */  private final T t;
 }

--- a/test/transform/resource/after-ecj/BuilderSimpleOnRecord.java
+++ b/test/transform/resource/after-ecj/BuilderSimpleOnRecord.java
@@ -28,8 +28,6 @@ public @lombok.Builder(access = lombok.AccessLevel.PROTECTED) record BuilderSimp
       return (((("BuilderSimpleOnRecord.BuilderSimpleOnRecordBuilder(l=" + this.l) + ", a=") + this.a) + ")");
     }
   }
-/* Implicit */  private final List<T> l;
-/* Implicit */  private final String a;
   protected static @java.lang.SuppressWarnings("all") @lombok.Generated <T>BuilderSimpleOnRecord.BuilderSimpleOnRecordBuilder<T> builder() {
     return new BuilderSimpleOnRecord.BuilderSimpleOnRecordBuilder<T>();
   }

--- a/test/transform/resource/after-ecj/BuilderSingularOnRecord.java
+++ b/test/transform/resource/after-ecj/BuilderSingularOnRecord.java
@@ -114,9 +114,6 @@ public @Builder record BuilderSingularOnRecord(List children, Collection scarves
       return (((((("BuilderSingularOnRecord.BuilderSingularOnRecordBuilder(children=" + this.children) + ", scarves=") + this.scarves) + ", rawList=") + this.rawList) + ")");
     }
   }
-/* Implicit */  private final List<T> children;
-/* Implicit */  private final Collection<? extends Number> scarves;
-/* Implicit */  private final List rawList;
   public static @java.lang.SuppressWarnings("all") @lombok.Generated <T>BuilderSingularOnRecord.BuilderSingularOnRecordBuilder<T> builder() {
     return new BuilderSingularOnRecord.BuilderSingularOnRecordBuilder<T>();
   }

--- a/test/transform/resource/after-ecj/ConstructorsOnRecord.java
+++ b/test/transform/resource/after-ecj/ConstructorsOnRecord.java
@@ -3,6 +3,4 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 public @AllArgsConstructor @RequiredArgsConstructor @NoArgsConstructor record ConstructorsOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
 }

--- a/test/transform/resource/after-ecj/DataOnRecord.java
+++ b/test/transform/resource/after-ecj/DataOnRecord.java
@@ -1,6 +1,4 @@
 // version 14:
 import lombok.Data;
 public @Data record DataOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
 }

--- a/test/transform/resource/after-ecj/DelegateOnRecord.java
+++ b/test/transform/resource/after-ecj/DelegateOnRecord.java
@@ -1,7 +1,6 @@
 // version 14:
 import lombok.experimental.Delegate;
 record DelegateOnRecord(Runnable runnable) {
-/* Implicit */  private final Runnable runnable;
   public @java.lang.SuppressWarnings("all") @lombok.Generated void run() {
     this.runnable.run();
   }

--- a/test/transform/resource/after-ecj/EqualsAndHashCodeOnRecord.java
+++ b/test/transform/resource/after-ecj/EqualsAndHashCodeOnRecord.java
@@ -1,6 +1,4 @@
 // version 14:
 import lombok.EqualsAndHashCode;
 public @EqualsAndHashCode record EqualsAndHashCodeOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
 }

--- a/test/transform/resource/after-ecj/FieldDefaultsOnRecord.java
+++ b/test/transform/resource/after-ecj/FieldDefaultsOnRecord.java
@@ -1,5 +1,3 @@
 // version 14:
 public @lombok.experimental.FieldDefaults(makeFinal = true) record FieldDefaultsOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
 }

--- a/test/transform/resource/after-ecj/FieldDefaultsViaConfigOnRecord.java
+++ b/test/transform/resource/after-ecj/FieldDefaultsViaConfigOnRecord.java
@@ -1,5 +1,3 @@
 // version 14:
 public record FieldDefaultsViaConfigOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
 }

--- a/test/transform/resource/after-ecj/FieldNameConstantsOnRecord.java
+++ b/test/transform/resource/after-ecj/FieldNameConstantsOnRecord.java
@@ -11,10 +11,6 @@ public @FieldNameConstants(level = AccessLevel.PACKAGE) record FieldNameConstant
       super();
     }
   }
-/* Implicit */  private final String iAmADvdPlayer;
-/* Implicit */  private final int $skipMe;
-/* Implicit */  private final int andMe;
-/* Implicit */  private final String butPrintMePlease;
   static double skipMeToo;
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/GetterOnRecord.java
+++ b/test/transform/resource/after-ecj/GetterOnRecord.java
@@ -1,6 +1,4 @@
 // version 14:
 import lombok.Getter;
 public @Getter record GetterOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
 }

--- a/test/transform/resource/after-ecj/JacksonizedOnRecord.java
+++ b/test/transform/resource/after-ecj/JacksonizedOnRecord.java
@@ -56,8 +56,6 @@ public @lombok.extern.jackson.Jacksonized @lombok.Builder @JsonIgnoreProperties 
       return (((("JacksonizedOnRecord.JacksonizedOnRecordBuilder(string=" + this.string) + ", values=") + this.values) + ")");
     }
   }
-/* Implicit */  private final String string;
-/* Implicit */  private final List<String> values;
   public static @java.lang.SuppressWarnings("all") @lombok.Generated JacksonizedOnRecord.JacksonizedOnRecordBuilder builder() {
     return new JacksonizedOnRecord.JacksonizedOnRecordBuilder();
   }

--- a/test/transform/resource/after-ecj/LockedInRecord.java
+++ b/test/transform/resource/after-ecj/LockedInRecord.java
@@ -1,8 +1,5 @@
 import lombok.Locked;
 public record LockedInRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
-  private final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.concurrent.locks.Lock $lock = new java.util.concurrent.locks.ReentrantLock();
   public @Locked void foo() {
     String foo = "bar";
   }

--- a/test/transform/resource/after-ecj/LoggerConfigOnRecord.java
+++ b/test/transform/resource/after-ecj/LoggerConfigOnRecord.java
@@ -1,6 +1,4 @@
 // version 14:
 import lombok.extern.slf4j.Slf4j;
 public @Slf4j record LoggerConfigOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
 }

--- a/test/transform/resource/after-ecj/LoggerFloggerRecord.java
+++ b/test/transform/resource/after-ecj/LoggerFloggerRecord.java
@@ -1,7 +1,6 @@
 import lombok.extern.flogger.Flogger;
 class LoggerFloggerRecord {
   public @Flogger record Inner(String x) {
-/* Implicit */    private final String x;
     private static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
     <clinit>() {
     }

--- a/test/transform/resource/after-ecj/LoggerSlf4jOnRecord.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4jOnRecord.java
@@ -1,7 +1,5 @@
 import lombok.extern.slf4j.Slf4j;
 public @Slf4j record LoggerSlf4jOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
   private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jOnRecord.class);
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/NonNullExistingConstructorOnRecord.java
+++ b/test/transform/resource/after-ecj/NonNullExistingConstructorOnRecord.java
@@ -1,8 +1,6 @@
 // version 14:
 import lombok.NonNull;
 public record NonNullExistingConstructorOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
   public NonNullExistingConstructorOnRecord(@NonNull String b) {
     this("default", b);
     if ((b == null))

--- a/test/transform/resource/after-ecj/NonNullOnRecordExistingConstructor.java
+++ b/test/transform/resource/after-ecj/NonNullOnRecordExistingConstructor.java
@@ -1,14 +1,13 @@
 // version 14:
+// skip compare content
 import lombok.NonNull;
 public record NonNullOnRecordExistingConstructor(String a) {
-/* Implicit */  private final String a;
-  public NonNullOnRecordExistingConstructor(@NonNull String a) {
+  public NonNullOnRecordExistingConstructor {
     super();
     if ((a == null))
         {
           throw new java.lang.NullPointerException("a is marked non-null but is null");
         }
     System.out.println("Hello");
-    this.a = a;
   }
 }

--- a/test/transform/resource/after-ecj/NonNullOnRecordExistingSetter.java
+++ b/test/transform/resource/after-ecj/NonNullOnRecordExistingSetter.java
@@ -1,7 +1,6 @@
 // version 19:
 import lombok.NonNull;
 public record NonNullOnRecordExistingSetter(String a) {
-/* Implicit */  private final String a;
   public NonNullOnRecordExistingSetter(String a) {
     super();
     this.a = a;

--- a/test/transform/resource/after-ecj/NonNullOnRecordSimple.java
+++ b/test/transform/resource/after-ecj/NonNullOnRecordSimple.java
@@ -1,8 +1,6 @@
 // version 14:
 import lombok.NonNull;
 public record NonNullOnRecordSimple(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
   public @java.lang.SuppressWarnings("all") @lombok.Generated NonNullOnRecordSimple(@NonNull String a, @NonNull String b) {
     super();
     if ((a == null))

--- a/test/transform/resource/after-ecj/NonNullOnRecordTypeUse.java
+++ b/test/transform/resource/after-ecj/NonNullOnRecordTypeUse.java
@@ -1,9 +1,6 @@
 // version 14:
 import lombok.NonNull;
 public record NonNullOnRecordTypeUse(int a, int b, int c) {
-/* Implicit */  private final int[] a;
-/* Implicit */  private final int @NonNull [] b;
-/* Implicit */  private final int[] @NonNull [] c;
   public @java.lang.SuppressWarnings("all") @lombok.Generated NonNullOnRecordTypeUse(@NonNull int[] a, int @NonNull [] b, int[] @NonNull [] c) {
     super();
     if ((a == null))

--- a/test/transform/resource/after-ecj/SetterOnRecord.java
+++ b/test/transform/resource/after-ecj/SetterOnRecord.java
@@ -1,6 +1,4 @@
 // version 14:
 import lombok.Setter;
 public @Setter record SetterOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
 }

--- a/test/transform/resource/after-ecj/SynchronizedInRecord.java
+++ b/test/transform/resource/after-ecj/SynchronizedInRecord.java
@@ -1,8 +1,5 @@
 import lombok.Synchronized;
 public record SynchronizedInRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
-  private final @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.Object $lock = new java.lang.Object[0];
   public @Synchronized void foo() {
     String foo = "bar";
   }

--- a/test/transform/resource/after-ecj/ToStringOnRecord.java
+++ b/test/transform/resource/after-ecj/ToStringOnRecord.java
@@ -1,6 +1,4 @@
 // version 14:
 import lombok.ToString;
 public @ToString record ToStringOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
 }

--- a/test/transform/resource/after-ecj/UtilityClassOnRecord.java
+++ b/test/transform/resource/after-ecj/UtilityClassOnRecord.java
@@ -1,6 +1,4 @@
 // version 14:
 import lombok.experimental.UtilityClass;
 public @UtilityClass record UtilityClassOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
 }

--- a/test/transform/resource/after-ecj/ValueOnRecord.java
+++ b/test/transform/resource/after-ecj/ValueOnRecord.java
@@ -1,6 +1,4 @@
 // version 14:
 import lombok.Value;
 public @Value record ValueOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
 }

--- a/test/transform/resource/after-ecj/WithByOnRecord.java
+++ b/test/transform/resource/after-ecj/WithByOnRecord.java
@@ -1,8 +1,6 @@
 // version 14:
 import lombok.experimental.WithBy;
 public @WithBy record WithByOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
   public @java.lang.SuppressWarnings("all") @lombok.Generated WithByOnRecord withABy(final java.util.function.Function<? super String, ? extends String> transformer) {
     return new WithByOnRecord(transformer.apply(this.a), this.b);
   }

--- a/test/transform/resource/after-ecj/WithByOnRecordComponent.java
+++ b/test/transform/resource/after-ecj/WithByOnRecordComponent.java
@@ -1,8 +1,6 @@
 // version 14:
 import lombok.experimental.WithBy;
 public record WithByOnRecordComponent(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
   public @java.lang.SuppressWarnings("all") @lombok.Generated WithByOnRecordComponent withABy(final java.util.function.Function<? super String, ? extends String> transformer) {
     return new WithByOnRecordComponent(transformer.apply(this.a), this.b);
   }

--- a/test/transform/resource/after-ecj/WithOnNestedRecord.java
+++ b/test/transform/resource/after-ecj/WithOnNestedRecord.java
@@ -1,8 +1,6 @@
 import lombok.With;
 public record WithOnNestedRecord()<T> {
   public @With record Nested(String a, String b) {
-/* Implicit */    private final String a;
-/* Implicit */    private final String b;
     /**
      * @return a clone of this object, except with this updated property (returns {@code this} if an identical value is passed).
      */

--- a/test/transform/resource/after-ecj/WithOnRecord.java
+++ b/test/transform/resource/after-ecj/WithOnRecord.java
@@ -1,8 +1,6 @@
 // version 14:
 import lombok.With;
 public @With record WithOnRecord(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
   /**
    * @return a clone of this object, except with this updated property (returns {@code this} if an identical value is passed).
    */

--- a/test/transform/resource/after-ecj/WithOnRecordComponent.java
+++ b/test/transform/resource/after-ecj/WithOnRecordComponent.java
@@ -1,8 +1,6 @@
 // version 14:
 import lombok.With;
 public record WithOnRecordComponent(String a, String b) {
-/* Implicit */  private final String a;
-/* Implicit */  private final String b;
   /**
    * @return a clone of this object, except with this updated property (returns {@code this} if an identical value is passed).
    */


### PR DESCRIPTION
This PR fixes #3883

Eclipse changed how they handle records. Instead of generating fields early on it now does it in a later stage. To keep the support in lombok we now map the record components to fields ourself and add theses fields to our AST. To keep the test output the same I added a patch that removes the implicit fields from the output if they are present.