### PR TITLE
@Logger(AccessLevel)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ John Paul Taylor II <johnpaultaylorii@gmail.com>
 Karthik kathari <44122128+varkart@users.noreply.github.com>
 Kevin Chirls <kchirls@users.noreply.github.com>
 Liu DongMiao <liudongmiao@gmail.com>
+Liam Pace <liam.hollum.pace@gmail.com>
 Luan Nico <luannico27@gmail.com>
 Maarten Mulders <mthmulders@users.noreply.github.com>
 Manu Sridharan <msridhar@gmail.com>

--- a/docker/gradle/files/classpath/.gitignore
+++ b/docker/gradle/files/classpath/.gitignore
@@ -1,0 +1,5 @@
+build/
+.gradle/
+gradle/
+gradlew
+gradlew.bat

--- a/src/core/lombok/CustomLog.java
+++ b/src/core/lombok/CustomLog.java
@@ -66,6 +66,13 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface CustomLog {
 	/**
+	 * If you want your Logger to be non-private, you can specify an alternate access level here.
+	 * 
+	 * @return The constructed Logger method will be generated with this access modifier.
+	 */
+	AccessLevel access() default AccessLevel.PRIVATE;
+	
+	/**
 	 * 
 	 * Sets a custom topic/category. Note that this requires you to specify a parameter configuration for your custom logger that includes {@code TOPIC}.
 	 * 

--- a/src/core/lombok/eclipse/handlers/HandleLog.java
+++ b/src/core/lombok/eclipse/handlers/HandleLog.java
@@ -39,8 +39,6 @@ import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 
-import com.sun.tools.javac.code.Flags;
-
 import lombok.AccessLevel;
 import lombok.ConfigurationKeys;
 import lombok.core.AnnotationValues;
@@ -138,15 +136,6 @@ public class HandleLog {
 		return result;
 	}
 	
-	private static int toFlags(AccessLevel level) {
-		switch (level) {
-			case PUBLIC: return Flags.PUBLIC; 
-			case PROTECTED: return Flags.PROTECTED;
-			case PRIVATE: return Flags.PRIVATE;
-			default: return 0;
-		}
-	}
-	
 	private static FieldDeclaration createField(LoggingFramework framework, AccessLevel access, Annotation source, ClassLiteralAccess loggingType, String logFieldName, boolean useStatic, Expression loggerTopic) {
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		long p = (long) pS << 32 | pE;
@@ -155,7 +144,7 @@ public class HandleLog {
 		FieldDeclaration fieldDecl = new FieldDeclaration(logFieldName.toCharArray(), 0, -1);
 		setGeneratedBy(fieldDecl, source);
 		fieldDecl.declarationSourceEnd = -1;
-		fieldDecl.modifiers = toFlags(access) | (useStatic ? Modifier.STATIC : 0) | Modifier.FINAL;
+		fieldDecl.modifiers = toEclipseModifier(access) | (useStatic ? Modifier.STATIC : 0) | Modifier.FINAL;
 		
 		LogDeclaration logDeclaration = framework.getDeclaration();
 		fieldDecl.type = createTypeReference(logDeclaration.getLoggerType().getName(), source);

--- a/src/core/lombok/eclipse/handlers/HandleLog.java
+++ b/src/core/lombok/eclipse/handlers/HandleLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2024 The Project Lombok Authors.
+ * Copyright (C) 2010-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/core/lombok/eclipse/handlers/HandleLog.java
+++ b/src/core/lombok/eclipse/handlers/HandleLog.java
@@ -100,6 +100,7 @@ public class HandleLog {
 			Expression loggerTopic = (Expression) annotation.getActualExpression("topic");
 			
 			if (valueGuess instanceof String && ((String) valueGuess).trim().isEmpty()) loggerTopic = null;
+			
 			if (framework.getDeclaration().getParametersWithTopic() == null && loggerTopic != null) {
 				annotationNode.addError(framework.getAnnotationAsString() + " does not allow a topic.");
 				loggerTopic = null;
@@ -108,6 +109,9 @@ public class HandleLog {
 				annotationNode.addError(framework.getAnnotationAsString() + " requires a topic.");
 				loggerTopic = new StringLiteral(new char[]{}, 0, 0, 0);
 			}
+			
+			if (access == AccessLevel.NONE)
+				break;
 			
 			ClassLiteralAccess loggingType = selfType(owner, source);
 			FieldDeclaration fieldDeclaration = createField(framework, access, source, loggingType, logFieldName.getName(), useStatic, loggerTopic);
@@ -138,7 +142,7 @@ public class HandleLog {
 		switch (level) {
 			case PUBLIC: return Flags.PUBLIC; 
 			case PROTECTED: return Flags.PROTECTED;
-			case PRIVATE: return Flags.PUBLIC;
+			case PRIVATE: return Flags.PRIVATE;
 			default: return 0;
 		}
 	}

--- a/src/core/lombok/extern/apachecommons/CommonsLog.java
+++ b/src/core/lombok/extern/apachecommons/CommonsLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2017 The Project Lombok Authors.
+ * Copyright (C) 2010-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/core/lombok/extern/apachecommons/CommonsLog.java
+++ b/src/core/lombok/extern/apachecommons/CommonsLog.java
@@ -26,6 +26,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import lombok.AccessLevel;
+
 /**
  * Causes lombok to generate a logger field.
  * <p>
@@ -62,6 +64,13 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface CommonsLog {
+	/**
+	 * If you want your Logger to be non-private, you can specify an alternate access level here.
+	 * 
+	 * @return The constructed Logger method will be generated with this access modifier.
+	 */
+	AccessLevel access() default AccessLevel.PRIVATE;
+	
 	/** @return The category of the constructed Logger. By default, it will use the type where the annotation is placed. */
 	String topic() default "";
 }

--- a/src/core/lombok/extern/flogger/Flogger.java
+++ b/src/core/lombok/extern/flogger/Flogger.java
@@ -26,6 +26,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import lombok.AccessLevel;
+
 /**
  * Causes lombok to generate a logger field.
  * <p>
@@ -60,4 +62,10 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface Flogger {
+	/**
+	 * If you want your Logger to be non-private, you can specify an alternate access level here.
+	 * 
+	 * @return The constructed Logger method will be generated with this access modifier.
+	 */
+	AccessLevel access() default AccessLevel.PRIVATE;
 }

--- a/src/core/lombok/extern/flogger/Flogger.java
+++ b/src/core/lombok/extern/flogger/Flogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 The Project Lombok Authors.
+ * Copyright (C) 2018-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/core/lombok/extern/java/Log.java
+++ b/src/core/lombok/extern/java/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2017 The Project Lombok Authors.
+ * Copyright (C) 2010-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/core/lombok/extern/java/Log.java
+++ b/src/core/lombok/extern/java/Log.java
@@ -26,6 +26,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import lombok.AccessLevel;
+
 /**
  * Causes lombok to generate a logger field.
  * <p>
@@ -61,6 +63,13 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface Log {
+	/**
+	 * If you want your logger to be non-private, you can specify an alternate access level here.
+	 * 
+	 * @return The constructed Logger method will be generated with this access modifier.
+	 */
+	AccessLevel access() default AccessLevel.PRIVATE;
+	
 	/** @return The category of the constructed Logger. By default, it will use the type where the annotation is placed. */
 	String topic() default "";
 }

--- a/src/core/lombok/extern/jbosslog/JBossLog.java
+++ b/src/core/lombok/extern/jbosslog/JBossLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 The Project Lombok Authors.
+ * Copyright (C) 2016-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/core/lombok/extern/jbosslog/JBossLog.java
+++ b/src/core/lombok/extern/jbosslog/JBossLog.java
@@ -26,6 +26,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import lombok.AccessLevel;
+
 /**
  * Causes lombok to generate a logger field.
  * <p>
@@ -61,6 +63,13 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface JBossLog {
+	/**
+	 * If you want your Logger to be non-private, you can specify an alternate access level here.
+	 * 
+	 * @return The constructed Logger method will be generated with this access modifier.
+	 */
+	AccessLevel access() default AccessLevel.PRIVATE;
+	
 	/** @return The category of the constructed Logger. By default, it will use the type where the annotation is placed. */
 	String topic() default "";
 }

--- a/src/core/lombok/extern/log4j/Log4j.java
+++ b/src/core/lombok/extern/log4j/Log4j.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2017 The Project Lombok Authors.
+ * Copyright (C) 2010-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/core/lombok/extern/log4j/Log4j.java
+++ b/src/core/lombok/extern/log4j/Log4j.java
@@ -26,6 +26,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import lombok.AccessLevel;
+
 /**
  * Causes lombok to generate a logger field.
  * <p>
@@ -62,6 +64,13 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface Log4j {
+	/**
+	 * If you want your Logger to be non-private, you can specify an alternate access level here.
+	 * 
+	 * @return The constructed Logger method will be generated with this access modifier.
+	 */
+	AccessLevel access() default AccessLevel.PRIVATE;
+	
 	/** @return The category of the constructed Logger. By default, it will use the type where the annotation is placed. */
 	String topic() default "";
 }

--- a/src/core/lombok/extern/log4j/Log4j2.java
+++ b/src/core/lombok/extern/log4j/Log4j2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2017 The Project Lombok Authors.
+ * Copyright (C) 2013-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/core/lombok/extern/log4j/Log4j2.java
+++ b/src/core/lombok/extern/log4j/Log4j2.java
@@ -26,6 +26,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import lombok.AccessLevel;
+
 /**
  * Causes lombok to generate a logger field.
  * <p>
@@ -62,6 +64,13 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface Log4j2 {
+	/**
+	 * If you want your Logger to be non-private, you can specify an alternate access level here.
+	 * 
+	 * @return The constructed Logger method will be generated with this access modifier.
+	 */
+	AccessLevel access() default AccessLevel.PRIVATE;
+	
 	/** @return The category of the constructed Logger. By default, it will use the type where the annotation is placed. */
 	String topic() default "";
 }

--- a/src/core/lombok/extern/slf4j/Slf4j.java
+++ b/src/core/lombok/extern/slf4j/Slf4j.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2017 The Project Lombok Authors.
+ * Copyright (C) 2010-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/core/lombok/extern/slf4j/Slf4j.java
+++ b/src/core/lombok/extern/slf4j/Slf4j.java
@@ -26,6 +26,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import lombok.AccessLevel;
+
 /**
  * Causes lombok to generate a logger field.
  * <p>
@@ -61,6 +63,13 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface Slf4j {
+	/**
+	 * If you want your Logger to be non-private, you can specify an alternate access level here.
+	 * 
+	 * @return The constructed Logger method will be generated with this access modifier.
+	 */
+	AccessLevel access() default AccessLevel.PRIVATE;
+	
 	/** @return The category of the constructed Logger. By default, it will use the type where the annotation is placed. */
 	String topic() default "";
 }

