### PR TITLE
Add a single annotation replacing the use of @Getter and @Setter both

### DIFF
--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -205,7 +205,16 @@ public class ConfigurationKeys {
 	 * If set, <em>any</em> usage of {@code @Data} results in a warning / error.
 	 */
 	public static final ConfigurationKey<FlagUsageType> DATA_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.data.flagUsage", "Emit a warning or error if @Data is used.") {};
-	
+
+	// ----- GSet -----
+
+	/**
+	 * lombok configuration: {@code lombok.gset.flagUsage} = {@code WARNING} | {@code ERROR}.
+	 *
+	 * If set, <em>any</em> usage of {@code @GSet} results in a warning / error.
+	 */
+	public static final ConfigurationKey<FlagUsageType> GSET_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.gset.flagUsage", "Emit a warning or error if @GSet is used.") {};
+
 	// ----- Value -----
 	
 	/**

--- a/src/core/lombok/GSet.java
+++ b/src/core/lombok/GSet.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2009-2017 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package lombok;
 
 import java.lang.annotation.ElementType;
@@ -5,6 +27,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/*
+ * Replaces the need to use both Getter and Setter annotations together
+ * 
+ * This annotation can be applied directly to a class
+ */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.SOURCE)
 public @interface GSet { }

--- a/src/core/lombok/GSet.java
+++ b/src/core/lombok/GSet.java
@@ -5,8 +5,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.FIELD, ElementType.TYPE})
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.SOURCE)
-public @interface GSet {
-    
-}
+public @interface GSet { }

--- a/src/core/lombok/GSet.java
+++ b/src/core/lombok/GSet.java
@@ -1,0 +1,12 @@
+package lombok;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+public @interface GSet {
+    
+}

--- a/src/core/lombok/javac/handlers/HandleGSet.java
+++ b/src/core/lombok/javac/handlers/HandleGSet.java
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package lombok.javac.handlers;
 
 import static lombok.core.handlers.HandlerUtil.*;
 import static lombok.javac.handlers.JavacHandlerUtil.*;
@@ -34,11 +35,10 @@ import lombok.spi.Provides;
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.util.List;
 
-package lombok.javac.handlers;
-
 /**
  * Handles the {@code lombok.GSet} annotation for javac.
  */
+@Provides
 public class HandleGSet extends JavacAnnotationHandler<Data>{
 
     private HandleGetter handleGetter = new HandleGetter();
@@ -47,19 +47,18 @@ public class HandleGSet extends JavacAnnotationHandler<Data>{
 
     @Override
     public void handle(AnnotationValues<Data> annotation, JCAnnotation ast, JavacNode annotationNode){
-        handleFlagUsage(annotationNode, ConfigurationKeys.DATA_FLAG_USAGE, "@Data");
+        handleFlagUsage(annotationNode, ConfigurationKeys.GSET_FLAG_USAGE, "@GSet");
 
         deleteAnnotationIfNeccessary(annotationNode, Data.class);
         JavacNode typeNode = annotationNode.up();
 
         if (!isClass(typeNode)) {
-            annotationNode.addError("@Data is only supported on a class.");
+            annotationNode.addError("@GSet is only supported on a class.");
             return;
         }
 
         String staticConstructorName = annotation.getInstance().staticConstructor();
 
-        // TODO move this to the end OR move it to the top in eclipse.
         handleGetter.generateGetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true, List.<JCAnnotation>nil());
         handleSetter.generateSetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true, List.<JCAnnotation>nil(), List.<JCAnnotation>nil());
     }

--- a/src/core/lombok/javac/handlers/HandleGSet.java
+++ b/src/core/lombok/javac/handlers/HandleGSet.java
@@ -25,11 +25,10 @@ import static lombok.core.handlers.HandlerUtil.*;
 import static lombok.javac.handlers.JavacHandlerUtil.*;
 import lombok.AccessLevel;
 import lombok.ConfigurationKeys;
-import lombok.Data;
+import lombok.GSet;
 import lombok.core.AnnotationValues;
 import lombok.javac.JavacAnnotationHandler;
 import lombok.javac.JavacNode;
-import lombok.javac.handlers.HandleConstructor.SkipIfConstructorExists;
 import lombok.spi.Provides;
 
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
@@ -46,10 +45,10 @@ public class HandleGSet extends JavacAnnotationHandler<Data>{
 
 
     @Override
-    public void handle(AnnotationValues<Data> annotation, JCAnnotation ast, JavacNode annotationNode){
+    public void handle(AnnotationValues<GSet> annotation, JCAnnotation ast, JavacNode annotationNode){
         handleFlagUsage(annotationNode, ConfigurationKeys.GSET_FLAG_USAGE, "@GSet");
 
-        deleteAnnotationIfNeccessary(annotationNode, Data.class);
+        deleteAnnotationIfNeccessary(annotationNode, GSet.class);
         JavacNode typeNode = annotationNode.up();
 
         if (!isClass(typeNode)) {

--- a/src/core/lombok/javac/handlers/HandleGSet.java
+++ b/src/core/lombok/javac/handlers/HandleGSet.java
@@ -1,0 +1,5 @@
+package lombok.javac.handlers;
+
+public class HandleGSet {
+    
+}

--- a/src/core/lombok/javac/handlers/HandleGSet.java
+++ b/src/core/lombok/javac/handlers/HandleGSet.java
@@ -1,5 +1,66 @@
+/*
+ * Copyright (C) 2009-2025 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.javac.handlers.JavacHandlerUtil.*;
+import lombok.AccessLevel;
+import lombok.ConfigurationKeys;
+import lombok.Data;
+import lombok.core.AnnotationValues;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.javac.handlers.HandleConstructor.SkipIfConstructorExists;
+import lombok.spi.Provides;
+
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.util.List;
+
 package lombok.javac.handlers;
 
-public class HandleGSet {
-    
+/**
+ * Handles the {@code lombok.GSet} annotation for javac.
+ */
+public class HandleGSet extends JavacAnnotationHandler<Data>{
+
+    private HandleGetter handleGetter = new HandleGetter();
+    private HandleSetter handleSetter = new HandleSetter();
+
+
+    @Override
+    public void handle(AnnotationValues<Data> annotation, JCAnnotation ast, JavacNode annotationNode){
+        handleFlagUsage(annotationNode, ConfigurationKeys.DATA_FLAG_USAGE, "@Data");
+
+        deleteAnnotationIfNeccessary(annotationNode, Data.class);
+        JavacNode typeNode = annotationNode.up();
+
+        if (!isClass(typeNode)) {
+            annotationNode.addError("@Data is only supported on a class.");
+            return;
+        }
+
+        String staticConstructorName = annotation.getInstance().staticConstructor();
+
+        // TODO move this to the end OR move it to the top in eclipse.
+        handleGetter.generateGetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true, List.<JCAnnotation>nil());
+        handleSetter.generateSetterForType(typeNode, annotationNode, AccessLevel.PUBLIC, true, List.<JCAnnotation>nil(), List.<JCAnnotation>nil());
+    }
 }


### PR DESCRIPTION
This PR is for the issue #3835

Adds a new annotation that combines **Getter** and **Setter** annotations into a single one **Gset**

I may have missed some required configurations details - particularly, this annotation **doesn´t support parameters** yet and **I haven't been able to test it fully** due to some local environment issues, that´s why I wanted to share this early version in case it's helpful or can be built upon.

Feedback is very welcome. Thanks!

PD: "GSet" name were based on a suggestion from @fabriciuMF