### PR TITLE
Add support for JDK 25

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     env:
-      EA_JDK: 24
+      EA_JDK: 25
     strategy: 
       matrix: 
-        jdk: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
+        jdk: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
         goal: [javacCurrent]
         include:
           - jdk: 11

--- a/src/delombok/lombok/delombok/PrettyPrinter.java
+++ b/src/delombok/lombok/delombok/PrettyPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 The Project Lombok Authors.
+ * Copyright (C) 2016-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -92,13 +92,13 @@ import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Position;
 
 import lombok.javac.CommentInfo;
-import lombok.javac.Javac;
-import lombok.javac.PackageName;
-import lombok.permit.Permit;
 import lombok.javac.CommentInfo.EndConnection;
 import lombok.javac.CommentInfo.StartConnection;
+import lombok.javac.Javac;
 import lombok.javac.JavacTreeMaker.TreeTag;
 import lombok.javac.JavacTreeMaker.TypeTag;
+import lombok.javac.PackageName;
+import lombok.permit.Permit;
 
 public class PrettyPrinter extends JCTree.Visitor {
 	private static final String LINE_SEP = System.getProperty("line.separator");
@@ -697,7 +697,7 @@ public class PrettyPrinter extends JCTree.Visitor {
 		 */
 		try {
 			innermostArrayBracketsAreVarargs = varargs;
-			if (tree.vartype == null || tree.vartype.pos == -1) {
+			if (tree.vartype == null || tree.vartype.pos == -1 || endPos(tree.vartype) == -1) {
 				print("var");
 			} else {
 				print(tree.vartype);

--- a/src/utils/lombok/javac/Javac.java
+++ b/src/utils/lombok/javac/Javac.java
@@ -82,7 +82,7 @@ public class Javac {
 	public static final long COMPACT_RECORD_CONSTRUCTOR = 1L << 51; // MethodSymbols (the 'implicit' many-args constructor that records have)
 	public static final long UNINITIALIZED_FIELD = 1L << 51; // VarSymbols (To identify fields that the compact record constructor won't initialize)
 	public static final long GENERATED_MEMBER = 1L << 24; // MethodSymbols, VarSymbols (marks methods and the constructor generated in records)
-	public static final long SEALED = 1L << 62; // ClassSymbols (Flag to indicate sealed class/interface declaration)
+	public static final long SEALED = 1L << 62 | 1L << 48; // ClassSymbols (Flag to indicate sealed class/interface declaration)
 	public static final long NON_SEALED = 1L << 63; // ClassSymbols (Flag to indicate that the class/interface was declared with the non-sealed modifier)
 	
 	/**


### PR DESCRIPTION
This PR adds support for JDK 25

I removed the mandatory warning because it is never used and it the `javac` method will be [gone soon too](https://github.com/openjdk/jdk/commit/cab515962b6940b50b975b12c8f5e99d0430f694#diff-7c7763cf662e3d88be93a2fd7557f1573cd793fd806e1ed3b86057456306e590).