--- a/src/core/lombok/extern/slf4j/XSlf4j.java
+++ b/src/core/lombok/extern/slf4j/XSlf4j.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2017 The Project Lombok Authors.
+ * Copyright (C) 2012-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/core/lombok/extern/slf4j/XSlf4j.java
+++ b/src/core/lombok/extern/slf4j/XSlf4j.java
@@ -26,6 +26,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import lombok.AccessLevel;
+
 /**
  * Causes lombok to generate a logger field.
  * <p>
@@ -61,6 +63,13 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface XSlf4j {
+	/**
+	 * If you want your Logger to be non-private, you can specify an alternate access level here.
+	 * 
+	 * @return The constructed Logger method will be generated with this access modifier.
+	 */
+	AccessLevel access() default AccessLevel.PRIVATE;
+	
 	/** @return The category of the constructed Logger. By default, it will use the type where the annotation is placed. */
 	String topic() default "";
 }

--- a/src/core/lombok/javac/handlers/HandleLog.java
+++ b/src/core/lombok/javac/handlers/HandleLog.java
@@ -99,6 +99,9 @@ public class HandleLog {
 				loggerTopic = typeNode.getTreeMaker().Literal("");
 			}
 			
+			if (access == AccessLevel.NONE)
+				break;
+			
 			JCFieldAccess loggingType = selfType(typeNode);
 			createField(framework, access, typeNode, loggingType, annotationNode, logFieldName.getName(), useStatic, loggerTopic);
 			break;
@@ -118,7 +121,7 @@ public class HandleLog {
 		switch (level) {
 			case PUBLIC: return Flags.PUBLIC; 
 			case PROTECTED: return Flags.PROTECTED;
-			case PRIVATE: return Flags.PUBLIC;
+			case PRIVATE: return Flags.PRIVATE;
 			default: return 0;
 		}
 	}

--- a/src/core/lombok/javac/handlers/HandleLog.java
+++ b/src/core/lombok/javac/handlers/HandleLog.java
@@ -117,14 +117,6 @@ public class HandleLog {
 		return maker.Select(maker.Ident(name), typeNode.toName("class"));
 	}
 	
-	private static int toFlags(AccessLevel level) {
-		switch (level) {
-			case PUBLIC: return Flags.PUBLIC; 
-			case PROTECTED: return Flags.PROTECTED;
-			case PRIVATE: return Flags.PRIVATE;
-			default: return 0;
-		}
-	}
 	
 	private static boolean createField(LoggingFramework framework, AccessLevel access, JavacNode typeNode, JCFieldAccess loggingType, JavacNode source, String logFieldName, boolean useStatic, JCExpression loggerTopic) {
 		JavacTreeMaker maker = typeNode.getTreeMaker();
@@ -139,7 +131,7 @@ public class HandleLog {
 		JCMethodInvocation factoryMethodCall = maker.Apply(List.<JCExpression>nil(), factoryMethod, List.<JCExpression>from(factoryParameters));
 		
 		JCVariableDecl fieldDecl = recursiveSetGeneratedBy(maker.VarDef(
-			maker.Modifiers(toFlags(access) | Flags.FINAL | (useStatic ? Flags.STATIC : 0)),
+			maker.Modifiers(toJavacModifier(access) | Flags.FINAL | (useStatic ? Flags.STATIC : 0)),
 			typeNode.toName(logFieldName), loggerType, factoryMethodCall), source);
 		
 		if (isRecord(typeNode) && Javac.getJavaCompilerVersion() < 16) {

--- a/src/core/lombok/javac/handlers/HandleLog.java
+++ b/src/core/lombok/javac/handlers/HandleLog.java
@@ -21,10 +21,21 @@
  */
 package lombok.javac.handlers;
 
-import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.core.handlers.HandlerUtil.handleFlagUsage;
 import static lombok.javac.Javac.CTC_BOT;
 import static lombok.javac.handlers.JavacHandlerUtil.*;
 
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
+import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.Name;
+
+import lombok.AccessLevel;
 import lombok.ConfigurationKeys;
 import lombok.core.AnnotationValues;
 import lombok.core.configuration.IdentifierName;
@@ -38,16 +49,6 @@ import lombok.javac.JavacTreeMaker;
 import lombok.javac.handlers.JavacHandlerUtil.MemberExistsResult;
 import lombok.spi.Provides;
 
-import com.sun.tools.javac.code.Flags;
-import com.sun.tools.javac.tree.JCTree.JCAnnotation;
-import com.sun.tools.javac.tree.JCTree.JCClassDecl;
-import com.sun.tools.javac.tree.JCTree.JCExpression;
-import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
-import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
-import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
-import com.sun.tools.javac.util.List;
-import com.sun.tools.javac.util.Name;
-
 public class HandleLog {
 	private static final IdentifierName LOG = IdentifierName.valueOf("log");
 	
@@ -55,7 +56,7 @@ public class HandleLog {
 		throw new UnsupportedOperationException();
 	}
 	
-	public static void processAnnotation(LoggingFramework framework, AnnotationValues<?> annotation, JavacNode annotationNode) {
+	public static void processAnnotation(LoggingFramework framework, AccessLevel access, AnnotationValues<?> annotation, JavacNode annotationNode) {
 		deleteAnnotationIfNeccessary(annotationNode, framework.getAnnotationClass());
 		
 		JavacNode typeNode = annotationNode.up();
@@ -99,7 +100,7 @@ public class HandleLog {
 			}
 			
 			JCFieldAccess loggingType = selfType(typeNode);
-			createField(framework, typeNode, loggingType, annotationNode, logFieldName.getName(), useStatic, loggerTopic);
+			createField(framework, access, typeNode, loggingType, annotationNode, logFieldName.getName(), useStatic, loggerTopic);
 			break;
 		default:
 			annotationNode.addError("@Log is legal only on types.");
@@ -113,7 +114,16 @@ public class HandleLog {
 		return maker.Select(maker.Ident(name), typeNode.toName("class"));
 	}
 	
-	private static boolean createField(LoggingFramework framework, JavacNode typeNode, JCFieldAccess loggingType, JavacNode source, String logFieldName, boolean useStatic, JCExpression loggerTopic) {
+	private static int toFlags(AccessLevel level) {
+		switch (level) {
+			case PUBLIC: return Flags.PUBLIC; 
+			case PROTECTED: return Flags.PROTECTED;
+			case PRIVATE: return Flags.PUBLIC;
+			default: return 0;
+		}
+	}
+	
+	private static boolean createField(LoggingFramework framework, AccessLevel access, JavacNode typeNode, JCFieldAccess loggingType, JavacNode source, String logFieldName, boolean useStatic, JCExpression loggerTopic) {
 		JavacTreeMaker maker = typeNode.getTreeMaker();
 		
 		LogDeclaration logDeclaration = framework.getDeclaration();
@@ -126,7 +136,7 @@ public class HandleLog {
 		JCMethodInvocation factoryMethodCall = maker.Apply(List.<JCExpression>nil(), factoryMethod, List.<JCExpression>from(factoryParameters));
 		
 		JCVariableDecl fieldDecl = recursiveSetGeneratedBy(maker.VarDef(
-			maker.Modifiers(Flags.PRIVATE | Flags.FINAL | (useStatic ? Flags.STATIC : 0)),
+			maker.Modifiers(toFlags(access) | Flags.FINAL | (useStatic ? Flags.STATIC : 0)),
 			typeNode.toName(logFieldName), loggerType, factoryMethodCall), source);
 		
 		if (isRecord(typeNode) && Javac.getJavaCompilerVersion() < 16) {
@@ -177,7 +187,7 @@ public class HandleLog {
 	public static class HandleCommonsLog extends JavacAnnotationHandler<lombok.extern.apachecommons.CommonsLog> {
 		@Override public void handle(AnnotationValues<lombok.extern.apachecommons.CommonsLog> annotation, JCAnnotation ast, JavacNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.LOG_COMMONS_FLAG_USAGE, "@apachecommons.CommonsLog", ConfigurationKeys.LOG_ANY_FLAG_USAGE, "any @Log");
-			processAnnotation(LoggingFramework.COMMONS, annotation, annotationNode);
+			processAnnotation(LoggingFramework.COMMONS, annotation.getInstance().access(), annotation, annotationNode);
 		}
 	}
 	
@@ -188,7 +198,7 @@ public class HandleLog {
 	public static class HandleJulLog extends JavacAnnotationHandler<lombok.extern.java.Log> {
 		@Override public void handle(AnnotationValues<lombok.extern.java.Log> annotation, JCAnnotation ast, JavacNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.LOG_JUL_FLAG_USAGE, "@java.Log", ConfigurationKeys.LOG_ANY_FLAG_USAGE, "any @Log");
-			processAnnotation(LoggingFramework.JUL, annotation, annotationNode);
+			processAnnotation(LoggingFramework.JUL, annotation.getInstance().access(), annotation, annotationNode);
 		}
 	}
 	
@@ -199,7 +209,7 @@ public class HandleLog {
 	public static class HandleLog4jLog extends JavacAnnotationHandler<lombok.extern.log4j.Log4j> {
 		@Override public void handle(AnnotationValues<lombok.extern.log4j.Log4j> annotation, JCAnnotation ast, JavacNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.LOG_LOG4J_FLAG_USAGE, "@Log4j", ConfigurationKeys.LOG_ANY_FLAG_USAGE, "any @Log");
-			processAnnotation(LoggingFramework.LOG4J, annotation, annotationNode);
+			processAnnotation(LoggingFramework.LOG4J, annotation.getInstance().access(), annotation, annotationNode);
 		}
 	}
 	
@@ -210,7 +220,7 @@ public class HandleLog {
 	public static class HandleLog4j2Log extends JavacAnnotationHandler<lombok.extern.log4j.Log4j2> {
 		@Override public void handle(AnnotationValues<lombok.extern.log4j.Log4j2> annotation, JCAnnotation ast, JavacNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.LOG_LOG4J2_FLAG_USAGE, "@Log4j2", ConfigurationKeys.LOG_ANY_FLAG_USAGE, "any @Log");
-			processAnnotation(LoggingFramework.LOG4J2, annotation, annotationNode);
+			processAnnotation(LoggingFramework.LOG4J2, annotation.getInstance().access(), annotation, annotationNode);
 		}
 	}
 	
@@ -221,7 +231,7 @@ public class HandleLog {
 	public static class HandleSlf4jLog extends JavacAnnotationHandler<lombok.extern.slf4j.Slf4j> {
 		@Override public void handle(AnnotationValues<lombok.extern.slf4j.Slf4j> annotation, JCAnnotation ast, JavacNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.LOG_SLF4J_FLAG_USAGE, "@Slf4j", ConfigurationKeys.LOG_ANY_FLAG_USAGE, "any @Log");
-			processAnnotation(LoggingFramework.SLF4J, annotation, annotationNode);
+			processAnnotation(LoggingFramework.SLF4J, annotation.getInstance().access(), annotation, annotationNode);
 		}
 	}
 	
@@ -232,7 +242,7 @@ public class HandleLog {
 	public static class HandleXSlf4jLog extends JavacAnnotationHandler<lombok.extern.slf4j.XSlf4j> {
 		@Override public void handle(AnnotationValues<lombok.extern.slf4j.XSlf4j> annotation, JCAnnotation ast, JavacNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.LOG_XSLF4J_FLAG_USAGE, "@XSlf4j", ConfigurationKeys.LOG_ANY_FLAG_USAGE, "any @Log");
-			processAnnotation(LoggingFramework.XSLF4J, annotation, annotationNode);
+			processAnnotation(LoggingFramework.XSLF4J, annotation.getInstance().access(), annotation, annotationNode);
 		}
 	}
 	
@@ -243,7 +253,7 @@ public class HandleLog {
 	public static class HandleJBossLog extends JavacAnnotationHandler<lombok.extern.jbosslog.JBossLog> {
 		@Override public void handle(AnnotationValues<lombok.extern.jbosslog.JBossLog> annotation, JCAnnotation ast, JavacNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.LOG_JBOSSLOG_FLAG_USAGE, "@JBossLog", ConfigurationKeys.LOG_ANY_FLAG_USAGE, "any @Log");
-			processAnnotation(LoggingFramework.JBOSSLOG, annotation, annotationNode);
+			processAnnotation(LoggingFramework.JBOSSLOG, annotation.getInstance().access(), annotation, annotationNode);
 		}
 	}
 	
@@ -254,7 +264,7 @@ public class HandleLog {
 	public static class HandleFloggerLog extends JavacAnnotationHandler<lombok.extern.flogger.Flogger> {
 		@Override public void handle(AnnotationValues<lombok.extern.flogger.Flogger> annotation, JCAnnotation ast, JavacNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.LOG_FLOGGER_FLAG_USAGE, "@Flogger", ConfigurationKeys.LOG_ANY_FLAG_USAGE, "any @Log");
-			processAnnotation(LoggingFramework.FLOGGER, annotation, annotationNode);
+			processAnnotation(LoggingFramework.FLOGGER, annotation.getInstance().access(), annotation, annotationNode);
 		}
 	}
 	
@@ -271,7 +281,7 @@ public class HandleLog {
 				return;
 			}
 			LoggingFramework framework = new LoggingFramework(lombok.CustomLog.class, logDeclaration);
-			processAnnotation(framework, annotation, annotationNode);
+			processAnnotation(framework, annotation.getInstance().access(), annotation, annotationNode);
 		}
 	}
 }

--- a/test/transform/resource/after-delombok/LoggerCommonsAccess.java
+++ b/test/transform/resource/after-delombok/LoggerCommonsAccess.java
@@ -1,0 +1,33 @@
+import lombok.AccessLevel;
+class LoggerCommonsAccessPublic {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessPublic.class);
+
+}
+class LoggerCommonsAccessModule {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessModule.class);
+
+}
+class LoggerCommonsAccessProtected {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	protected static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessProtected.class);
+
+}
+class LoggerCommonsAccessPackage {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessPackage.class);
+
+}
+class LoggerCommonsAccessPrivate {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	private static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessPrivate.class);
+
+}
+class LoggerCommonsAccessNone {
+}

--- a/test/transform/resource/after-delombok/LoggerCustomAccess.java
+++ b/test/transform/resource/after-delombok/LoggerCustomAccess.java
@@ -1,0 +1,33 @@
+import lombok.AccessLevel;
+class LoggerCustomAccessPublic {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static final MyLogger log = MyLoggerFactory.create(LoggerCustomAccessPublic.class);
+
+}
+class LoggerCustomAccessModule {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final MyLogger log = MyLoggerFactory.create(LoggerCustomAccessModule.class);
+
+}
+class LoggerCustomAccessProtected {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	protected static final MyLogger log = MyLoggerFactory.create(LoggerCustomAccessProtected.class);
+
+}
+class LoggerCustomAccessPackage {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final MyLogger log = MyLoggerFactory.create(LoggerCustomAccessPackage.class);
+
+}
+class LoggerCustomAccessPrivate {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	private static final MyLogger log = MyLoggerFactory.create(LoggerCustomAccessPrivate.class);
+
+}
+class LoggerCustomAccessNone {
+}

--- a/test/transform/resource/after-delombok/LoggerCustomAccess.java
+++ b/test/transform/resource/after-delombok/LoggerCustomAccess.java
@@ -31,3 +31,11 @@ class LoggerCustomAccessPrivate {
 }
 class LoggerCustomAccessNone {
 }
+class MyLoggerFactory {
+	static MyLogger create(Class<?> clazz) {
+		return null;
+	}
+}
+class MyLogger {
+}
+

--- a/test/transform/resource/after-delombok/LoggerFloggerAccess.java
+++ b/test/transform/resource/after-delombok/LoggerFloggerAccess.java
@@ -1,0 +1,33 @@
+import lombok.AccessLevel;
+class LoggerFloggerAccessPublic {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+
+}
+class LoggerFloggerAccessModule {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+
+}
+class LoggerFloggerAccessProtected {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	protected static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+
+}
+class LoggerFloggerAccessPackage {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+
+}
+class LoggerFloggerAccessPrivate {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	private static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+
+}
+class LoggerFloggerAccessNone {
+}

--- a/test/transform/resource/after-delombok/LoggerJBossLogAccess.java
+++ b/test/transform/resource/after-delombok/LoggerJBossLogAccess.java
@@ -1,0 +1,33 @@
+import lombok.AccessLevel;
+class LoggerJBossLogAccessPublic {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessPublic.class);
+
+}
+class LoggerJBossLogAccessModule {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessModule.class);
+
+}
+class LoggerJBossLogAccessProtected {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	protected static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessProtected.class);
+
+}
+class LoggerJBossLogAccessPackage {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessPackage.class);
+
+}
+class LoggerJBossLogAccessPrivate {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	private static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessPrivate.class);
+
+}
+class LoggerJBossLogAccessNone {
+}

