### PR TITLE
Suppress messages during resolution

### DIFF
--- a/src/core/lombok/javac/JavacAST.java
+++ b/src/core/lombok/javac/JavacAST.java
@@ -68,6 +68,7 @@ import com.sun.tools.javac.util.JCDiagnostic;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Name;
+import com.sun.tools.javac.util.Position;
 
 /**
  * Wraps around javac's internal AST view to add useful features as well as the ability to visit parents from children,
@@ -595,6 +596,7 @@ public class JavacAST extends AST<JavacAST, JavacNode, JCTree> {
 	}
 	
 	public void removeFromDeferredDiagnostics(int startPos, int endPos) {
+		if (startPos == Position.NOPOS || endPos == Position.NOPOS) return;
 		JCCompilationUnit self = (JCCompilationUnit) top().get();
 		new CompilerMessageSuppressor(getContext()).removeAllBetween(self.sourcefile, startPos, endPos);
 	}

--- a/src/core/lombok/javac/JavacResolution.java
+++ b/src/core/lombok/javac/JavacResolution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 The Project Lombok Authors.
+ * Copyright (C) 2011-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -416,7 +416,7 @@ public class JavacResolution {
 	}
 	
 	private static int compare(Name a, Name b) {
-		return a.compareTo(b);
+		return a.toString().compareTo(b.toString());
 	}
 	
 	private static boolean isLocalType(TypeSymbol symbol) {
@@ -469,7 +469,7 @@ public class JavacResolution {
 						winLevel = level;
 						continue;
 					}
-					if (compare(winner.tsym.getQualifiedName(), t.tsym.getQualifiedName()) < 0) winner = t;
+					if (compare(winner.tsym.getQualifiedName(), t.tsym.getQualifiedName()) > 0) winner = t;
 				}
 				if (winner == null) return createJavaLangObject(ast);
 				return typeToJCTree(winner, ast, allowCompound, allowVoid, allowCapture);

--- a/src/utils/lombok/permit/Permit.java
+++ b/src/utils/lombok/permit/Permit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 The Project Lombok Authors.
+ * Copyright (C) 2018-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -163,6 +163,14 @@ public class Permit {
 	
 	public static <T> Constructor<T> getConstructor(Class<T> c, Class<?>... parameterTypes) throws NoSuchMethodException {
 		return setAccessible(c.getDeclaredConstructor(parameterTypes));
+	}
+	
+	public static <T> Constructor<T> permissiveGetConstructor(Class<T> c, Class<?>... parameterTypes) {
+		try {
+			return getConstructor(c, parameterTypes);
+		} catch (Exception ignore) {
+			return null;
+		}
 	}
 	
 	private static Object reflectiveStaticFieldAccess(Class<?> c, String fName) {

--- a/test/transform/resource/after-delombok/ExtensionMethodInLambda.java
+++ b/test/transform/resource/after-delombok/ExtensionMethodInLambda.java
@@ -2,6 +2,8 @@
 import java.util.function.Function;
 
 public class ExtensionMethodInLambda {
+	private static final Function<String, String> testStatic = s -> ExtensionMethodInLambda.Extensions.reverse(s);
+	
 	public void testSimple() {
 		String test = "test";
 		test = ExtensionMethodInLambda.Extensions.map(test, s -> ExtensionMethodInLambda.Extensions.reverse(s));

--- a/test/transform/resource/after-ecj/ExtensionMethodInLambda.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodInLambda.java
@@ -15,6 +15,9 @@ public @ExtensionMethod(value = ExtensionMethodInLambda.Extensions.class) class 
       return "0";
     }
   }
+  private static final Function<String, String> testStatic = (<no type> s) -> ExtensionMethodInLambda.Extensions.reverse(s);
+  <clinit>() {
+  }
   public ExtensionMethodInLambda() {
     super();
   }

--- a/test/transform/resource/before/ExtensionMethodInLambda.java
+++ b/test/transform/resource/before/ExtensionMethodInLambda.java
@@ -4,6 +4,8 @@ import lombok.experimental.ExtensionMethod;
 
 @ExtensionMethod(value = ExtensionMethodInLambda.Extensions.class)
 public class ExtensionMethodInLambda {
+	private static final Function<String, String> testStatic = s -> s.reverse();
+	
 	public void testSimple() {
 		String test = "test";
 		test = test.map(s -> s.reverse());

--- a/test/transform/resource/messages-delombok/ExtensionMethodInLambda.java.messages
+++ b/test/transform/resource/messages-delombok/ExtensionMethodInLambda.java.messages
@@ -1,1 +1,1 @@
-19 cannot find symbol symbol: method invalid((s)->s.reverse()) location: variable test of type java.lang.String
+21 cannot find symbol symbol: method invalid((s)->s.reverse()) location: variable test of type java.lang.String

--- a/test/transform/resource/messages-delombok/ValInvalidParameter.java.messages
+++ b/test/transform/resource/messages-delombok/ValInvalidParameter.java.messages
@@ -1,1 +1,7 @@
+6 Cannot use 'val' here because initializer expression does not have a representable type: Type cannot be resolved
+7 Cannot use 'val' here because initializer expression does not have a representable type: Type cannot be resolved
+8 Cannot use 'val' here because initializer expression does not have a representable type: Type cannot be resolved
+9 Cannot use 'val' here because initializer expression does not have a representable type: Type cannot be resolved
+10 Cannot use 'val' here because initializer expression does not have a representable type: Type cannot be resolved
+11 Cannot use 'val' here because initializer expression does not have a representable type: Type cannot be resolved
 12 Cannot use 'val' here because initializer expression does not have a representable type: Type cannot be resolved

--- a/test/transform/resource/messages-ecj/ExtensionMethodInLambda.java.messages
+++ b/test/transform/resource/messages-ecj/ExtensionMethodInLambda.java.messages
@@ -1,1 +1,1 @@
-19 The method invalid((<no type> s) -> {}) is undefined for the type String
+21 The method invalid((<no type> s) -> {}) is undefined for the type String

--- a/test/transform/resource/messages-idempotent/ExtensionMethodInLambda.java.messages
+++ b/test/transform/resource/messages-idempotent/ExtensionMethodInLambda.java.messages
@@ -1,1 +1,1 @@
-17 cannot find symbol symbol: method invalid((s)->s.reverse()) location: variable test of type java.lang.String
+19 cannot find symbol symbol: method invalid((s)->s.reverse()) location: variable test of type java.lang.String


### PR DESCRIPTION
This PR fixes #3954 and #3947 

-  To suppress messages during resolution lombok injected a temporary message collection into the current diagnostic handler and restored the original one afterwards. Instead of using this error prone approach lombok now installs a  `DiscardDiagnosticHandler` that is designed exactly for this purpose and is also used by the compiler itself.
- The removeAllBetween method now uses a `LinkedList` to be compatible with all known versions of the `Log` class. I also noticed that this code was broken a long time and even if I remove it all our tests pass. Might be possible to remove all that stuff.
- I also noticed that the `compare` method in `JavacResolution` doesn't work because the used `Name::compareTo` returns different results in Java 8