### PR TITLE
[BUG] Lombok Tests Failing

### DIFF
--- a/test/transform/resource/after-delombok/LoggerCommonsAccess.java
+++ b/test/transform/resource/after-delombok/LoggerCommonsAccess.java
@@ -5,6 +5,7 @@ class LoggerCommonsAccessPublic {
 	public static final org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessPublic.class);
 
 }
+@SuppressWarnings("deprecation")
 class LoggerCommonsAccessModule {
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated

--- a/test/transform/resource/after-delombok/LoggerCustomAccess.java
+++ b/test/transform/resource/after-delombok/LoggerCustomAccess.java
@@ -5,6 +5,7 @@ class LoggerCustomAccessPublic {
 	public static final MyLogger log = MyLoggerFactory.create(LoggerCustomAccessPublic.class);
 
 }
+@SuppressWarnings("deprecation")
 class LoggerCustomAccessModule {
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated

--- a/test/transform/resource/after-delombok/LoggerFloggerAccess.java
+++ b/test/transform/resource/after-delombok/LoggerFloggerAccess.java
@@ -5,6 +5,7 @@ class LoggerFloggerAccessPublic {
 	public static final com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
 
 }
+@SuppressWarnings("deprecation")
 class LoggerFloggerAccessModule {
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated

--- a/test/transform/resource/after-delombok/LoggerJBossLogAccess.java
+++ b/test/transform/resource/after-delombok/LoggerJBossLogAccess.java
@@ -5,6 +5,7 @@ class LoggerJBossLogAccessPublic {
 	public static final org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessPublic.class);
 
 }
+@SuppressWarnings("deprecation")
 class LoggerJBossLogAccessModule {
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated

--- a/test/transform/resource/after-delombok/LoggerJulAccess.java
+++ b/test/transform/resource/after-delombok/LoggerJulAccess.java
@@ -5,6 +5,7 @@ class LoggerJulAccessPublic {
 	public static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessPublic.class.getName());
 
 }
+@SuppressWarnings("deprecation")
 class LoggerJulAccessModule {
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated

--- a/test/transform/resource/after-delombok/LoggerLog4j2Access.java
+++ b/test/transform/resource/after-delombok/LoggerLog4j2Access.java
@@ -5,6 +5,7 @@ class LoggerLog4j2AccessPublic {
 	public static final org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessPublic.class);
 
 }
+@SuppressWarnings("deprecation")
 class LoggerLog4j2AccessModule {
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated

--- a/test/transform/resource/after-delombok/LoggerLog4jAccess.java
+++ b/test/transform/resource/after-delombok/LoggerLog4jAccess.java
@@ -5,6 +5,7 @@ class LoggerLog4jAccessPublic {
 	public static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessPublic.class);
 
 }
+@SuppressWarnings("deprecation")
 class LoggerLog4jAccessModule {
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated

--- a/test/transform/resource/after-delombok/LoggerSlf4jAccess.java
+++ b/test/transform/resource/after-delombok/LoggerSlf4jAccess.java
@@ -5,6 +5,7 @@ class LoggerSlf4jAccessPublic {
 	public static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessPublic.class);
 
 }
+@SuppressWarnings("deprecation")
 class LoggerSlf4jAccessModule {
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated

--- a/test/transform/resource/after-delombok/LoggerXslf4jAccess.java
+++ b/test/transform/resource/after-delombok/LoggerXslf4jAccess.java
@@ -5,6 +5,7 @@ class LoggerXslf4jAccessPublic {
 	public static final org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessPublic.class);
 
 }
+@SuppressWarnings("deprecation")
 class LoggerXslf4jAccessModule {
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated

--- a/test/transform/resource/after-ecj/LoggerCommonsAccess.java
+++ b/test/transform/resource/after-ecj/LoggerCommonsAccess.java
@@ -9,7 +9,7 @@ import lombok.extern.apachecommons.CommonsLog;
     super();
   }
 }
-@CommonsLog(access = AccessLevel.MODULE) class LoggerCommonsAccessModule {
+@SuppressWarnings("deprecation") @CommonsLog(access = AccessLevel.MODULE) class LoggerCommonsAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.commons.logging.Log log = org.apache.commons.logging.LogFactory.getLog(LoggerCommonsAccessModule.class);
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerCustomAccess.java
+++ b/test/transform/resource/after-ecj/LoggerCustomAccess.java
@@ -9,7 +9,7 @@ import lombok.CustomLog;
     super();
   }
 }