--- a/test/transform/resource/after-delombok/LoggerJulAccess.java
+++ b/test/transform/resource/after-delombok/LoggerJulAccess.java
@@ -1,0 +1,33 @@
+import lombok.AccessLevel;
+class LoggerJulAccessPublic {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessPublic.class.getName());
+
+}
+class LoggerJulAccessModule {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessModule.class.getName());
+
+}
+class LoggerJulAccessProtected {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	protected static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessProtected.class.getName());
+
+}
+class LoggerJulAccessPackage {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessPackage.class.getName());
+
+}
+class LoggerJulAccessPrivate {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessPrivate.class.getName());
+
+}
+class LoggerJulAccessNone {
+}

--- a/test/transform/resource/after-delombok/LoggerLog4j2Access.java
+++ b/test/transform/resource/after-delombok/LoggerLog4j2Access.java
@@ -1,0 +1,33 @@
+import lombok.AccessLevel;
+class LoggerLog4j2AccessPublic {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessPublic.class);
+
+}
+class LoggerLog4j2AccessModule {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessModule.class);
+
+}
+class LoggerLog4j2AccessProtected {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	protected static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessProtected.class);
+
+}
+class LoggerLog4j2AccessPackage {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessPackage.class);
+
+}
+class LoggerLog4j2AccessPrivate {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	private static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessPrivate.class);
+
+}
+class LoggerLog4j2AccessNone {
+}

--- a/test/transform/resource/after-delombok/LoggerLog4jAccess.java
+++ b/test/transform/resource/after-delombok/LoggerLog4jAccess.java
@@ -1,0 +1,33 @@
+import lombok.AccessLevel;
+class LoggerLog4jAccessPublic {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessPublic.class);
+
+}
+class LoggerLog4jAccessModule {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessModule.class);
+
+}
+class LoggerLog4jAccessProtected {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	protected static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessProtected.class);
+
+}
+class LoggerLog4jAccessPackage {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessPackage.class);
+
+}
+class LoggerLog4jAccessPrivate {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessPrivate.class);
+
+}
+class LoggerLog4jAccessNone {
+}

--- a/test/transform/resource/after-delombok/LoggerSlf4jAccess.java
+++ b/test/transform/resource/after-delombok/LoggerSlf4jAccess.java
@@ -1,0 +1,33 @@
+import lombok.AccessLevel;
+class LoggerSlf4jAccessPublic {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessPublic.class);
+
+}
+class LoggerSlf4jAccessModule {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessModule.class);
+
+}
+class LoggerSlf4jAccessProtected {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	protected static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessProtected.class);
+
+}
+class LoggerSlf4jAccessPackage {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessPackage.class);
+
+}
+class LoggerSlf4jAccessPrivate {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessPrivate.class);
+
+}
+class LoggerSlf4jAccessNone {
+}

--- a/test/transform/resource/after-delombok/LoggerXslf4jAccess.java
+++ b/test/transform/resource/after-delombok/LoggerXslf4jAccess.java
@@ -1,0 +1,33 @@
+import lombok.AccessLevel;
+class LoggerXslf4jAccessPublic {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessPublic.class);
+
+}
+class LoggerXslf4jAccessModule {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessModule.class);
+
+}
+class LoggerXslf4jAccessProtected {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	protected static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessProtected.class);
+
+}
+class LoggerXslf4jAccessPackage {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessPackage.class);
+
+}
+class LoggerXslf4jAccessPrivate {
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	private static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessPrivate.class);
+
+}
+class LoggerXslf4jAccessNone {
+}

--- a/test/transform/resource/after-ecj/LoggerCommonsAccess.java
+++ b/test/transform/resource/after-ecj/LoggerCommonsAccess.java
@@ -1,0 +1,49 @@
+import lombok.AccessLevel;
+import lombok.extern.apachecommons.CommonsLog;
+@CommonsLog(access=AccessLevel.PUBLIC) class LoggerCommonsAccessPublic {
+  public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessPublic.class);
+  <clinit>() {
+  }
+  LoggerCommonsAccessPublic() {
+    super();
+  }
+}
+@CommonsLog(access=AccessLevel.MODULE) class LoggerCommonsAccessModule {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessModule.class);
+  <clinit>() {
+  }
+  LoggerCommonsAccessModule() {
+    super();
+  }
+}
+@CommonsLog(access=AccessLevel.PROTECTED) class LoggerCommonsAccessProtected {
+  protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessProtected.class);
+  <clinit>() {
+  }
+  LoggerCommonsAccessProtected() {
+    super();
+  }
+}
+@CommonsLog(access=AccessLevel.PACKAGE) class LoggerCommonsAccessPackage {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessPackage.class);
+  <clinit>() {
+  }
+  LoggerCommonsAccessPackage() {
+    super();
+  }
+}
+@CommonsLog(access=AccessLevel.PRIVATE) class LoggerCommonsAccessPrivate {
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessPrivate.class);
+  <clinit>() {
+  }
+  LoggerCommonsAccessPrivate() {
+    super();
+  }
+}
+@CommonsLog(access=AccessLevel.NONE) class LoggerCommonsAccessNone {
+  <clinit>() {
+  }
+  LoggerCommonsAccessNone() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerCommonsAccess.java
+++ b/test/transform/resource/after-ecj/LoggerCommonsAccess.java
@@ -1,48 +1,51 @@
 import lombok.AccessLevel;
 import lombok.extern.apachecommons.CommonsLog;
-@CommonsLog(access=AccessLevel.PUBLIC) class LoggerCommonsAccessPublic {
+@CommonsLog(access = AccessLevel.PUBLIC) class LoggerCommonsAccessPublic {
   public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessPublic.class);
   <clinit>() {
   }
+
   LoggerCommonsAccessPublic() {
     super();
   }
 }
-@CommonsLog(access=AccessLevel.MODULE) class LoggerCommonsAccessModule {
+@CommonsLog(access = AccessLevel.MODULE) class LoggerCommonsAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessModule.class);
   <clinit>() {
   }
+
   LoggerCommonsAccessModule() {
     super();
   }
 }
