### PR TITLE
Add missing stripIndent method

### DIFF
--- a/src/delombok/lombok/delombok/DocCommentIntegrator.java
+++ b/src/delombok/lombok/delombok/DocCommentIntegrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2024 The Project Lombok Authors.
+ * Copyright (C) 2009-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -132,6 +132,10 @@ public class DocCommentIntegrator {
 			((DocCommentTable) map_).putComment(node, new Comment() {
 				@Override public String getText() {
 					return docCommentContent_;
+				}
+				
+				@Override public Comment stripIndent() {
+					return this;
 				}
 				
 				@Override public DiagnosticPosition getPos() {

--- a/src/stubs/com/sun/tools/javac/parser/Tokens.java
+++ b/src/stubs/com/sun/tools/javac/parser/Tokens.java
@@ -14,6 +14,8 @@ public class Tokens {
 		
 		String getText();
 		
+		Comment stripIndent();
+		
 		JCDiagnostic.DiagnosticPosition getPos();
 		
 		int getSourcePos(int index);


### PR DESCRIPTION
This PR fixes #3940

The `stripIndent` method was added in JDK 25 and is required. I also adjusted our `validateJavadoc` method to trigger javadoc parsing.