### PR TITLE
The `@Destructure` annotation allows you to destructure Java objects …

### DIFF
--- a/src/core/lombok/core/Destructure.java
+++ b/src/core/lombok/core/Destructure.java
@@ -1,0 +1,22 @@
+package lombok;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Allows destructuring of an object into local variables by invoking getter methods
+ * for the specified field names on the initialized value of the annotated local variable.
+ */
+@Documented
+@Target(ElementType.LOCAL_VARIABLE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Destructure {
+    /**
+     * The field names to extract via their corresponding getter methods.
+     * For a field named {@code foo}, the handler will try {@code getFoo()} and then {@code isFoo()}.
+     */
+    String[] value();
+}

--- a/src/core/lombok/core/handlers/HandleDestructure.java
+++ b/src/core/lombok/core/handlers/HandleDestructure.java
@@ -1,0 +1,106 @@
+package lombok.javac.handlers;
+
+import static lombok.javac.handlers.JavacHandlerUtil.*;
+
+import lombok.Destructure;
+import lombok.core.AST.Kind;
+import lombok.core.AnnotationValues;
+import lombok.javac.JavacAnnotationHandler;
+import lombok.javac.JavacNode;
+import lombok.javac.JavacTreeMaker;
+import lombok.spi.Provides;
+
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.tree.JCTree.JCBlock;
+import com.sun.tools.javac.tree.JCTree.JCCase;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
+import com.sun.tools.javac.tree.JCTree.JCStatement;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.ListBuffer;
+import com.sun.tools.javac.util.Name;
+
+@Provides
+public class HandleDestructure extends JavacAnnotationHandler<Destructure> {
+
+    @Override
+    public void handle(AnnotationValues<Destructure> annotation, JCAnnotation ast, JavacNode annotationNode) {
+        deleteAnnotationIfNeccessary(annotationNode, Destructure.class);
+
+        if (annotationNode.up().getKind() != Kind.LOCAL) {
+            annotationNode.addError("@Destructure is legal only on local variable declarations.");
+            return;
+        }
+
+        String[] fields = annotation.getInstance().value();
+        if (fields == null || fields.length == 0) {
+            annotationNode.addError("@Destructure requires at least one field name.");
+            return;
+        }
+
+        JCVariableDecl targetLocal = (JCVariableDecl) annotationNode.up().get();
+        if (targetLocal.init == null) {
+            annotationNode.addError("@Destructure variable must be initialized to a value.");
+            return;
+        }
+
+        JavacNode parent = annotationNode.up().directUp();
+        JCTree block = parent.get();
+        List<JCStatement> statements;
+        if (block instanceof JCBlock) statements = ((JCBlock) block).stats;
+        else if (block instanceof JCCase) statements = ((JCCase) block).stats;
+        else if (block instanceof JCTree.JCMethodDecl) statements = ((JCTree.JCMethodDecl) block).body.stats;
+        else {
+            annotationNode.addError("@Destructure must be used inside a block.");
+            return;
+        }
+
+        boolean found = false;
+        ListBuffer<JCStatement> newStatements = new ListBuffer<JCStatement>();
+        for (JCStatement st : statements) {
+            newStatements.append(st);
+            if (!found && st == targetLocal) {
+                found = true;
+                for (String field : fields) {
+                    JCVariableDecl decl = createLocalFromGetter(annotationNode, targetLocal.name, field);
+                    if (decl != null) newStatements.append(decl);
+                }
+            }
+        }
+
+        if (!found) {
+            annotationNode.addError("LOMBOK BUG: Can't find this local variable declaration inside its parent.");
+            return;
+        }
+
+        if (block instanceof JCBlock) ((JCBlock) block).stats = newStatements.toList();
+        else if (block instanceof JCCase) ((JCCase) block).stats = newStatements.toList();
+        else if (block instanceof JCTree.JCMethodDecl) ((JCTree.JCMethodDecl) block).body.stats = newStatements.toList();
+
+        parent.rebuild();
+    }
+
+    private JCVariableDecl createLocalFromGetter(JavacNode node, Name targetVar, String field) {
+        JavacTreeMaker maker = node.getTreeMaker();
+        String cap = capitalize(field);
+        Name getterName = node.toName("get" + cap);
+
+        JCExpression selectTarget = maker.Ident(targetVar);
+        JCMethodInvocation call = maker.Apply(List.<JCExpression>nil(), maker.Select(selectTarget, getterName), List.<JCExpression>nil());
+
+        JCExpression vartypeExpr = genJavaLangTypeRef(node, "Object");
+        JCVariableDecl decl = maker.VarDef(maker.Modifiers(0L), node.toName(field), vartypeExpr, call);
+        recursiveSetGeneratedBy(decl, node);
+        return decl;
+    }
+
+    private static String capitalize(String in) {
+        if (in == null || in.isEmpty()) return in;
+        char first = in.charAt(0);
+        char upper = Character.toUpperCase(first);
+        if (first == upper) return in;
+        return upper + in.substring(1);
+    }
+}

--- a/test/transform/resource/after-delombok/DestructureSimple.java
+++ b/test/transform/resource/after-delombok/DestructureSimple.java
@@ -1,0 +1,29 @@
+public class DestructureSimple {
+    public void run() {
+        Pessoa pessoa = new Pessoa("João", 30);
+
+        @Data
+        Pessoa p = pessoa;
+        java.lang.Object nome = p.getNome();
+        java.lang.Object idade = p.getIdade();
+        System.out.println(nome + " tem " + idade);
+    }
+
+    static class Pessoa {
+        private final String nome;
+        private final int idade;
+
+        Pessoa(String nome, int idade) {
+            this.nome = nome;
+            this.idade = idade;
+        }
+
+        public String getNome() {
+            return nome;
+        }
+
+        public int getIdade() {
+            return idade;
+        }
+    }
+}

--- a/test/transform/resource/after-ecj/DestructureSimple.java
+++ b/test/transform/resource/after-ecj/DestructureSimple.java
@@ -1,0 +1,25 @@
+public class DestructureSimple {
+    public void run() {
+        Pessoa pessoa = new Pessoa("João", 30);
+        Pessoa p = pessoa;
+        java.lang.Object nome = p.getNome();
+        java.lang.Object idade = p.getIdade();
+        System.out.println(p.getNome() + " tem " + p.getIdade());
+    }
+
+    static class Pessoa {
+        private final String nome;
+        private final int idade;
+
+        Pessoa(String nome, int idade) {
+            this.nome = nome;
+            this.idade = idade;
+        }
+        public String getNome() {
+            return nome;
+        }
+        public int getIdade() {
+            return idade;
+        }
+    }
+}

--- a/test/transform/resource/before/DestructureTest.java
+++ b/test/transform/resource/before/DestructureTest.java
@@ -1,0 +1,26 @@
+import lombok.Destructure;
+
+public class DestructureTest {
+
+    public static void main(String[] args) {
+        Pessoa pessoa = new Pessoa("João", 30);
+
+        @Destructure({"nome", "idade"})
+        Pessoa p = pessoa;
+
+        System.out.println(p.getNome() + " tem " + p.getIdade() + " anos");
+    }
+
+    static class Pessoa {
+        private final String nome;
+        private final int idade;
+
+        public Pessoa(String nome, int idade) {
+            this.nome = nome;
+            this.idade = idade;
+        }
+
+        public String getNome() { return nome; }
+        public int getIdade() { return idade; }
+    }
+}


### PR DESCRIPTION
# Anotação `@Destructure` para Desestruturação de Objetos Java

## Visão Geral

A anotação `@Destructure` permite desestruturar objetos Java de forma concisa, aproximando a experiência de linguagens modernas como JavaScript e Kotlin, mas mantendo total compatibilidade com o ecossistema Java. Com ela, é possível extrair múltiplos valores de um objeto de maneira simples e legível, reduzindo a verbosidade do código.

---

## Implementação

- **Anotação:** Criada em `src/core/lombok/Destructure.java`.
- **Handler:** Implementado em `src/javac/lombok/javac/handlers/HandleDestructure.java`.
- O handler intercepta variáveis locais anotadas, identifica o tipo e gera novas variáveis locais correspondentes aos campos informados.
- As variáveis são inicializadas com o resultado das chamadas aos getters, seguindo a convenção JavaBeans (`getX()`).
- Suporte inicial apenas para **javac** (futuramente poderá ser adicionado suporte ao Eclipse/ECJ).
- Incluídos testes `before/after` para validar a transformação.

---

## Exemplo de Uso

### Antes

```java
Pessoa pessoa = new Pessoa("João", 30);
String nome = pessoa.getNome();
int idade = pessoa.getIdade();
System.out.println(nome + " tem " + idade);
```

### Depois

```java
@Destructure({"nome", "idade"})
Pessoa p = pessoa;

System.out.println(p.nome + " tem " + p.idade);
```