-@CommonsLog(access=AccessLevel.PROTECTED) class LoggerCommonsAccessProtected {
+@CommonsLog(access = AccessLevel.PROTECTED) class LoggerCommonsAccessProtected {
   protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessProtected.class);
   <clinit>() {
   }
+
   LoggerCommonsAccessProtected() {
     super();
   }
 }
-@CommonsLog(access=AccessLevel.PACKAGE) class LoggerCommonsAccessPackage {
+@CommonsLog(access = AccessLevel.PACKAGE) class LoggerCommonsAccessPackage {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessPackage.class);
   <clinit>() {
   }
+
   LoggerCommonsAccessPackage() {
     super();
   }
 }
-@CommonsLog(access=AccessLevel.PRIVATE) class LoggerCommonsAccessPrivate {
+@CommonsLog(access = AccessLevel.PRIVATE) class LoggerCommonsAccessPrivate {
   private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessPrivate.class);
   <clinit>() {
   }
+
   LoggerCommonsAccessPrivate() {
     super();
   }
 }
-@CommonsLog(access=AccessLevel.NONE) class LoggerCommonsAccessNone {
-  <clinit>() {
-  }
+@CommonsLog(access = AccessLevel.NONE) class LoggerCommonsAccessNone {
   LoggerCommonsAccessNone() {
     super();
   }

--- a/test/transform/resource/after-ecj/LoggerCustomAccess.java
+++ b/test/transform/resource/after-ecj/LoggerCustomAccess.java
@@ -47,3 +47,17 @@ import lombok.CustomLog;
     super();
   }
 }
+class MyLoggerFactory {
+  MyLoggerFactory() {
+    super();
+  }
+  static MyLogger create(Class<?> clazz) {
+    return null;
+  }
+}
+class MyLogger {
+  MyLogger() {
+    super();
+  }
+}
+

--- a/test/transform/resource/after-ecj/LoggerCustomAccess.java
+++ b/test/transform/resource/after-ecj/LoggerCustomAccess.java
@@ -1,0 +1,49 @@
+import lombok.AccessLevel;
+import lombok.CustomLog;
+@CustomLog(access=AccessLevel.PUBLIC) class LoggerCustomAccessPublic {
+  public static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomAccessPublic.class);
+  <clinit>() {
+  }
+  LoggerCustomAccessPublic() {
+    super();
+  }
+}
+@CustomLog(access=AccessLevel.MODULE) class LoggerCustomAccessModule {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomAccessModule.class);
+  <clinit>() {
+  }
+  LoggerCustomAccessModule() {
+    super();
+  }
+}
+@CustomLog(access=AccessLevel.PROTECTED) class LoggerCustomAccessProtected {
+  protected static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomAccessProtected.class);
+  <clinit>() {
+  }
+  LoggerCustomAccessProtected() {
+    super();
+  }
+}
+@CustomLog(access=AccessLevel.PACKAGE) class LoggerCustomAccessPackage {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomAccessPackage.class);
+  <clinit>() {
+  }
+  LoggerCustomAccessPackage() {
+    super();
+  }
+}
+@CustomLog(access=AccessLevel.PRIVATE) class LoggerCustomAccessPrivate {
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomAccessPrivate.class);
+  <clinit>() {
+  }
+  LoggerCustomAccessPrivate() {
+    super();
+  }
+}
+@CustomLog(access=AccessLevel.NONE) class LoggerCustomAccessNone {
+  <clinit>() {
+  }
+  LoggerCustomAccessNone() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerCustomAccess.java
+++ b/test/transform/resource/after-ecj/LoggerCustomAccess.java
@@ -1,48 +1,51 @@
 import lombok.AccessLevel;
 import lombok.CustomLog;
-@CustomLog(access=AccessLevel.PUBLIC) class LoggerCustomAccessPublic {
+@CustomLog(access = AccessLevel.PUBLIC) class LoggerCustomAccessPublic {
   public static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomAccessPublic.class);
   <clinit>() {
   }
+
   LoggerCustomAccessPublic() {
     super();
   }
 }
-@CustomLog(access=AccessLevel.MODULE) class LoggerCustomAccessModule {
+@CustomLog(access = AccessLevel.MODULE) class LoggerCustomAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomAccessModule.class);
   <clinit>() {
   }
+
   LoggerCustomAccessModule() {
     super();
   }
 }
-@CustomLog(access=AccessLevel.PROTECTED) class LoggerCustomAccessProtected {
+@CustomLog(access = AccessLevel.PROTECTED) class LoggerCustomAccessProtected {
   protected static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomAccessProtected.class);
   <clinit>() {
   }
+
   LoggerCustomAccessProtected() {
     super();
   }
 }
-@CustomLog(access=AccessLevel.PACKAGE) class LoggerCustomAccessPackage {
+@CustomLog(access = AccessLevel.PACKAGE) class LoggerCustomAccessPackage {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomAccessPackage.class);
   <clinit>() {
   }
+
   LoggerCustomAccessPackage() {
     super();
   }
 }
-@CustomLog(access=AccessLevel.PRIVATE) class LoggerCustomAccessPrivate {
+@CustomLog(access = AccessLevel.PRIVATE) class LoggerCustomAccessPrivate {
   private static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomAccessPrivate.class);
   <clinit>() {
   }
+
   LoggerCustomAccessPrivate() {
     super();
   }
 }
