### PR TITLE
Support Jackson3 in @Jacksonized

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Jappe van der Hel <jappe.vanderhel@gmail.com>
 John Paul Taylor II <johnpaultaylorii@gmail.com>
 Karthik kathari <44122128+varkart@users.noreply.github.com>
 Kevin Chirls <kchirls@users.noreply.github.com>
+Lars Uffmann <lars.uffmann@gmail.com>
 Liu DongMiao <liudongmiao@gmail.com>
 Liam Pace <liam.hollum.pace@gmail.com>
 Luan Nico <luannico27@gmail.com>

--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -711,6 +711,22 @@ public class ConfigurationKeys {
 	 */
 	public static final ConfigurationKey<FlagUsageType> JACKSONIZED_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.jacksonized.flagUsage", "Emit a warning or error if @Jacksonized is used.") {};
 	
+
+	/**
+	 * lombok configuration: {@code lombok.jacksonized.useJackson2} = {@code true} | {@code false}.
+	 *
+	 * If set to {@code true}, generate Jackson 2.x compatible code.
+	 */
+	public static final ConfigurationKey<Boolean> JACKSONIZED_USE_JACKSON2 = new ConfigurationKey<Boolean>("lombok.jacksonized.useJackson2", "Generate Jackson 2.x compatible code (default: true)") {};
+
+	/**
+	 * lombok configuration: {@code lombok.jacksonized.useJackson3} = {@code true} | {@code false}.
+	 *
+	 * If set to {@code true}, generate Jackson 3.x compatible code.
+	 */
+	public static final ConfigurationKey<Boolean> JACKSONIZED_USE_JACKSON3 = new ConfigurationKey<Boolean>("lombok.jacksonized.useJackson3", "Generate Jackson 3.x compatible code (default: false)") {};
+
+
 	// ----- Configuration System -----
 	
 	/**

--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -29,6 +29,7 @@ import lombok.core.configuration.CheckerFrameworkVersion;
 import lombok.core.configuration.ConfigurationKey;
 import lombok.core.configuration.FlagUsageType;
 import lombok.core.configuration.IdentifierName;
+import lombok.core.configuration.JacksonVersion;
 import lombok.core.configuration.LogDeclaration;
 import lombok.core.configuration.NullAnnotationLibrary;
 import lombok.core.configuration.NullCheckExceptionType;
@@ -713,18 +714,11 @@ public class ConfigurationKeys {
 	
 
 	/**
-	 * lombok configuration: {@code lombok.jacksonized.useJackson2} = {@code true} | {@code false}.
+	 * lombok configuration: {@code lombok.jacksonized.jacksonVersion} = {@code 2} | {@code 3} | {@code 2_3}.
 	 *
-	 * If set to {@code true}, generate Jackson 2.x compatible code.
+	 * The jackson major version to use.
 	 */
-	public static final ConfigurationKey<Boolean> JACKSONIZED_USE_JACKSON2 = new ConfigurationKey<Boolean>("lombok.jacksonized.useJackson2", "Generate Jackson 2.x compatible code (default: true)") {};
-
-	/**
-	 * lombok configuration: {@code lombok.jacksonized.useJackson3} = {@code true} | {@code false}.
-	 *
-	 * If set to {@code true}, generate Jackson 3.x compatible code.
-	 */
-	public static final ConfigurationKey<Boolean> JACKSONIZED_USE_JACKSON3 = new ConfigurationKey<Boolean>("lombok.jacksonized.useJackson3", "Generate Jackson 3.x compatible code (default: false)") {};
+	public static final ConfigurationKey<JacksonVersion> JACKSONIZED_JACKSON_VERSION = new ConfigurationKey<JacksonVersion>("lombok.jacksonized.jacksonVersion", "Select the jackson major version to use (default: 2)") {};
 
 
 	// ----- Configuration System -----

--- a/src/core/lombok/core/configuration/JacksonVersion.java
+++ b/src/core/lombok/core/configuration/JacksonVersion.java
@@ -1,0 +1,46 @@
+package lombok.core.configuration;
+
+public final class JacksonVersion implements ConfigurationValueType {
+
+	private final boolean useJackson2;
+	private final boolean useJackson3;
+
+	public static final JacksonVersion _2 = new JacksonVersion(true,  false);
+	public static final JacksonVersion _3 = new JacksonVersion(true,  false);
+	public static final JacksonVersion _23 = new JacksonVersion(true,  true);
+
+	public JacksonVersion(boolean useJackson2, boolean useJackson3) {
+		this.useJackson2 = useJackson2;
+		this.useJackson3 = useJackson3;
+	}
+
+	public static String exampleValue() {
+		return "2";
+	}
+
+	public static String description() {
+		return "Select the major version of the jackson framework.";
+	}
+
+	public static JacksonVersion valueOf(String value) {
+		if (value == null || value.isEmpty()) {
+			return _2;
+		} else if ("2".equals(value.trim())) {
+			return _2;
+		} else if ("3".equals(value.trim())) {
+			return _3;
+		} else if ("2_3".equals(value.trim())) {
+			return _23;
+		} else{
+			throw new IllegalArgumentException("Unsupported Jackson version selector. Supported values: 2, 3 or 2_3 ");
+		}
+	}
+
+	public boolean useJackson2() {
+		return useJackson2;
+	}
+
+	public boolean useJackson3() {
+		return useJackson3;
+	}
+}

--- a/src/core/lombok/core/configuration/JacksonVersion.java
+++ b/src/core/lombok/core/configuration/JacksonVersion.java
@@ -5,13 +5,12 @@ public final class JacksonVersion implements ConfigurationValueType {
 	private final boolean useJackson2;
 	private final boolean useJackson3;
 
-	public static final JacksonVersion _2 = new JacksonVersion(true,  false);
-	public static final JacksonVersion _3 = new JacksonVersion(false,  true);
-	public static final JacksonVersion _23 = new JacksonVersion(true,  true);
+	private static final JacksonVersion _2 = new JacksonVersion(true,  false);
+	private static final JacksonVersion _3 = new JacksonVersion(false,  true);
+	private static final JacksonVersion _23 = new JacksonVersion(true,  true);
 
-	public JacksonVersion(boolean useJackson2, boolean useJackson3) {
-		this.useJackson2 = useJackson2;
-		this.useJackson3 = useJackson3;
+	public static final JacksonVersion getDefault() {
+		return _2;
 	}
 
 	public static String exampleValue() {
@@ -24,7 +23,7 @@ public final class JacksonVersion implements ConfigurationValueType {
 
 	public static JacksonVersion valueOf(String value) {
 		if (value == null || value.isEmpty()) {
-			return _2;
+			return getDefault();
 		} else if ("2".equals(value.trim())) {
 			return _2;
 		} else if ("3".equals(value.trim())) {
@@ -34,6 +33,11 @@ public final class JacksonVersion implements ConfigurationValueType {
 		} else {
 			throw new IllegalArgumentException("Unsupported Jackson version selector.");
 		}
+	}
+
+	private JacksonVersion(boolean useJackson2, boolean useJackson3) {
+		this.useJackson2 = useJackson2;
+		this.useJackson3 = useJackson3;
 	}
 
 	public boolean useJackson2() {

--- a/src/core/lombok/core/configuration/JacksonVersion.java
+++ b/src/core/lombok/core/configuration/JacksonVersion.java
@@ -15,7 +15,7 @@ public final class JacksonVersion implements ConfigurationValueType {
 	}
 
 	public static String exampleValue() {
-		return "2";
+		return "2, 3 or 2_3";
 	}
 
 	public static String description() {
@@ -31,8 +31,8 @@ public final class JacksonVersion implements ConfigurationValueType {
 			return _3;
 		} else if ("2_3".equals(value.trim())) {
 			return _23;
-		} else{
-			throw new IllegalArgumentException("Unsupported Jackson version selector. Supported values: 2, 3 or 2_3 ");
+		} else {
+			throw new IllegalArgumentException("Unsupported Jackson version selector.");
 		}
 	}
 

--- a/src/core/lombok/core/configuration/JacksonVersion.java
+++ b/src/core/lombok/core/configuration/JacksonVersion.java
@@ -6,7 +6,7 @@ public final class JacksonVersion implements ConfigurationValueType {
 	private final boolean useJackson3;
 
 	public static final JacksonVersion _2 = new JacksonVersion(true,  false);
-	public static final JacksonVersion _3 = new JacksonVersion(true,  false);
+	public static final JacksonVersion _3 = new JacksonVersion(false,  true);
 	public static final JacksonVersion _23 = new JacksonVersion(true,  true);
 
 	public JacksonVersion(boolean useJackson2, boolean useJackson3) {
@@ -42,5 +42,9 @@ public final class JacksonVersion implements ConfigurationValueType {
 
 	public boolean useJackson3() {
 		return useJackson3;
+	}
+
+	public boolean isValid() {
+		return useJackson2 || useJackson3;
 	}
 }

--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -467,6 +467,7 @@ public class HandlerUtil {
 			"com.fasterxml.jackson.annotation.JsonUnwrapped",
 			"com.fasterxml.jackson.annotation.JsonView",
 			"com.fasterxml.jackson.databind.annotation.JsonDeserialize",
+			"tools.jackson.databind.annotation.JsonDeserialize",
 			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper",
 			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty",
 			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText",
@@ -488,6 +489,7 @@ public class HandlerUtil {
 			"com.fasterxml.jackson.annotation.JsonTypeName",
 			"com.fasterxml.jackson.annotation.JsonView",
 			"com.fasterxml.jackson.databind.annotation.JsonNaming",
+			"tools.jackson.databind.annotation.JsonNaming",
 		}));
 	}
 	

--- a/src/core/lombok/eclipse/handlers/HandleJacksonized.java
+++ b/src/core/lombok/eclipse/handlers/HandleJacksonized.java
@@ -149,8 +149,8 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 		MemberValuePair builderMvp = new MemberValuePair("builder".toCharArray(), td.sourceStart, td.sourceEnd, builderClassLiteralAccess);
 
 		JacksonVersion jacksonVersion = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, JacksonVersion._2);
-		if (! jacksonVersion.isValid()) {
-			annotationNode.addError("Usage: No valid jackson version selected");
+		if (jacksonVersion == null || !jacksonVersion.isValid()) {
+			annotationNode.addError("No valid jackson version selected.");
 			return;
 		}
 

--- a/src/core/lombok/eclipse/handlers/HandleJacksonized.java
+++ b/src/core/lombok/eclipse/handlers/HandleJacksonized.java
@@ -148,7 +148,7 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 		ClassLiteralAccess builderClassLiteralAccess = new ClassLiteralAccess(td.sourceEnd, builderClassExpression);
 		MemberValuePair builderMvp = new MemberValuePair("builder".toCharArray(), td.sourceStart, td.sourceEnd, builderClassLiteralAccess);
 
-		JacksonVersion jacksonVersion = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, JacksonVersion._2);
+		JacksonVersion jacksonVersion = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, JacksonVersion.getDefault());
 		if (jacksonVersion == null || !jacksonVersion.isValid()) {
 			annotationNode.addError("No valid jackson version selected.");
 			return;

--- a/src/core/lombok/eclipse/handlers/HandleJacksonized.java
+++ b/src/core/lombok/eclipse/handlers/HandleJacksonized.java
@@ -149,6 +149,10 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 
 		Boolean useJackson2 = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_USE_JACKSON2, Boolean.TRUE);
 		Boolean useJackson3 = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_USE_JACKSON3, Boolean.FALSE);
+		if (! (useJackson2 || useJackson3)) {
+			annotationNode.addError("Usage: lombok.jacksonized.useJackson2, lombok.jacksonized.useJackson3 or both must be true.");
+			return;
+		}
 
 		if (useJackson2) {
 			td.annotations = addAnnotation(td, td.annotations, JACKSON2_JSON_DESERIALIZE_ANNOTATION, builderMvp);

--- a/src/core/lombok/eclipse/handlers/HandleJacksonized.java
+++ b/src/core/lombok/eclipse/handlers/HandleJacksonized.java
@@ -148,8 +148,8 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 		ClassLiteralAccess builderClassLiteralAccess = new ClassLiteralAccess(td.sourceEnd, builderClassExpression);
 		MemberValuePair builderMvp = new MemberValuePair("builder".toCharArray(), td.sourceStart, td.sourceEnd, builderClassLiteralAccess);
 
-		JacksonVersion jacksonVersion = annotationNode.getAst().readConfiguration(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION);
-		if (! (jacksonVersion.useJackson2() || jacksonVersion.useJackson3())) {
+		JacksonVersion jacksonVersion = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, JacksonVersion._2);
+		if (! jacksonVersion.isValid()) {
 			annotationNode.addError("Usage: No valid jackson version selected");
 			return;
 		}

--- a/src/core/lombok/eclipse/handlers/HandleJacksonized.java
+++ b/src/core/lombok/eclipse/handlers/HandleJacksonized.java
@@ -62,8 +62,10 @@ import lombok.spi.Provides;
 @HandlerPriority(-512) // Above Handle(Super)Builder's level (builders must be already generated).
 public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 
-	private static final char[][] JSON_POJO_BUILDER_ANNOTATION = Eclipse.fromQualifiedName("com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder");
-	private static final char[][] JSON_DESERIALIZE_ANNOTATION = Eclipse.fromQualifiedName("com.fasterxml.jackson.databind.annotation.JsonDeserialize");
+	private static final char[][] JACKSON3_JSON_POJO_BUILDER_ANNOTATION = Eclipse.fromQualifiedName("tools.jackson.databind.annotation.JsonPOJOBuilder");
+	private static final char[][] JACKSON2_JSON_POJO_BUILDER_ANNOTATION = Eclipse.fromQualifiedName("com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder");
+	private static final char[][] JACKSON3_JSON_DESERIALIZE_ANNOTATION = Eclipse.fromQualifiedName("tools.jackson.databind.annotation.JsonDeserialize");
+	private static final char[][] JACKSON2_JSON_DESERIALIZE_ANNOTATION = Eclipse.fromQualifiedName("com.fasterxml.jackson.databind.annotation.JsonDeserialize");
 	private static final char[][] JSON_PROPERTY_ANNOTATION = Eclipse.fromQualifiedName("com.fasterxml.jackson.annotation.JsonProperty");
 	
 	@Override public void handle(AnnotationValues<Jacksonized> annotation, Annotation ast, EclipseNode annotationNode) {
@@ -136,12 +138,20 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 			annotationNode.addError("@JsonDeserialize already exists on class. Either delete @JsonDeserialize, or remove @Jacksonized and manually configure Jackson.");
 			return;
 		}
+		if (hasAnnotation("tools.jackson.databind.annotation.JsonDeserialize", tdNode)) {
+			annotationNode.addError("@JsonDeserialize already exists on class. Either delete @JsonDeserialize, or remove @Jacksonized and manually configure Jackson.");
+			return;
+		}
 		long p = (long) ast.sourceStart << 32 | ast.sourceEnd;
 		TypeReference builderClassExpression = namePlusTypeParamsToTypeReference(builderClassNode, null, p);
 		ClassLiteralAccess builderClassLiteralAccess = new ClassLiteralAccess(td.sourceEnd, builderClassExpression);
 		MemberValuePair builderMvp = new MemberValuePair("builder".toCharArray(), td.sourceStart, td.sourceEnd, builderClassLiteralAccess);
-		td.annotations = addAnnotation(td, td.annotations, JSON_DESERIALIZE_ANNOTATION, builderMvp);
-		
+		/* if (jackson2) */ {
+			td.annotations = addAnnotation(td, td.annotations, JACKSON2_JSON_DESERIALIZE_ANNOTATION, builderMvp);
+		}
+		/* if (jackson3) */ {
+			td.annotations = addAnnotation(td, td.annotations, JACKSON3_JSON_DESERIALIZE_ANNOTATION, builderMvp);
+		}
 		// Copy annotations from the class to the builder class.
 		Annotation[] copyableAnnotations = findJacksonAnnotationsOnClass(td, tdNode);
 		builderClass.annotations = copyAnnotations(builderClass, builderClass.annotations, copyableAnnotations);
@@ -151,8 +161,12 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 		MemberValuePair withPrefixMvp = new MemberValuePair("withPrefix".toCharArray(), builderClass.sourceStart, builderClass.sourceEnd, withPrefixLiteral);
 		StringLiteral buildMethodNameLiteral = new StringLiteral(buildMethodName.toCharArray(), builderClass.sourceStart, builderClass.sourceEnd, 0);
 		MemberValuePair buildMethodNameMvp = new MemberValuePair("buildMethodName".toCharArray(), builderClass.sourceStart, builderClass.sourceEnd, buildMethodNameLiteral);
-		builderClass.annotations = addAnnotation(builderClass, builderClass.annotations, JSON_POJO_BUILDER_ANNOTATION, withPrefixMvp, buildMethodNameMvp);
-		
+		/* if (jackson2) */ {
+			builderClass.annotations = addAnnotation(builderClass, builderClass.annotations, JACKSON2_JSON_POJO_BUILDER_ANNOTATION, withPrefixMvp, buildMethodNameMvp);
+		}
+		/* if (jackson3) */ {
+			builderClass.annotations = addAnnotation(builderClass, builderClass.annotations, JACKSON3_JSON_POJO_BUILDER_ANNOTATION, withPrefixMvp, buildMethodNameMvp);
+		}
 		// @SuperBuilder? Make it package-private!
 		if (superBuilderAnnotationNode != null) 
 			builderClass.modifiers = builderClass.modifiers & ~ClassFileConstants.AccPrivate;

--- a/src/core/lombok/eclipse/handlers/HandleJacksonized.java
+++ b/src/core/lombok/eclipse/handlers/HandleJacksonized.java
@@ -146,10 +146,14 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 		TypeReference builderClassExpression = namePlusTypeParamsToTypeReference(builderClassNode, null, p);
 		ClassLiteralAccess builderClassLiteralAccess = new ClassLiteralAccess(td.sourceEnd, builderClassExpression);
 		MemberValuePair builderMvp = new MemberValuePair("builder".toCharArray(), td.sourceStart, td.sourceEnd, builderClassLiteralAccess);
-		/* if (jackson2) */ {
+
+		Boolean useJackson2 = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_USE_JACKSON2, Boolean.TRUE);
+		Boolean useJackson3 = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_USE_JACKSON3, Boolean.FALSE);
+
+		if (useJackson2) {
 			td.annotations = addAnnotation(td, td.annotations, JACKSON2_JSON_DESERIALIZE_ANNOTATION, builderMvp);
 		}
-		/* if (jackson3) */ {
+		if (useJackson3) {
 			td.annotations = addAnnotation(td, td.annotations, JACKSON3_JSON_DESERIALIZE_ANNOTATION, builderMvp);
 		}
 		// Copy annotations from the class to the builder class.
@@ -161,10 +165,10 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 		MemberValuePair withPrefixMvp = new MemberValuePair("withPrefix".toCharArray(), builderClass.sourceStart, builderClass.sourceEnd, withPrefixLiteral);
 		StringLiteral buildMethodNameLiteral = new StringLiteral(buildMethodName.toCharArray(), builderClass.sourceStart, builderClass.sourceEnd, 0);
 		MemberValuePair buildMethodNameMvp = new MemberValuePair("buildMethodName".toCharArray(), builderClass.sourceStart, builderClass.sourceEnd, buildMethodNameLiteral);
-		/* if (jackson2) */ {
+		if (useJackson2) {
 			builderClass.annotations = addAnnotation(builderClass, builderClass.annotations, JACKSON2_JSON_POJO_BUILDER_ANNOTATION, withPrefixMvp, buildMethodNameMvp);
 		}
-		/* if (jackson3) */ {
+		if (useJackson3) {
 			builderClass.annotations = addAnnotation(builderClass, builderClass.annotations, JACKSON3_JSON_POJO_BUILDER_ANNOTATION, withPrefixMvp, buildMethodNameMvp);
 		}
 		// @SuperBuilder? Make it package-private!

--- a/src/core/lombok/javac/handlers/HandleJacksonized.java
+++ b/src/core/lombok/javac/handlers/HandleJacksonized.java
@@ -174,7 +174,7 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 			return;
 		}
 
-		JacksonVersion jacksonVersion = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, JacksonVersion._2);
+		JacksonVersion jacksonVersion = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, JacksonVersion.getDefault());
 		if (jacksonVersion == null || !jacksonVersion.isValid()) {
 			annotationNode.addError("No valid jackson version selected.");
 			return;

--- a/src/core/lombok/javac/handlers/HandleJacksonized.java
+++ b/src/core/lombok/javac/handlers/HandleJacksonized.java
@@ -174,8 +174,8 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 			return;
 		}
 
-		JacksonVersion jacksonVersion = annotationNode.getAst().readConfiguration(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION);
-		if (! (jacksonVersion.useJackson2() || jacksonVersion.useJackson3())) {
+		JacksonVersion jacksonVersion = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, JacksonVersion._2);
+		if (! jacksonVersion.isValid()) {
 			annotationNode.addError("Usage: No valid jackson version selected");
 			return;
 		}

--- a/src/core/lombok/javac/handlers/HandleJacksonized.java
+++ b/src/core/lombok/javac/handlers/HandleJacksonized.java
@@ -174,9 +174,12 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 		}
 
 		Boolean useJackson2 = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_USE_JACKSON2, Boolean.TRUE);
-		//FIXME: default for jackson3 should be false, I need to figure out how to use a non default config option in tests.
-		Boolean useJackson3 = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_USE_JACKSON3, Boolean.TRUE);
+		Boolean useJackson3 = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_USE_JACKSON3, Boolean.FALSE);
 