-@CustomLog(access = AccessLevel.MODULE) class LoggerCustomAccessModule {
+@SuppressWarnings("deprecation") @CustomLog(access = AccessLevel.MODULE) class LoggerCustomAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated MyLogger log = MyLoggerFactory.create(LoggerCustomAccessModule.class);
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerFloggerAccess.java
+++ b/test/transform/resource/after-ecj/LoggerFloggerAccess.java
@@ -9,7 +9,7 @@ import lombok.extern.flogger.Flogger;
     super();
   }
 }
-@Flogger(access = AccessLevel.MODULE) class LoggerFloggerAccessModule {
+@SuppressWarnings("deprecation") @Flogger(access = AccessLevel.MODULE) class LoggerFloggerAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated com.google.common.flogger.FluentLogger log = com.google.common.flogger.FluentLogger.forEnclosingClass();
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerJBossLogAccess.java
+++ b/test/transform/resource/after-ecj/LoggerJBossLogAccess.java
@@ -9,7 +9,7 @@ import lombok.extern.jbosslog.JBossLog;
     super();
   }
 }
-@JBossLog(access = AccessLevel.MODULE) class LoggerJBossLogAccessModule {
+@SuppressWarnings("deprecation") @JBossLog(access = AccessLevel.MODULE) class LoggerJBossLogAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(LoggerJBossLogAccessModule.class);
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerJulAccess.java
+++ b/test/transform/resource/after-ecj/LoggerJulAccess.java
@@ -9,7 +9,7 @@ import lombok.extern.java.Log;
     super();
   }
 }
-@Log(access = AccessLevel.MODULE) class LoggerJulAccessModule {
+@SuppressWarnings("deprecation") @Log(access = AccessLevel.MODULE) class LoggerJulAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated java.util.logging.Logger log = java.util.logging.Logger.getLogger(LoggerJulAccessModule.class.getName());
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerLog4j2Access.java
+++ b/test/transform/resource/after-ecj/LoggerLog4j2Access.java
@@ -9,7 +9,7 @@ import lombok.extern.log4j.Log4j2;
     super();
   }
 }
-@Log4j2(access = AccessLevel.MODULE) class LoggerLog4j2AccessModule {
+@SuppressWarnings("deprecation") @Log4j2(access = AccessLevel.MODULE) class LoggerLog4j2AccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.logging.log4j.Logger log = org.apache.logging.log4j.LogManager.getLogger(LoggerLog4j2AccessModule.class);
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerLog4jAccess.java
+++ b/test/transform/resource/after-ecj/LoggerLog4jAccess.java
@@ -9,7 +9,7 @@ import lombok.extern.log4j.Log4j;
     super();
   }
 }
-@Log4j(access = AccessLevel.MODULE) class LoggerLog4jAccessModule {
+@SuppressWarnings("deprecation") @Log4j(access = AccessLevel.MODULE) class LoggerLog4jAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(LoggerLog4jAccessModule.class);
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerSlf4jAccess.java
+++ b/test/transform/resource/after-ecj/LoggerSlf4jAccess.java
@@ -9,7 +9,7 @@ import lombok.extern.slf4j.Slf4j;
     super();
   }
 }
-@Slf4j(access = AccessLevel.MODULE) class LoggerSlf4jAccessModule {
+@SuppressWarnings("deprecation") @Slf4j(access = AccessLevel.MODULE) class LoggerSlf4jAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LoggerSlf4jAccessModule.class);
   <clinit>() {
   }

--- a/test/transform/resource/after-ecj/LoggerXslf4jAccess.java
+++ b/test/transform/resource/after-ecj/LoggerXslf4jAccess.java
@@ -9,7 +9,7 @@ import lombok.extern.slf4j.XSlf4j;
     super();
   }
 }