-@CustomLog(access=AccessLevel.NONE) class LoggerCustomAccessNone {
-  <clinit>() {
-  }
+@CustomLog(access = AccessLevel.NONE) class LoggerCustomAccessNone {
   LoggerCustomAccessNone() {
     super();
   }

--- a/test/transform/resource/after-ecj/LoggerFloggerAccess.java
+++ b/test/transform/resource/after-ecj/LoggerFloggerAccess.java
@@ -1,0 +1,49 @@
+import lombok.AccessLevel;
+import lombok.extern.flogger.Flogger;
+@Flogger(access=AccessLevel.PUBLIC) class LoggerFloggerAccessPublic {
+  public static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+  <clinit>() {
+  }
+  LoggerFloggerAccessPublic() {
+    super();
+  }
+}
+@Flogger(access=AccessLevel.MODULE) class LoggerFloggerAccessModule {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+  <clinit>() {
+  }
+  LoggerFloggerAccessModule() {
+    super();
+  }
+}
+@Flogger(access=AccessLevel.PROTECTED) class LoggerFloggerAccessProtected {
+  protected static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+  <clinit>() {
+  }
+  LoggerFloggerAccessProtected() {
+    super();
+  }
+}
+@Flogger(access=AccessLevel.PACKAGE) class LoggerFloggerAccessPackage {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+  <clinit>() {
+  }
+  LoggerFloggerAccessPackage() {
+    super();
+  }
+}
+@Flogger(access=AccessLevel.PRIVATE) class LoggerFloggerAccessPrivate {
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
+  <clinit>() {
+  }
+  LoggerFloggerAccessPrivate() {
+    super();
+  }
+}
+@Flogger(access=AccessLevel.NONE) class LoggerFloggerAccessNone {
+  <clinit>() {
+  }
+  LoggerFloggerAccessNone() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerFloggerAccess.java
+++ b/test/transform/resource/after-ecj/LoggerFloggerAccess.java
@@ -1,48 +1,51 @@
 import lombok.AccessLevel;
 import lombok.extern.flogger.Flogger;
-@Flogger(access=AccessLevel.PUBLIC) class LoggerFloggerAccessPublic {
+@Flogger(access = AccessLevel.PUBLIC) class LoggerFloggerAccessPublic {
   public static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
   <clinit>() {
   }
+
   LoggerFloggerAccessPublic() {
     super();
   }
 }
-@Flogger(access=AccessLevel.MODULE) class LoggerFloggerAccessModule {
+@Flogger(access = AccessLevel.MODULE) class LoggerFloggerAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
   <clinit>() {
   }
+
   LoggerFloggerAccessModule() {
     super();
   }
 }
-@Flogger(access=AccessLevel.PROTECTED) class LoggerFloggerAccessProtected {
+@Flogger(access = AccessLevel.PROTECTED) class LoggerFloggerAccessProtected {
   protected static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
   <clinit>() {
   }
+
   LoggerFloggerAccessProtected() {
     super();
   }
 }
-@Flogger(access=AccessLevel.PACKAGE) class LoggerFloggerAccessPackage {
+@Flogger(access = AccessLevel.PACKAGE) class LoggerFloggerAccessPackage {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
   <clinit>() {
   }
+
   LoggerFloggerAccessPackage() {
     super();
   }
 }
-@Flogger(access=AccessLevel.PRIVATE) class LoggerFloggerAccessPrivate {
+@Flogger(access = AccessLevel.PRIVATE) class LoggerFloggerAccessPrivate {
   private static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
   <clinit>() {
   }
+
   LoggerFloggerAccessPrivate() {
     super();
   }
 }
-@Flogger(access=AccessLevel.NONE) class LoggerFloggerAccessNone {
-  <clinit>() {
-  }
+@Flogger(access = AccessLevel.NONE) class LoggerFloggerAccessNone {
   LoggerFloggerAccessNone() {
     super();
   }

--- a/test/transform/resource/after-ecj/LoggerJBossLogAccess.java
+++ b/test/transform/resource/after-ecj/LoggerJBossLogAccess.java
@@ -1,48 +1,51 @@
 import lombok.AccessLevel;
 import lombok.extern.jbosslog.JBossLog;
-@JBossLog(access=AccessLevel.PUBLIC) class LoggerJBossLogAccessPublic {
+@JBossLog(access = AccessLevel.PUBLIC) class LoggerJBossLogAccessPublic {
   public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessPublic.class);
   <clinit>() {
   }
+
   LoggerJBossLogAccessPublic() {
     super();
   }
 }
-@JBossLog(access=AccessLevel.MODULE) class LoggerJBossLogAccessModule {
+@JBossLog(access = AccessLevel.MODULE) class LoggerJBossLogAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessModule.class);
   <clinit>() {
   }
+
   LoggerJBossLogAccessModule() {
     super();
   }
 }
-@JBossLog(access=AccessLevel.PROTECTED) class LoggerJBossLogAccessProtected {
+@JBossLog(access = AccessLevel.PROTECTED) class LoggerJBossLogAccessProtected {
   protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessProtected.class);
   <clinit>() {
   }
+
   LoggerJBossLogAccessProtected() {
     super();
   }
 }
-@JBossLog(access=AccessLevel.PACKAGE) class LoggerJBossLogAccessPackage {
+@JBossLog(access = AccessLevel.PACKAGE) class LoggerJBossLogAccessPackage {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessPackage.class);
   <clinit>() {
   }
+
   LoggerJBossLogAccessPackage() {
     super();
   }
 }
-@JBossLog(access=AccessLevel.PRIVATE) class LoggerJBossLogAccessPrivate {
+@JBossLog(access = AccessLevel.PRIVATE) class LoggerJBossLogAccessPrivate {
   private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessPrivate.class);
   <clinit>() {
   }
+
   LoggerJBossLogAccessPrivate() {
     super();
   }
 }
-@JBossLog(access=AccessLevel.NONE) class LoggerJBossLogAccessNone {
-  <clinit>() {
-  }
+@JBossLog(access = AccessLevel.NONE) class LoggerJBossLogAccessNone {
   LoggerJBossLogAccessNone() {
     super();
   }

--- a/test/transform/resource/after-ecj/LoggerJBossLogAccess.java
+++ b/test/transform/resource/after-ecj/LoggerJBossLogAccess.java
@@ -1,0 +1,49 @@
+import lombok.AccessLevel;
+import lombok.extern.jbosslog.JBossLog;
+@JBossLog(access=AccessLevel.PUBLIC) class LoggerJBossLogAccessPublic {
+  public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessPublic.class);
+  <clinit>() {
+  }
+  LoggerJBossLogAccessPublic() {
+    super();
+  }
+}
+@JBossLog(access=AccessLevel.MODULE) class LoggerJBossLogAccessModule {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessModule.class);
+  <clinit>() {
+  }
+  LoggerJBossLogAccessModule() {
+    super();
+  }
+}
+@JBossLog(access=AccessLevel.PROTECTED) class LoggerJBossLogAccessProtected {
+  protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessProtected.class);
+  <clinit>() {
+  }
+  LoggerJBossLogAccessProtected() {
+    super();
+  }
+}
+@JBossLog(access=AccessLevel.PACKAGE) class LoggerJBossLogAccessPackage {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessPackage.class);
+  <clinit>() {
+  }
+  LoggerJBossLogAccessPackage() {
+    super();
+  }
+}
+@JBossLog(access=AccessLevel.PRIVATE) class LoggerJBossLogAccessPrivate {
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessPrivate.class);
+  <clinit>() {
+  }
+  LoggerJBossLogAccessPrivate() {
+    super();
+  }
+}
+@JBossLog(access=AccessLevel.NONE) class LoggerJBossLogAccessNone {
+  <clinit>() {
+  }
+  LoggerJBossLogAccessNone() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerJulAccess.java
+++ b/test/transform/resource/after-ecj/LoggerJulAccess.java
@@ -1,48 +1,51 @@
 import lombok.AccessLevel;
 import lombok.extern.java.Log;
-@Log(access=AccessLevel.PUBLIC) class LoggerJulAccessPublic {
+@Log(access = AccessLevel.PUBLIC) class LoggerJulAccessPublic {
   public static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessPublic.class.getName());
   <clinit>() {
   }
+
   LoggerJulAccessPublic() {
     super();
   }
 }
-@Log(access=AccessLevel.MODULE) class LoggerJulAccessModule {
+@Log(access = AccessLevel.MODULE) class LoggerJulAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessModule.class.getName());
   <clinit>() {
   }
+
   LoggerJulAccessModule() {
     super();
   }
 }
-@Log(access=AccessLevel.PROTECTED) class LoggerJulAccessProtected {
+@Log(access = AccessLevel.PROTECTED) class LoggerJulAccessProtected {
   protected static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessProtected.class.getName());
   <clinit>() {
   }
+
   LoggerJulAccessProtected() {
     super();
   }
 }
-@Log(access=AccessLevel.PACKAGE) class LoggerJulAccessPackage {
+@Log(access = AccessLevel.PACKAGE) class LoggerJulAccessPackage {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessPackage.class.getName());
   <clinit>() {
   }
+
   LoggerJulAccessPackage() {
     super();
   }
 }
-@Log(access=AccessLevel.PRIVATE) class LoggerJulAccessPrivate {
+@Log(access = AccessLevel.PRIVATE) class LoggerJulAccessPrivate {
   private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessPrivate.class.getName());
   <clinit>() {
   }
+
   LoggerJulAccessPrivate() {
     super();
   }
 }
-@Log(access=AccessLevel.NONE) class LoggerJulAccessNone {
-  <clinit>() {
-  }
+@Log(access = AccessLevel.NONE) class LoggerJulAccessNone {
   LoggerJulAccessNone() {
     super();
   }

--- a/test/transform/resource/after-ecj/LoggerJulAccess.java
+++ b/test/transform/resource/after-ecj/LoggerJulAccess.java
@@ -1,0 +1,49 @@
+import lombok.AccessLevel;
+import lombok.extern.java.Log;
+@Log(access=AccessLevel.PUBLIC) class LoggerJulAccessPublic {
+  public static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessPublic.class.getName());
+  <clinit>() {
+  }
+  LoggerJulAccessPublic() {
+    super();
+  }
+}
+@Log(access=AccessLevel.MODULE) class LoggerJulAccessModule {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessModule.class.getName());
+  <clinit>() {
+  }
+  LoggerJulAccessModule() {
+    super();
+  }
+}
+@Log(access=AccessLevel.PROTECTED) class LoggerJulAccessProtected {
+  protected static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessProtected.class.getName());
+  <clinit>() {
+  }
+  LoggerJulAccessProtected() {
+    super();
+  }
+}
+@Log(access=AccessLevel.PACKAGE) class LoggerJulAccessPackage {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessPackage.class.getName());
+  <clinit>() {
+  }
+  LoggerJulAccessPackage() {
+    super();
+  }
+}
+@Log(access=AccessLevel.PRIVATE) class LoggerJulAccessPrivate {
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessPrivate.class.getName());
+  <clinit>() {
+  }
+  LoggerJulAccessPrivate() {
+    super();
+  }
+}
+@Log(access=AccessLevel.NONE) class LoggerJulAccessNone {
+  <clinit>() {
+  }
+  LoggerJulAccessNone() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerLog4j2Access.java
+++ b/test/transform/resource/after-ecj/LoggerLog4j2Access.java
@@ -1,0 +1,49 @@
+import lombok.AccessLevel;
+import lombok.extern.log4j.Log4j2;
+@Log4j2(access=AccessLevel.PUBLIC) class LoggerLog4j2AccessPublic {
+  public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessPublic.class);
+  <clinit>() {
+  }
+  LoggerLog4j2AccessPublic() {
+    super();
+  }
+}
+@Log4j2(access=AccessLevel.MODULE) class LoggerLog4j2AccessModule {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessModule.class);
+  <clinit>() {
+  }
+  LoggerLog4j2AccessModule() {
+    super();
+  }
+}
+@Log4j2(access=AccessLevel.PROTECTED) class LoggerLog4j2AccessProtected {
+  protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessProtected.class);
+  <clinit>() {
+  }
+  LoggerLog4j2AccessProtected() {
+    super();
+  }
+}
+@Log4j2(access=AccessLevel.PACKAGE) class LoggerLog4j2AccessPackage {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessPackage.class);
+  <clinit>() {
+  }
+  LoggerLog4j2AccessPackage() {
+    super();
+  }
+}
+@Log4j2(access=AccessLevel.PRIVATE) class LoggerLog4j2AccessPrivate {
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessPrivate.class);
+  <clinit>() {
+  }
+  LoggerLog4j2AccessPrivate() {
+    super();
+  }
+}
+@Log4j2(access=AccessLevel.NONE) class LoggerLog4j2AccessNone {
+  <clinit>() {
+  }
+  LoggerLog4j2AccessNone() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerLog4j2Access.java
+++ b/test/transform/resource/after-ecj/LoggerLog4j2Access.java
@@ -1,48 +1,51 @@
 import lombok.AccessLevel;
 import lombok.extern.log4j.Log4j2;
-@Log4j2(access=AccessLevel.PUBLIC) class LoggerLog4j2AccessPublic {
+@Log4j2(access = AccessLevel.PUBLIC) class LoggerLog4j2AccessPublic {
   public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessPublic.class);
   <clinit>() {
   }
+
   LoggerLog4j2AccessPublic() {
     super();
   }
 }
-@Log4j2(access=AccessLevel.MODULE) class LoggerLog4j2AccessModule {
+@Log4j2(access = AccessLevel.MODULE) class LoggerLog4j2AccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessModule.class);
   <clinit>() {
   }
+
   LoggerLog4j2AccessModule() {
     super();
   }
 }
-@Log4j2(access=AccessLevel.PROTECTED) class LoggerLog4j2AccessProtected {
+@Log4j2(access = AccessLevel.PROTECTED) class LoggerLog4j2AccessProtected {
   protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessProtected.class);
   <clinit>() {
   }
+
   LoggerLog4j2AccessProtected() {
     super();
   }
 }
-@Log4j2(access=AccessLevel.PACKAGE) class LoggerLog4j2AccessPackage {
+@Log4j2(access = AccessLevel.PACKAGE) class LoggerLog4j2AccessPackage {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessPackage.class);
   <clinit>() {
   }
+
   LoggerLog4j2AccessPackage() {
     super();
   }
 }
-@Log4j2(access=AccessLevel.PRIVATE) class LoggerLog4j2AccessPrivate {
+@Log4j2(access = AccessLevel.PRIVATE) class LoggerLog4j2AccessPrivate {
   private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessPrivate.class);
   <clinit>() {
   }
+
   LoggerLog4j2AccessPrivate() {
     super();
   }
 }