+		if (! (useJackson2 || useJackson3)) {
+			annotationNode.addError("Usage: lombok.jacksonized.useJackson2, lombok.jacksonized.useJackson3 or both must be true.");
+			return;
+		}
 		if (useJackson2) {
 			JCExpression jsonDeserializeType = chainDots(annotatedNode, "com", "fasterxml", "jackson", "databind", "annotation", "JsonDeserialize");
 			JCExpression builderClassExpression = namePlusTypeParamsToTypeReference(maker, tdNode, annotationNode.toName(builderClassName), false, List.<JCTypeParameter>nil());

--- a/src/core/lombok/javac/handlers/HandleJacksonized.java
+++ b/src/core/lombok/javac/handlers/HandleJacksonized.java
@@ -174,6 +174,7 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 		}
 
 		Boolean useJackson2 = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_USE_JACKSON2, Boolean.TRUE);
+		//FIXME: default for jackson3 should be false, I need to figure out how to use a non default config option in tests.
 		Boolean useJackson3 = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_USE_JACKSON3, Boolean.TRUE);
 
 		if (useJackson2) {

--- a/src/core/lombok/javac/handlers/HandleJacksonized.java
+++ b/src/core/lombok/javac/handlers/HandleJacksonized.java
@@ -172,7 +172,11 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 			annotationNode.addError("@JsonDeserialize already exists on class. Either delete @JsonDeserialize, or remove @Jacksonized and manually configure Jackson.");
 			return;
 		}