-@XSlf4j(access = AccessLevel.MODULE) class LoggerXslf4jAccessModule {
+@SuppressWarnings("deprecation") @XSlf4j(access = AccessLevel.MODULE) class LoggerXslf4jAccessModule {
   static final @java.lang.SuppressWarnings("all") @lombok.Generated org.slf4j.ext.XLogger log = org.slf4j.ext.XLoggerFactory.getXLogger(LoggerXslf4jAccessModule.class);
   <clinit>() {
   }

--- a/test/transform/resource/before/LoggerCommonsAccess.java
+++ b/test/transform/resource/before/LoggerCommonsAccess.java
@@ -5,6 +5,7 @@ import lombok.extern.apachecommons.CommonsLog;
 class LoggerCommonsAccessPublic {
 }
 
+@SuppressWarnings("deprecation")
 @CommonsLog(access = AccessLevel.MODULE)
 class LoggerCommonsAccessModule {
 }

--- a/test/transform/resource/before/LoggerCustomAccess.java
+++ b/test/transform/resource/before/LoggerCustomAccess.java
@@ -6,6 +6,7 @@ import lombok.CustomLog;
 class LoggerCustomAccessPublic {
 }
 
+@SuppressWarnings("deprecation")
 @CustomLog(access = AccessLevel.MODULE)
 class LoggerCustomAccessModule {
 }

--- a/test/transform/resource/before/LoggerFloggerAccess.java
+++ b/test/transform/resource/before/LoggerFloggerAccess.java
@@ -5,6 +5,7 @@ import lombok.extern.flogger.Flogger;
 class LoggerFloggerAccessPublic {
 }
 
+@SuppressWarnings("deprecation")
 @Flogger(access = AccessLevel.MODULE)
 class LoggerFloggerAccessModule {
 }

--- a/test/transform/resource/before/LoggerJBossLogAccess.java
+++ b/test/transform/resource/before/LoggerJBossLogAccess.java
@@ -5,6 +5,7 @@ import lombok.extern.jbosslog.JBossLog;
 class LoggerJBossLogAccessPublic {
 }
 
+@SuppressWarnings("deprecation")
 @JBossLog(access = AccessLevel.MODULE)
 class LoggerJBossLogAccessModule {
 }

--- a/test/transform/resource/before/LoggerJulAccess.java
+++ b/test/transform/resource/before/LoggerJulAccess.java
@@ -5,6 +5,7 @@ import lombok.extern.java.Log;
 class LoggerJulAccessPublic {
 }
 
+@SuppressWarnings("deprecation")
 @Log(access = AccessLevel.MODULE)
 class LoggerJulAccessModule {
 }

--- a/test/transform/resource/before/LoggerLog4j2Access.java
+++ b/test/transform/resource/before/LoggerLog4j2Access.java
@@ -5,6 +5,7 @@ import lombok.extern.log4j.Log4j2;
 class LoggerLog4j2AccessPublic {
 }
 
+@SuppressWarnings("deprecation")
 @Log4j2(access = AccessLevel.MODULE)
 class LoggerLog4j2AccessModule {
 }

--- a/test/transform/resource/before/LoggerLog4jAccess.java
+++ b/test/transform/resource/before/LoggerLog4jAccess.java
@@ -5,6 +5,7 @@ import lombok.extern.log4j.Log4j;
 class LoggerLog4jAccessPublic {
 }
 
+@SuppressWarnings("deprecation")
 @Log4j(access = AccessLevel.MODULE)
 class LoggerLog4jAccessModule {
 }

--- a/test/transform/resource/before/LoggerSlf4jAccess.java
+++ b/test/transform/resource/before/LoggerSlf4jAccess.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 class LoggerSlf4jAccessPublic {
 }
 
+@SuppressWarnings("deprecation")
 @Slf4j(access = AccessLevel.MODULE)
 class LoggerSlf4jAccessModule {
 }

--- a/test/transform/resource/before/LoggerXslf4jAccess.java
+++ b/test/transform/resource/before/LoggerXslf4jAccess.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.XSlf4j;
 class LoggerXslf4jAccessPublic {
 }
 
+@SuppressWarnings("deprecation")
 @XSlf4j(access = AccessLevel.MODULE)
 class LoggerXslf4jAccessModule {
 }


### PR DESCRIPTION
Initially discovered on PR #3945, some unit tests unexpectedly started to fail due to the deprecation of `AccessLevel.MODULE`. This PR attempts to fix these tests and any others along the way. Right now, the failing tests for the various `@Log` annotations new access level feature are now passing locally. I'm still searching for if any other annotations are unexpectedly failing tests.