-@Log4j2(access=AccessLevel.NONE) class LoggerLog4j2AccessNone {
-  <clinit>() {
-  }
+@Log4j2(access = AccessLevel.NONE) class LoggerLog4j2AccessNone {
   LoggerLog4j2AccessNone() {
     super();
   }

--- a/test/transform/resource/after-ecj/LoggerLog4jAccess.java
+++ b/test/transform/resource/after-ecj/LoggerLog4jAccess.java
@@ -1,48 +1,51 @@
 import lombok.AccessLevel;
 import lombok.extern.log4j.Log4j;
-@Log4j(access=AccessLevel.PUBLIC) class LoggerLog4jAccessPublic {
+@Log4j(access = AccessLevel.PUBLIC) class LoggerLog4jAccessPublic {
   public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessPublic.class);
   <clinit>() {
   }
+
   LoggerLog4jAccessPublic() {
     super();
   }
 }
-@Log4j(access=AccessLevel.MODULE) class LoggerLog4jAccessModule {
+@Log4j(access = AccessLevel.MODULE) class LoggerLog4jAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessModule.class);
   <clinit>() {
   }
+
   LoggerLog4jAccessModule() {
     super();
   }
 }
-@Log4j(access=AccessLevel.PROTECTED) class LoggerLog4jAccessProtected {
+@Log4j(access = AccessLevel.PROTECTED) class LoggerLog4jAccessProtected {
   protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessProtected.class);
   <clinit>() {
   }
+
   LoggerLog4jAccessProtected() {
     super();
   }
 }
-@Log4j(access=AccessLevel.PACKAGE) class LoggerLog4jAccessPackage {
+@Log4j(access = AccessLevel.PACKAGE) class LoggerLog4jAccessPackage {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessPackage.class);
   <clinit>() {
   }
+
   LoggerLog4jAccessPackage() {
     super();
   }
 }
-@Log4j(access=AccessLevel.PRIVATE) class LoggerLog4jAccessPrivate {
+@Log4j(access = AccessLevel.PRIVATE) class LoggerLog4jAccessPrivate {
   private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessPrivate.class);
   <clinit>() {
   }
+
   LoggerLog4jAccessPrivate() {
     super();
   }
 }
-@Log4j(access=AccessLevel.NONE) class LoggerLog4jAccessNone {
-  <clinit>() {
-  }
+@Log4j(access = AccessLevel.NONE) class LoggerLog4jAccessNone {
   LoggerLog4jAccessNone() {
     super();
   }

--- a/test/transform/resource/after-ecj/LoggerLog4jAccess.java
+++ b/test/transform/resource/after-ecj/LoggerLog4jAccess.java
@@ -1,0 +1,49 @@
+import lombok.AccessLevel;
+import lombok.extern.log4j.Log4j;
+@Log4j(access=AccessLevel.PUBLIC) class LoggerLog4jAccessPublic {
+  public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessPublic.class);
+  <clinit>() {
+  }
+  LoggerLog4jAccessPublic() {
+    super();
+  }
+}
+@Log4j(access=AccessLevel.MODULE) class LoggerLog4jAccessModule {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessModule.class);
+  <clinit>() {
+  }
+  LoggerLog4jAccessModule() {
+    super();
+  }
+}
+@Log4j(access=AccessLevel.PROTECTED) class LoggerLog4jAccessProtected {
+  protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessProtected.class);
+  <clinit>() {
+  }
+  LoggerLog4jAccessProtected() {
+    super();
+  }
+}
+@Log4j(access=AccessLevel.PACKAGE) class LoggerLog4jAccessPackage {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessPackage.class);
+  <clinit>() {
+  }
+  LoggerLog4jAccessPackage() {
+    super();
+  }
+}
+@Log4j(access=AccessLevel.PRIVATE) class LoggerLog4jAccessPrivate {
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessPrivate.class);
+  <clinit>() {
+  }
+  LoggerLog4jAccessPrivate() {
+    super();
+  }
+}
+@Log4j(access=AccessLevel.NONE) class LoggerLog4jAccessNone {
+  <clinit>() {
+  }
+  LoggerLog4jAccessNone() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerSlf4jAccess.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4jAccess.java
@@ -1,0 +1,49 @@
+import lombok.AccessLevel;
+import lombok.extern.slf4j.Slf4j;
+@Slf4j(access=AccessLevel.PUBLIC) class LoggerSlf4jAccessPublic {
+  public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessPublic.class);
+  <clinit>() {
+  }
+  LoggerSlf4jAccessPublic() {
+    super();
+  }
+}
+@Slf4j(access=AccessLevel.MODULE) class LoggerSlf4jAccessModule {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessModule.class);
+  <clinit>() {
+  }
+  LoggerSlf4jAccessModule() {
+    super();
+  }
+}
+@Slf4j(access=AccessLevel.PROTECTED) class LoggerSlf4jAccessProtected {
+  protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessProtected.class);
+  <clinit>() {
+  }
+  LoggerSlf4jAccessProtected() {
+    super();
+  }
+}
+@Slf4j(access=AccessLevel.PACKAGE) class LoggerSlf4jAccessPackage {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessPackage.class);
+  <clinit>() {
+  }
+  LoggerSlf4jAccessPackage() {
+    super();
+  }
+}
+@Slf4j(access=AccessLevel.PRIVATE) class LoggerSlf4jAccessPrivate {
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessPrivate.class);
+  <clinit>() {
+  }
+  LoggerSlf4jAccessPrivate() {
+    super();
+  }
+}
+@Slf4j(access=AccessLevel.NONE) class LoggerSlf4jAccessNone {
+  <clinit>() {
+  }
+  LoggerSlf4jAccessNone() {
+    super();
+  }
+}

--- a/test/transform/resource/after-ecj/LoggerSlf4jAccess.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4jAccess.java
@@ -1,48 +1,51 @@
 import lombok.AccessLevel;
 import lombok.extern.slf4j.Slf4j;
-@Slf4j(access=AccessLevel.PUBLIC) class LoggerSlf4jAccessPublic {
+@Slf4j(access = AccessLevel.PUBLIC) class LoggerSlf4jAccessPublic {
   public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessPublic.class);
   <clinit>() {
   }
+
   LoggerSlf4jAccessPublic() {
     super();
   }
 }
-@Slf4j(access=AccessLevel.MODULE) class LoggerSlf4jAccessModule {
+@Slf4j(access = AccessLevel.MODULE) class LoggerSlf4jAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessModule.class);
   <clinit>() {
   }
+
   LoggerSlf4jAccessModule() {
     super();
   }
 }
-@Slf4j(access=AccessLevel.PROTECTED) class LoggerSlf4jAccessProtected {
+@Slf4j(access = AccessLevel.PROTECTED) class LoggerSlf4jAccessProtected {
   protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessProtected.class);
   <clinit>() {
   }
+
   LoggerSlf4jAccessProtected() {
     super();
   }
 }
-@Slf4j(access=AccessLevel.PACKAGE) class LoggerSlf4jAccessPackage {
+@Slf4j(access = AccessLevel.PACKAGE) class LoggerSlf4jAccessPackage {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessPackage.class);
   <clinit>() {
   }
+
   LoggerSlf4jAccessPackage() {
     super();
   }
 }
-@Slf4j(access=AccessLevel.PRIVATE) class LoggerSlf4jAccessPrivate {
+@Slf4j(access = AccessLevel.PRIVATE) class LoggerSlf4jAccessPrivate {
   private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessPrivate.class);
   <clinit>() {
   }
+
   LoggerSlf4jAccessPrivate() {
     super();
   }
 }
-@Slf4j(access=AccessLevel.NONE) class LoggerSlf4jAccessNone {
-  <clinit>() {
-  }
+@Slf4j(access = AccessLevel.NONE) class LoggerSlf4jAccessNone {
   LoggerSlf4jAccessNone() {
     super();
   }

--- a/test/transform/resource/after-ecj/LoggerXslf4jAccess.java
+++ b/test/transform/resource/after-ecj/LoggerXslf4jAccess.java
@@ -1,48 +1,51 @@
 import lombok.AccessLevel;
 import lombok.extern.slf4j.XSlf4j;
-@XSlf4j(access=AccessLevel.PUBLIC) class LoggerXslf4jAccessPublic {
+@XSlf4j(access = AccessLevel.PUBLIC) class LoggerXslf4jAccessPublic {
   public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessPublic.class);
   <clinit>() {
   }
+
   LoggerXslf4jAccessPublic() {
     super();
   }
 }
-@XSlf4j(access=AccessLevel.MODULE) class LoggerXslf4jAccessModule {
+@XSlf4j(access = AccessLevel.MODULE) class LoggerXslf4jAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessModule.class);
   <clinit>() {
   }
+
   LoggerXslf4jAccessModule() {
     super();
   }
 }
-@XSlf4j(access=AccessLevel.PROTECTED) class LoggerXslf4jAccessProtected {
+@XSlf4j(access = AccessLevel.PROTECTED) class LoggerXslf4jAccessProtected {
   protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessProtected.class);
   <clinit>() {
   }
+
   LoggerXslf4jAccessProtected() {
     super();
   }
 }
-@XSlf4j(access=AccessLevel.PACKAGE) class LoggerXslf4jAccessPackage {
+@XSlf4j(access = AccessLevel.PACKAGE) class LoggerXslf4jAccessPackage {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessPackage.class);
   <clinit>() {
   }
+
   LoggerXslf4jAccessPackage() {
     super();
   }
 }
-@XSlf4j(access=AccessLevel.PRIVATE) class LoggerXslf4jAccessPrivate {
+@XSlf4j(access = AccessLevel.PRIVATE) class LoggerXslf4jAccessPrivate {
   private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessPrivate.class);
   <clinit>() {
   }
+
   LoggerXslf4jAccessPrivate() {
     super();
   }
 }
-@XSlf4j(access=AccessLevel.NONE) class LoggerXslf4jAccessNone {
-  <clinit>() {
-  }
+@XSlf4j(access = AccessLevel.NONE) class LoggerXslf4jAccessNone {
   LoggerXslf4jAccessNone() {
     super();
   }

--- a/test/transform/resource/after-ecj/LoggerXslf4jAccess.java
+++ b/test/transform/resource/after-ecj/LoggerXslf4jAccess.java
@@ -1,0 +1,49 @@
+import lombok.AccessLevel;
+import lombok.extern.slf4j.XSlf4j;
+@XSlf4j(access=AccessLevel.PUBLIC) class LoggerXslf4jAccessPublic {
+  public static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessPublic.class);
+  <clinit>() {
+  }
+  LoggerXslf4jAccessPublic() {
+    super();
+  }
+}
+@XSlf4j(access=AccessLevel.MODULE) class LoggerXslf4jAccessModule {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessModule.class);
+  <clinit>() {
+  }
+  LoggerXslf4jAccessModule() {
+    super();
+  }
+}
+@XSlf4j(access=AccessLevel.PROTECTED) class LoggerXslf4jAccessProtected {
+  protected static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessProtected.class);
+  <clinit>() {
+  }
+  LoggerXslf4jAccessProtected() {
+    super();
+  }
+}
+@XSlf4j(access=AccessLevel.PACKAGE) class LoggerXslf4jAccessPackage {
+  static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessPackage.class);
+  <clinit>() {
+  }
+  LoggerXslf4jAccessPackage() {
+    super();
+  }
+}
+@XSlf4j(access=AccessLevel.PRIVATE) class LoggerXslf4jAccessPrivate {
+  private static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessPrivate.class);
+  <clinit>() {
+  }
+  LoggerXslf4jAccessPrivate() {
+    super();
+  }
+}
+@XSlf4j(access=AccessLevel.NONE) class LoggerXslf4jAccessNone {
+  <clinit>() {
+  }
+  LoggerXslf4jAccessNone() {
+    super();
+  }
+}