-		/* if (jackson2) */ {
+
+		Boolean useJackson2 = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_USE_JACKSON2, Boolean.TRUE);
+		Boolean useJackson3 = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_USE_JACKSON3, Boolean.TRUE);
+
+		if (useJackson2) {
 			JCExpression jsonDeserializeType = chainDots(annotatedNode, "com", "fasterxml", "jackson", "databind", "annotation", "JsonDeserialize");
 			JCExpression builderClassExpression = namePlusTypeParamsToTypeReference(maker, tdNode, annotationNode.toName(builderClassName), false, List.<JCTypeParameter>nil());
 			JCFieldAccess builderClassReference = maker.Select(builderClassExpression, annotatedNode.toName("class"));
@@ -181,7 +185,7 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 			recursiveSetGeneratedBy(annotationJsonDeserialize, annotationNode);
 			td.mods.annotations = td.mods.annotations.append(annotationJsonDeserialize);
 		}
-		/* if (jackson3) */ {
+		if (useJackson3) {
 			JCExpression jsonDeserializeType = chainDots(annotatedNode, "tools", "jackson", "databind", "annotation", "JsonDeserialize");
 			JCExpression builderClassExpression = namePlusTypeParamsToTypeReference(maker, tdNode, annotationNode.toName(builderClassName), false, List.<JCTypeParameter>nil());
 			JCFieldAccess builderClassReference = maker.Select(builderClassExpression, annotatedNode.toName("class"));
@@ -199,7 +203,7 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 		}
 		builderClass.mods.annotations = builderClass.mods.annotations.appendList(copiedAnnotations);
 
-		/* if (jackson2) */ {
+		if (useJackson2) {
 			// Insert @JsonPOJOBuilder on the builder class.
 			JCExpression jsonPOJOBuilderType = chainDots(annotatedNode, "com", "fasterxml", "jackson", "databind", "annotation", "JsonPOJOBuilder");
 			JCExpression withPrefixExpr = maker.Assign(maker.Ident(annotationNode.toName("withPrefix")), maker.Literal(setPrefix));
@@ -208,7 +212,7 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 			recursiveSetGeneratedBy(annotationJsonPOJOBuilder, annotatedNode);
 			builderClass.mods.annotations = builderClass.mods.annotations.append(annotationJsonPOJOBuilder);
 		}
-		/* if (jackson3) */ {
+		if (useJackson3) {
 			// Insert @JsonPOJOBuilder on the builder class.
 			JCExpression jsonPOJOBuilderType = chainDots(annotatedNode, "tools", "jackson", "databind", "annotation", "JsonPOJOBuilder");
 			JCExpression withPrefixExpr = maker.Assign(maker.Ident(annotationNode.toName("withPrefix")), maker.Literal(setPrefix));

--- a/src/core/lombok/javac/handlers/HandleJacksonized.java
+++ b/src/core/lombok/javac/handlers/HandleJacksonized.java
@@ -175,8 +175,8 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 		}
 
 		JacksonVersion jacksonVersion = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, JacksonVersion._2);
-		if (! jacksonVersion.isValid()) {
-			annotationNode.addError("Usage: No valid jackson version selected");
+		if (jacksonVersion == null || !jacksonVersion.isValid()) {
+			annotationNode.addError("No valid jackson version selected.");
 			return;
 		}
 		if (jacksonVersion.useJackson2()) {

--- a/test/stubs/tools/jackson/databind/annotation/JsonDeserialize.java
+++ b/test/stubs/tools/jackson/databind/annotation/JsonDeserialize.java
@@ -1,0 +1,12 @@
+package tools.jackson.databind.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.TYPE, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonDeserialize {
+	public Class<?> builder() default Void.class;
+}

--- a/test/stubs/tools/jackson/databind/annotation/JsonPOJOBuilder.java
+++ b/test/stubs/tools/jackson/databind/annotation/JsonPOJOBuilder.java
@@ -1,0 +1,10 @@
+package tools.jackson.databind.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonPOJOBuilder {
+	public String buildMethodName() default "build";
+	public String withPrefix() default "with";
+}

--- a/test/transform/resource/after-delombok/JacksonizedBuilderComplex.java
+++ b/test/transform/resource/after-delombok/JacksonizedBuilderComplex.java
@@ -2,12 +2,14 @@
 //CONF: lombok.builder.className = Test*Name
 import java.util.List;
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderComplex.TestVoidName.class)
+@tools.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderComplex.TestVoidName.class)
 class JacksonizedBuilderComplex {
 	private static <T extends Number> void testVoidWithGenerics(T number, int arg2, String arg3, JacksonizedBuilderComplex selfRef) {
 	}
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated
 	@com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "with", buildMethodName = "execute")
+	@tools.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "with", buildMethodName = "execute")
 	public static class TestVoidName<T extends Number> {
 		@java.lang.SuppressWarnings("all")
 		@lombok.Generated

--- a/test/transform/resource/after-delombok/JacksonizedBuilderSimple.java
+++ b/test/transform/resource/after-delombok/JacksonizedBuilderSimple.java
@@ -3,6 +3,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderSimple.JacksonizedBuilderSimpleBuilder.class)
+@tools.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderSimple.JacksonizedBuilderSimpleBuilder.class)
 class JacksonizedBuilderSimple<T> {
 	private final int noshow = 0;
 	private final int yes;
@@ -18,6 +19,7 @@ class JacksonizedBuilderSimple<T> {
 	@lombok.Generated
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	@com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+	@tools.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
 	protected static class JacksonizedBuilderSimpleBuilder<T> {
 		@java.lang.SuppressWarnings("all")
 		@lombok.Generated

--- a/test/transform/resource/after-delombok/JacksonizedBuilderSingular.java
+++ b/test/transform/resource/after-delombok/JacksonizedBuilderSingular.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderSingular.JacksonizedBuilderSingularBuilder.class)
+@tools.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderSingular.JacksonizedBuilderSingularBuilder.class)
 public class JacksonizedBuilderSingular {
 	@JsonAnySetter
 	private Map<String, Object> any;
@@ -26,6 +27,7 @@ public class JacksonizedBuilderSingular {
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated
 	@com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+	@tools.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
 	public static class JacksonizedBuilderSingularBuilder {
 		@java.lang.SuppressWarnings("all")
 		@lombok.Generated

--- a/test/transform/resource/after-delombok/JacksonizedOnRecord.java
+++ b/test/transform/resource/after-delombok/JacksonizedOnRecord.java
@@ -6,11 +6,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedOnRecord.JacksonizedOnRecordBuilder.class)
+@tools.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedOnRecord.JacksonizedOnRecordBuilder.class)
 public record JacksonizedOnRecord(@JsonProperty("test") @Nullable String string, @JsonAnySetter List<String> values) {
 	@java.lang.SuppressWarnings("all")
 	@lombok.Generated
 	@JsonIgnoreProperties
 	@com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+	@tools.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
 	public static class JacksonizedOnRecordBuilder {
 		@java.lang.SuppressWarnings("all")
 		@lombok.Generated

--- a/test/transform/resource/after-delombok/JacksonizedSuperBuilderSimple.java
+++ b/test/transform/resource/after-delombok/JacksonizedSuperBuilderSimple.java
@@ -2,6 +2,7 @@
 public class JacksonizedSuperBuilderSimple {
 	@com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true)
 	@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedSuperBuilderSimple.Parent.ParentBuilderImpl.class)
+	@tools.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedSuperBuilderSimple.Parent.ParentBuilderImpl.class)
 	public static class Parent {
 		int field1;
 		@java.lang.SuppressWarnings("all")
@@ -36,6 +37,7 @@ public class JacksonizedSuperBuilderSimple {
 		@lombok.Generated
 		@com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true)
 		@com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
+		@tools.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "", buildMethodName = "build")
 		static final class ParentBuilderImpl extends JacksonizedSuperBuilderSimple.Parent.ParentBuilder<JacksonizedSuperBuilderSimple.Parent, JacksonizedSuperBuilderSimple.Parent.ParentBuilderImpl> {
 			@java.lang.SuppressWarnings("all")
 			@lombok.Generated

--- a/test/transform/resource/after-ecj/JacksonizedBuilderComplex.java
+++ b/test/transform/resource/after-ecj/JacksonizedBuilderComplex.java
@@ -1,8 +1,8 @@
 import java.util.List;
 import lombok.Builder;
 import lombok.extern.jackson.Jacksonized;
-@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderComplex.TestVoidName.class) class JacksonizedBuilderComplex {
-  public static @java.lang.SuppressWarnings("all") @lombok.Generated @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "with",buildMethodName = "execute") class TestVoidName<T extends Number> {
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderComplex.TestVoidName.class) @tools.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderComplex.TestVoidName.class) class JacksonizedBuilderComplex {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "with",buildMethodName = "execute") @tools.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "with",buildMethodName = "execute") class TestVoidName<T extends Number> {
     private @java.lang.SuppressWarnings("all") @lombok.Generated T number;
     private @java.lang.SuppressWarnings("all") @lombok.Generated int arg2;
     private @java.lang.SuppressWarnings("all") @lombok.Generated String arg3;

--- a/test/transform/resource/after-ecj/JacksonizedBuilderSimple.java
+++ b/test/transform/resource/after-ecj/JacksonizedBuilderSimple.java
@@ -1,7 +1,7 @@
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-@lombok.extern.jackson.Jacksonized @JsonIgnoreProperties(ignoreUnknown = true) @lombok.Builder(access = lombok.AccessLevel.PROTECTED) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderSimple.JacksonizedBuilderSimpleBuilder.class) class JacksonizedBuilderSimple<T> {
-  protected static @java.lang.SuppressWarnings("all") @lombok.Generated @JsonIgnoreProperties(ignoreUnknown = true) @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "",buildMethodName = "build") class JacksonizedBuilderSimpleBuilder<T> {
+@lombok.extern.jackson.Jacksonized @JsonIgnoreProperties(ignoreUnknown = true) @lombok.Builder(access = lombok.AccessLevel.PROTECTED) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderSimple.JacksonizedBuilderSimpleBuilder.class) @tools.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderSimple.JacksonizedBuilderSimpleBuilder.class) class JacksonizedBuilderSimple<T> {
+  protected static @java.lang.SuppressWarnings("all") @lombok.Generated @JsonIgnoreProperties(ignoreUnknown = true) @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "",buildMethodName = "build") @tools.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "",buildMethodName = "build") class JacksonizedBuilderSimpleBuilder<T> {
     private @java.lang.SuppressWarnings("all") @lombok.Generated int yes;
     private @java.lang.SuppressWarnings("all") @lombok.Generated List<T> also;
     @java.lang.SuppressWarnings("all") @lombok.Generated JacksonizedBuilderSimpleBuilder() {

--- a/test/transform/resource/after-ecj/JacksonizedBuilderSingular.java
+++ b/test/transform/resource/after-ecj/JacksonizedBuilderSingular.java
@@ -7,8 +7,8 @@ import com.google.common.collect.ImmutableMap;
 import lombok.Builder;
 import lombok.Singular;
 import lombok.extern.jackson.Jacksonized;
-public @Jacksonized @Builder @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderSingular.JacksonizedBuilderSingularBuilder.class) class JacksonizedBuilderSingular {
-  public static @java.lang.SuppressWarnings("all") @lombok.Generated @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "",buildMethodName = "build") class JacksonizedBuilderSingularBuilder {
+public @Jacksonized @Builder @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderSingular.JacksonizedBuilderSingularBuilder.class) @tools.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedBuilderSingular.JacksonizedBuilderSingularBuilder.class) class JacksonizedBuilderSingular {
+  public static @java.lang.SuppressWarnings("all") @lombok.Generated @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "",buildMethodName = "build") @tools.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "",buildMethodName = "build") class JacksonizedBuilderSingularBuilder {
     private @java.lang.SuppressWarnings("all") @lombok.Generated java.util.ArrayList<String> any$key;
     private @java.lang.SuppressWarnings("all") @lombok.Generated java.util.ArrayList<Object> any$value;
     private @java.lang.SuppressWarnings("all") @lombok.Generated java.util.ArrayList<String> values;

--- a/test/transform/resource/after-ecj/JacksonizedSuperBuilderSimple.java
+++ b/test/transform/resource/after-ecj/JacksonizedSuperBuilderSimple.java
@@ -1,5 +1,5 @@
 public class JacksonizedSuperBuilderSimple {
-  public static @lombok.extern.jackson.Jacksonized @lombok.experimental.SuperBuilder @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedSuperBuilderSimple.Parent.ParentBuilderImpl.class) class Parent {
+  public static @lombok.extern.jackson.Jacksonized @lombok.experimental.SuperBuilder @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true) @com.fasterxml.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedSuperBuilderSimple.Parent.ParentBuilderImpl.class) @tools.jackson.databind.annotation.JsonDeserialize(builder = JacksonizedSuperBuilderSimple.Parent.ParentBuilderImpl.class) class Parent {
     public static abstract @java.lang.SuppressWarnings("all") @lombok.Generated class ParentBuilder<C extends JacksonizedSuperBuilderSimple.Parent, B extends JacksonizedSuperBuilderSimple.Parent.ParentBuilder<C, B>> {
       private @java.lang.SuppressWarnings("all") @lombok.Generated int field1;
       public ParentBuilder() {
@@ -18,7 +18,7 @@ public class JacksonizedSuperBuilderSimple {
         return (("JacksonizedSuperBuilderSimple.Parent.ParentBuilder(field1=" + this.field1) + ")");
       }
     }
-    static final @java.lang.SuppressWarnings("all") @lombok.Generated @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true) @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "",buildMethodName = "build") class ParentBuilderImpl extends JacksonizedSuperBuilderSimple.Parent.ParentBuilder<JacksonizedSuperBuilderSimple.Parent, JacksonizedSuperBuilderSimple.Parent.ParentBuilderImpl> {
+    static final @java.lang.SuppressWarnings("all") @lombok.Generated @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true) @com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "",buildMethodName = "build") @tools.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "",buildMethodName = "build") class ParentBuilderImpl extends JacksonizedSuperBuilderSimple.Parent.ParentBuilder<JacksonizedSuperBuilderSimple.Parent, JacksonizedSuperBuilderSimple.Parent.ParentBuilderImpl> {
       private ParentBuilderImpl() {
         super();
       }

--- a/test/transform/resource/before/JacksonizedBuilderComplex.java
+++ b/test/transform/resource/before/JacksonizedBuilderComplex.java
@@ -1,6 +1,6 @@
 //version 8: Jackson deps are at least Java7+.
 //CONF: lombok.builder.className = Test*Name
-//CONF: lombok.jacksonized.useJackson3 = true
+//CONF: lombok.jacksonized.jacksonVersion = 2_3
 import java.util.List;
 import lombok.Builder;
 import lombok.extern.jackson.Jacksonized;

--- a/test/transform/resource/before/JacksonizedBuilderComplex.java
+++ b/test/transform/resource/before/JacksonizedBuilderComplex.java
@@ -1,5 +1,6 @@
 //version 8: Jackson deps are at least Java7+.
 //CONF: lombok.builder.className = Test*Name
+//CONF: lombok.jacksonized.useJackson3 = true
 import java.util.List;
 import lombok.Builder;
 import lombok.extern.jackson.Jacksonized;

--- a/test/transform/resource/before/JacksonizedBuilderSimple.java
+++ b/test/transform/resource/before/JacksonizedBuilderSimple.java
@@ -1,5 +1,5 @@
 //version 8: Jackson deps are at least Java7+.
-//CONF: lombok.jacksonized.useJackson3 = true
+//CONF: lombok.jacksonized.jacksonVersion = 2_3
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/test/transform/resource/before/JacksonizedBuilderSimple.java
+++ b/test/transform/resource/before/JacksonizedBuilderSimple.java
@@ -1,4 +1,5 @@
 //version 8: Jackson deps are at least Java7+.
+//CONF: lombok.jacksonized.useJackson3 = true
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/test/transform/resource/before/JacksonizedBuilderSingular.java
+++ b/test/transform/resource/before/JacksonizedBuilderSingular.java
@@ -1,5 +1,5 @@
 //version 8: Jackson deps are at least Java7+.
-//CONF: lombok.jacksonized.useJackson3 = true
+//CONF: lombok.jacksonized.jacksonVersion = 2_3
 import java.util.List;
 import java.util.Map;
 

--- a/test/transform/resource/before/JacksonizedBuilderSingular.java
+++ b/test/transform/resource/before/JacksonizedBuilderSingular.java
@@ -1,4 +1,5 @@
 //version 8: Jackson deps are at least Java7+.
+//CONF: lombok.jacksonized.useJackson3 = true
 import java.util.List;
 import java.util.Map;
 

--- a/test/transform/resource/before/JacksonizedOnRecord.java
+++ b/test/transform/resource/before/JacksonizedOnRecord.java
@@ -1,5 +1,5 @@
 //version 14:
-//CONF: lombok.jacksonized.useJackson3 = true
+//CONF: lombok.jacksonized.jacksonVersion = 2_3
 import java.util.List;
 import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;

--- a/test/transform/resource/before/JacksonizedOnRecord.java
+++ b/test/transform/resource/before/JacksonizedOnRecord.java
@@ -1,4 +1,5 @@
 //version 14:
+//CONF: lombok.jacksonized.useJackson3 = true
 import java.util.List;
 import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;

--- a/test/transform/resource/before/JacksonizedSuperBuilderSimple.java
+++ b/test/transform/resource/before/JacksonizedSuperBuilderSimple.java
@@ -1,3 +1,4 @@
+//CONF: lombok.jacksonized.useJackson3 = true
 //version 8: Jackson deps are at least Java7+.
 public class JacksonizedSuperBuilderSimple {
 	@lombok.extern.jackson.Jacksonized

--- a/test/transform/resource/before/JacksonizedSuperBuilderSimple.java
+++ b/test/transform/resource/before/JacksonizedSuperBuilderSimple.java
@@ -1,4 +1,4 @@
-//CONF: lombok.jacksonized.useJackson3 = true
+//CONF: lombok.jacksonized.jacksonVersion = 2_3
 //version 8: Jackson deps are at least Java7+.
 public class JacksonizedSuperBuilderSimple {
 	@lombok.extern.jackson.Jacksonized


### PR DESCRIPTION
Resolves #3950 

- Deals with Jackson annotations in the source that just have to be copied (HandlerUtil.java)

- Uses a new config option, `lombok.jacksonized.jacksonVersion` to decide which version of `JsonDeserialize` and `JsonPOJOBuilder` to use.