--- a/test/transform/resource/before/LoggerCommonsAccess.java
+++ b/test/transform/resource/before/LoggerCommonsAccess.java
@@ -1,0 +1,26 @@
+import lombok.AccessLevel;
+import lombok.extern.apachecommons.CommonsLog;
+
+@CommonsLog(access=AccessLevel.PUBLIC)
+class LoggerCommonsAccessPublic {
+}
+
+@CommonsLog(access=AccessLevel.MODULE)
+class LoggerCommonsAccessModule {
+}
+
+@CommonsLog(access=AccessLevel.PROTECTED)
+class LoggerCommonsAccessProtected {
+}
+
+@CommonsLog(access=AccessLevel.PACKAGE)
+class LoggerCommonsAccessPackage {
+}
+
+@CommonsLog(access=AccessLevel.PRIVATE)
+class LoggerCommonsAccessPrivate {
+}
+
+@CommonsLog(access=AccessLevel.NONE)
+class LoggerCommonsAccessNone {
+}

--- a/test/transform/resource/before/LoggerCommonsAccess.java
+++ b/test/transform/resource/before/LoggerCommonsAccess.java
@@ -1,26 +1,26 @@
 import lombok.AccessLevel;
 import lombok.extern.apachecommons.CommonsLog;
 
-@CommonsLog(access=AccessLevel.PUBLIC)
+@CommonsLog(access = AccessLevel.PUBLIC)
 class LoggerCommonsAccessPublic {
 }
 
-@CommonsLog(access=AccessLevel.MODULE)
+@CommonsLog(access = AccessLevel.MODULE)
 class LoggerCommonsAccessModule {
 }
 
-@CommonsLog(access=AccessLevel.PROTECTED)
+@CommonsLog(access = AccessLevel.PROTECTED)
 class LoggerCommonsAccessProtected {
 }
 
-@CommonsLog(access=AccessLevel.PACKAGE)
+@CommonsLog(access = AccessLevel.PACKAGE)
 class LoggerCommonsAccessPackage {
 }
 
-@CommonsLog(access=AccessLevel.PRIVATE)
+@CommonsLog(access = AccessLevel.PRIVATE)
 class LoggerCommonsAccessPrivate {
 }
 
-@CommonsLog(access=AccessLevel.NONE)
+@CommonsLog(access = AccessLevel.NONE)
 class LoggerCommonsAccessNone {
 }

--- a/test/transform/resource/before/LoggerCustomAccess.java
+++ b/test/transform/resource/before/LoggerCustomAccess.java
@@ -24,3 +24,11 @@ class LoggerCustomAccessPrivate {
 @CustomLog(access=AccessLevel.NONE)
 class LoggerCustomAccessNone {
 }
+class MyLoggerFactory {
+	static MyLogger create(Class<?> clazz) {
+		return null;
+	}
+}
+class MyLogger {
+}
+

--- a/test/transform/resource/before/LoggerCustomAccess.java
+++ b/test/transform/resource/before/LoggerCustomAccess.java
@@ -1,0 +1,26 @@
+import lombok.AccessLevel;
+import lombok.CustomLog;
+
+@CustomLog(access=AccessLevel.PUBLIC)
+class LoggerCustomAccessPublic {
+}
+
+@CustomLog(access=AccessLevel.MODULE)
+class LoggerCustomAccessModule {
+}
+
+@CustomLog(access=AccessLevel.PROTECTED)
+class LoggerCustomAccessProtected {
+}
+
+@CustomLog(access=AccessLevel.PACKAGE)
+class LoggerCustomAccessPackage {
+}
+
+@CustomLog(access=AccessLevel.PRIVATE)
+class LoggerCustomAccessPrivate {
+}
+
+@CustomLog(access=AccessLevel.NONE)
+class LoggerCustomAccessNone {
+}

--- a/test/transform/resource/before/LoggerCustomAccess.java
+++ b/test/transform/resource/before/LoggerCustomAccess.java
@@ -1,27 +1,28 @@
+//CONF: lombok.log.custom.declaration = MyLogger MyLoggerFactory.create(TYPE)
 import lombok.AccessLevel;
 import lombok.CustomLog;
 
-@CustomLog(access=AccessLevel.PUBLIC)
+@CustomLog(access = AccessLevel.PUBLIC)
 class LoggerCustomAccessPublic {
 }
 
-@CustomLog(access=AccessLevel.MODULE)
+@CustomLog(access = AccessLevel.MODULE)
 class LoggerCustomAccessModule {
 }
 
-@CustomLog(access=AccessLevel.PROTECTED)
+@CustomLog(access = AccessLevel.PROTECTED)
 class LoggerCustomAccessProtected {
 }
 
-@CustomLog(access=AccessLevel.PACKAGE)
+@CustomLog(access = AccessLevel.PACKAGE)
 class LoggerCustomAccessPackage {
 }
 
-@CustomLog(access=AccessLevel.PRIVATE)
+@CustomLog(access = AccessLevel.PRIVATE)
 class LoggerCustomAccessPrivate {
 }
 
-@CustomLog(access=AccessLevel.NONE)
+@CustomLog(access = AccessLevel.NONE)
 class LoggerCustomAccessNone {
 }
 class MyLoggerFactory {

--- a/test/transform/resource/before/LoggerFloggerAccess.java
+++ b/test/transform/resource/before/LoggerFloggerAccess.java
@@ -1,26 +1,26 @@
 import lombok.AccessLevel;
 import lombok.extern.flogger.Flogger;
 
-@Flogger(access=AccessLevel.PUBLIC)
+@Flogger(access = AccessLevel.PUBLIC)
 class LoggerFloggerAccessPublic {
 }
 
-@Flogger(access=AccessLevel.MODULE)
+@Flogger(access = AccessLevel.MODULE)
 class LoggerFloggerAccessModule {
 }
 
-@Flogger(access=AccessLevel.PROTECTED)
+@Flogger(access = AccessLevel.PROTECTED)
 class LoggerFloggerAccessProtected {
 }
 
-@Flogger(access=AccessLevel.PACKAGE)
+@Flogger(access = AccessLevel.PACKAGE)
 class LoggerFloggerAccessPackage {
 }
 
-@Flogger(access=AccessLevel.PRIVATE)
+@Flogger(access = AccessLevel.PRIVATE)
 class LoggerFloggerAccessPrivate {
 }
 
-@Flogger(access=AccessLevel.NONE)
+@Flogger(access = AccessLevel.NONE)
 class LoggerFloggerAccessNone {
 }

--- a/test/transform/resource/before/LoggerFloggerAccess.java
+++ b/test/transform/resource/before/LoggerFloggerAccess.java
@@ -1,0 +1,26 @@
+import lombok.AccessLevel;
+import lombok.extern.flogger.Flogger;
+
+@Flogger(access=AccessLevel.PUBLIC)
+class LoggerFloggerAccessPublic {
+}
+
+@Flogger(access=AccessLevel.MODULE)
+class LoggerFloggerAccessModule {
+}
+
+@Flogger(access=AccessLevel.PROTECTED)
+class LoggerFloggerAccessProtected {
+}
+
+@Flogger(access=AccessLevel.PACKAGE)
+class LoggerFloggerAccessPackage {
+}
+
+@Flogger(access=AccessLevel.PRIVATE)
+class LoggerFloggerAccessPrivate {
+}
+
+@Flogger(access=AccessLevel.NONE)
+class LoggerFloggerAccessNone {
+}

--- a/test/transform/resource/before/LoggerJbossLogAccess.java
+++ b/test/transform/resource/before/LoggerJbossLogAccess.java
@@ -1,26 +1,26 @@
 import lombok.AccessLevel;
 import lombok.extern.jbosslog.JBossLog;
 
-@JBossLog(access=AccessLevel.PUBLIC)
+@JBossLog(access = AccessLevel.PUBLIC)
 class LoggerJBossLogAccessPublic {
 }
 
-@JBossLog(access=AccessLevel.MODULE)
+@JBossLog(access = AccessLevel.MODULE)
 class LoggerJBossLogAccessModule {
 }
 
-@JBossLog(access=AccessLevel.PROTECTED)
+@JBossLog(access = AccessLevel.PROTECTED)
 class LoggerJBossLogAccessProtected {
 }
 
-@JBossLog(access=AccessLevel.PACKAGE)
+@JBossLog(access = AccessLevel.PACKAGE)
 class LoggerJBossLogAccessPackage {
 }
 
-@JBossLog(access=AccessLevel.PRIVATE)
+@JBossLog(access = AccessLevel.PRIVATE)
 class LoggerJBossLogAccessPrivate {
 }
 
-@JBossLog(access=AccessLevel.NONE)
+@JBossLog(access = AccessLevel.NONE)
 class LoggerJBossLogAccessNone {
 }

--- a/test/transform/resource/before/LoggerJbossLogAccess.java
+++ b/test/transform/resource/before/LoggerJbossLogAccess.java
@@ -1,0 +1,26 @@
+import lombok.AccessLevel;
+import lombok.extern.jbosslog.JBossLog;
+
+@JBossLog(access=AccessLevel.PUBLIC)
+class LoggerJBossLogAccessPublic {
+}
+
+@JBossLog(access=AccessLevel.MODULE)
+class LoggerJBossLogAccessModule {
+}
+
+@JBossLog(access=AccessLevel.PROTECTED)
+class LoggerJBossLogAccessProtected {
+}
+
+@JBossLog(access=AccessLevel.PACKAGE)
+class LoggerJBossLogAccessPackage {
+}
+
+@JBossLog(access=AccessLevel.PRIVATE)
+class LoggerJBossLogAccessPrivate {
+}
+
+@JBossLog(access=AccessLevel.NONE)
+class LoggerJBossLogAccessNone {
+}

--- a/test/transform/resource/before/LoggerJulAccess.java
+++ b/test/transform/resource/before/LoggerJulAccess.java
@@ -1,0 +1,26 @@
+import lombok.AccessLevel;
+import lombok.extern.java.Log;
+
+@Log(access=AccessLevel.PUBLIC)
+class LoggerJulAccessPublic {
+}
+
+@Log(access=AccessLevel.MODULE)
+class LoggerJulAccessModule {
+}
+
+@Log(access=AccessLevel.PROTECTED)
+class LoggerJulAccessProtected {
+}
+
+@Log(access=AccessLevel.PACKAGE)
+class LoggerJulAccessPackage {
+}
+
+@Log(access=AccessLevel.PRIVATE)
+class LoggerJulAccessPrivate {
+}
+
+@Log(access=AccessLevel.NONE)
+class LoggerJulAccessNone {
+}

--- a/test/transform/resource/before/LoggerJulAccess.java
+++ b/test/transform/resource/before/LoggerJulAccess.java
@@ -1,26 +1,26 @@
 import lombok.AccessLevel;
 import lombok.extern.java.Log;
 
-@Log(access=AccessLevel.PUBLIC)
+@Log(access = AccessLevel.PUBLIC)
 class LoggerJulAccessPublic {
 }
 
-@Log(access=AccessLevel.MODULE)
+@Log(access = AccessLevel.MODULE)
 class LoggerJulAccessModule {
 }
 
-@Log(access=AccessLevel.PROTECTED)
+@Log(access = AccessLevel.PROTECTED)
 class LoggerJulAccessProtected {
 }
 
-@Log(access=AccessLevel.PACKAGE)
+@Log(access = AccessLevel.PACKAGE)
 class LoggerJulAccessPackage {
 }
 
-@Log(access=AccessLevel.PRIVATE)
+@Log(access = AccessLevel.PRIVATE)
 class LoggerJulAccessPrivate {
 }
 
-@Log(access=AccessLevel.NONE)
+@Log(access = AccessLevel.NONE)
 class LoggerJulAccessNone {
 }

--- a/test/transform/resource/before/LoggerLog4j2Access.java
+++ b/test/transform/resource/before/LoggerLog4j2Access.java
@@ -1,0 +1,26 @@
+import lombok.AccessLevel;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2(access=AccessLevel.PUBLIC)
+class LoggerLog4j2AccessPublic {
+}
+
+@Log4j2(access=AccessLevel.MODULE)
+class LoggerLog4j2AccessModule {
+}
+
+@Log4j2(access=AccessLevel.PROTECTED)
+class LoggerLog4j2AccessProtected {
+}
+
+@Log4j2(access=AccessLevel.PACKAGE)
+class LoggerLog4j2AccessPackage {
+}
+
+@Log4j2(access=AccessLevel.PRIVATE)
+class LoggerLog4j2AccessPrivate {
+}
+
+@Log4j2(access=AccessLevel.NONE)
+class LoggerLog4j2AccessNone {
+}

--- a/test/transform/resource/before/LoggerLog4j2Access.java
+++ b/test/transform/resource/before/LoggerLog4j2Access.java
@@ -1,26 +1,26 @@
 import lombok.AccessLevel;
 import lombok.extern.log4j.Log4j2;
 
-@Log4j2(access=AccessLevel.PUBLIC)
+@Log4j2(access = AccessLevel.PUBLIC)
 class LoggerLog4j2AccessPublic {
 }
 
-@Log4j2(access=AccessLevel.MODULE)
+@Log4j2(access = AccessLevel.MODULE)
 class LoggerLog4j2AccessModule {
 }
 
-@Log4j2(access=AccessLevel.PROTECTED)
+@Log4j2(access = AccessLevel.PROTECTED)
 class LoggerLog4j2AccessProtected {
 }
 
-@Log4j2(access=AccessLevel.PACKAGE)
+@Log4j2(access = AccessLevel.PACKAGE)
 class LoggerLog4j2AccessPackage {
 }
 
-@Log4j2(access=AccessLevel.PRIVATE)
+@Log4j2(access = AccessLevel.PRIVATE)
 class LoggerLog4j2AccessPrivate {
 }
 
-@Log4j2(access=AccessLevel.NONE)
+@Log4j2(access = AccessLevel.NONE)
 class LoggerLog4j2AccessNone {
 }

--- a/test/transform/resource/before/LoggerLog4jAccess.java
+++ b/test/transform/resource/before/LoggerLog4jAccess.java
@@ -1,26 +1,26 @@
 import lombok.AccessLevel;
 import lombok.extern.log4j.Log4j;
 
-@Log4j(access=AccessLevel.PUBLIC)
+@Log4j(access = AccessLevel.PUBLIC)
 class LoggerLog4jAccessPublic {
 }
 
-@Log4j(access=AccessLevel.MODULE)
+@Log4j(access = AccessLevel.MODULE)
 class LoggerLog4jAccessModule {
 }
 
-@Log4j(access=AccessLevel.PROTECTED)
+@Log4j(access = AccessLevel.PROTECTED)
 class LoggerLog4jAccessProtected {
 }
 
-@Log4j(access=AccessLevel.PACKAGE)
+@Log4j(access = AccessLevel.PACKAGE)
 class LoggerLog4jAccessPackage {
 }
 
-@Log4j(access=AccessLevel.PRIVATE)
+@Log4j(access = AccessLevel.PRIVATE)
 class LoggerLog4jAccessPrivate {
 }
 
-@Log4j(access=AccessLevel.NONE)
+@Log4j(access = AccessLevel.NONE)
 class LoggerLog4jAccessNone {
 }

--- a/test/transform/resource/before/LoggerLog4jAccess.java
+++ b/test/transform/resource/before/LoggerLog4jAccess.java
@@ -1,0 +1,26 @@
+import lombok.AccessLevel;
+import lombok.extern.log4j.Log4j;
+
+@Log4j(access=AccessLevel.PUBLIC)
+class LoggerLog4jAccessPublic {
+}
+
+@Log4j(access=AccessLevel.MODULE)
+class LoggerLog4jAccessModule {
+}
+
+@Log4j(access=AccessLevel.PROTECTED)
+class LoggerLog4jAccessProtected {
+}
+
+@Log4j(access=AccessLevel.PACKAGE)
+class LoggerLog4jAccessPackage {
+}
+
+@Log4j(access=AccessLevel.PRIVATE)
+class LoggerLog4jAccessPrivate {
+}
+
+@Log4j(access=AccessLevel.NONE)
+class LoggerLog4jAccessNone {
+}

--- a/test/transform/resource/before/LoggerSlf4jAccess.java
+++ b/test/transform/resource/before/LoggerSlf4jAccess.java
@@ -1,26 +1,26 @@
 import lombok.AccessLevel;
 import lombok.extern.slf4j.Slf4j;
 
-@Slf4j(access=AccessLevel.PUBLIC)
+@Slf4j(access = AccessLevel.PUBLIC)
 class LoggerSlf4jAccessPublic {
 }
 
-@Slf4j(access=AccessLevel.MODULE)
+@Slf4j(access = AccessLevel.MODULE)
 class LoggerSlf4jAccessModule {
 }
 
-@Slf4j(access=AccessLevel.PROTECTED)
+@Slf4j(access = AccessLevel.PROTECTED)
 class LoggerSlf4jAccessProtected {
 }
 
-@Slf4j(access=AccessLevel.PACKAGE)
+@Slf4j(access = AccessLevel.PACKAGE)
 class LoggerSlf4jAccessPackage {
 }
 
-@Slf4j(access=AccessLevel.PRIVATE)
+@Slf4j(access = AccessLevel.PRIVATE)
 class LoggerSlf4jAccessPrivate {
 }
 
-@Slf4j(access=AccessLevel.NONE)
+@Slf4j(access = AccessLevel.NONE)
 class LoggerSlf4jAccessNone {
 }

--- a/test/transform/resource/before/LoggerSlf4jAccess.java
+++ b/test/transform/resource/before/LoggerSlf4jAccess.java
@@ -1,0 +1,26 @@
+import lombok.AccessLevel;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(access=AccessLevel.PUBLIC)
+class LoggerSlf4jAccessPublic {
+}
+
+@Slf4j(access=AccessLevel.MODULE)
+class LoggerSlf4jAccessModule {
+}
+
+@Slf4j(access=AccessLevel.PROTECTED)
+class LoggerSlf4jAccessProtected {
+}
+
+@Slf4j(access=AccessLevel.PACKAGE)
+class LoggerSlf4jAccessPackage {
+}
+
+@Slf4j(access=AccessLevel.PRIVATE)
+class LoggerSlf4jAccessPrivate {
+}
+
+@Slf4j(access=AccessLevel.NONE)
+class LoggerSlf4jAccessNone {
+}

--- a/test/transform/resource/before/LoggerXslf4jAccess.java
+++ b/test/transform/resource/before/LoggerXslf4jAccess.java
@@ -1,0 +1,26 @@
+import lombok.AccessLevel;
+import lombok.extern.slf4j.XSlf4j;
+
+@XSlf4j(access=AccessLevel.PUBLIC)
+class LoggerXslf4jAccessPublic {
+}
+
+@XSlf4j(access=AccessLevel.MODULE)
+class LoggerXslf4jAccessModule {
+}
+
+@XSlf4j(access=AccessLevel.PROTECTED)
+class LoggerXslf4jAccessProtected {
+}
+
+@XSlf4j(access=AccessLevel.PACKAGE)
+class LoggerXslf4jAccessPackage {
+}
+
+@XSlf4j(access=AccessLevel.PRIVATE)
+class LoggerXslf4jAccessPrivate {
+}
+
+@XSlf4j(access=AccessLevel.NONE)
+class LoggerXslf4jAccessNone {
+}

--- a/test/transform/resource/before/LoggerXslf4jAccess.java
+++ b/test/transform/resource/before/LoggerXslf4jAccess.java
@@ -1,26 +1,26 @@
 import lombok.AccessLevel;
 import lombok.extern.slf4j.XSlf4j;
 
-@XSlf4j(access=AccessLevel.PUBLIC)
+@XSlf4j(access = AccessLevel.PUBLIC)
 class LoggerXslf4jAccessPublic {
 }
 
-@XSlf4j(access=AccessLevel.MODULE)
+@XSlf4j(access = AccessLevel.MODULE)
 class LoggerXslf4jAccessModule {
 }
 
-@XSlf4j(access=AccessLevel.PROTECTED)
+@XSlf4j(access = AccessLevel.PROTECTED)
 class LoggerXslf4jAccessProtected {
 }
 
-@XSlf4j(access=AccessLevel.PACKAGE)
+@XSlf4j(access = AccessLevel.PACKAGE)
 class LoggerXslf4jAccessPackage {
 }
 
-@XSlf4j(access=AccessLevel.PRIVATE)
+@XSlf4j(access = AccessLevel.PRIVATE)
 class LoggerXslf4jAccessPrivate {
 }
 
-@XSlf4j(access=AccessLevel.NONE)
+@XSlf4j(access = AccessLevel.NONE)
 class LoggerXslf4jAccessNone {
 }


### PR DESCRIPTION
This pull request is related to Issue #2280.
When this issue was initially presented it was mildly controversial because it would require the ability to directly set the logger's name. Fast forward to today and now the `topic` parameter is officially supported within the various logging annotations, thus making the main drawback null and void. I have provided an implementation for this feature as while the average developer may not need it, those working with micro-services, embedded development, and game programming to name a few would greatly benefit from it.

This feature works just like `@Getter/@Setter`'s `access` parameter with one caveat:
- The default value for `access` is `AccessLevel.PRIVATE`

Where is what the feature looks like:
```java
package <org>.graphics;

@Log(access = AccessLevel.PROTECTED, topic="RenderPipeline")
public abstract class Graphics2D {
    public static class Graphics2DFactory {
        public Graphics2D create(String classname) {
            // create and return instance
        }
   }
    // ... draw/render methods 
}
```
```java
package <org>.graphics.opengl;
import static <org>.graphics.Graphics2D.log;

// This class can now use the provided logger from Graphics2D
class OpenGLGraphics2DImpl extends Graphics2D {
    // implement methods from Graphics2D
}
```
```java
package <org>.graphics.vulkan;
import static <org>.graphics.Graphics2D.log;

// This class can now use the provided logger from Graphics2D
class VulkanGraphics2DImpl extends Graphics2D {
    // implement methods from Graphics2D
}
```