### PR TITLE
Add STS5 support

### DIFF
--- a/src/installer/lombok/installer/Installer.java
+++ b/src/installer/lombok/installer/Installer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 The Project Lombok Authors.
+ * Copyright (C) 2009-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -91,6 +91,16 @@ public class Installer {
 	static void autoDiscover(List<IdeLocation> locations, List<CorruptedIdeLocationException> problems) {
 		for (IdeLocationProvider provider : locationProviders) {
 			provider.findIdes(locations, problems);
+		}
+		// Search in lombok.jar directory
+		File ourJar = IdeLocation.findOurJar();
+		try {
+			IdeLocation location = tryAllProviders(ourJar.getParent());
+			if (location != null) {
+				locations.add(location);
+			}
+		} catch (CorruptedIdeLocationException e) {
+			problems.add(e);
 		}
 	}
 	

--- a/src/installer/lombok/installer/eclipse/STS5LocationProvider.java
+++ b/src/installer/lombok/installer/eclipse/STS5LocationProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 The Project Lombok Authors.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.installer.eclipse;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import lombok.installer.IdeLocationProvider;
+import lombok.spi.Provides;
+
+@Provides(IdeLocationProvider.class)
+public class STS5LocationProvider extends EclipseProductLocationProvider {
+	
+	private static final EclipseProductDescriptor STS5 = new StandardProductDescriptor("Spring Tools Suite 5",
+			"SpringToolsForEclipse",
+			"sts",
+			STS5LocationProvider.class.getResource("STS.png"),
+			Collections.unmodifiableList(Arrays.asList("springsource", "spring-tool-suite"))
+	);
+	
+	public STS5LocationProvider() {
+		super(STS5);
+	}
+}

--- a/src/installer/lombok/installer/eclipse/StandardProductDescriptor.java
+++ b/src/installer/lombok/installer/eclipse/StandardProductDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 The Project Lombok Authors.
+ * Copyright (C) 2016-2025 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@ package lombok.installer.eclipse;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -133,8 +132,17 @@ public class StandardProductDescriptor implements EclipseProductDescriptor {
 	}
 	
 	private static List<String> executableNames(String baseName) {
-		String base = baseName.toLowerCase();
-		return Collections.unmodifiableList(Arrays.asList(base, base + ".app", base + ".exe", base + "c.exe"));
+		String[] bases = new String[] {baseName, baseName.toLowerCase()};
+		String[] suffixes = new String[] {"", ".app", ".exe", "c.exe"};
+		
+		List<String> result = new ArrayList<String>();
+		
+		for (String base : bases) {
+			for (String suffix : suffixes) {
+				result.add(base + suffix);
+			}
+		}
+		return Collections.unmodifiableList(result);
 	}
 	
 	private static List<String> generateAlternatives(String[] roots, String pathSeparator, Collection<String> alternatives) {


### PR DESCRIPTION
This PR fixes #3985

I updated the list of executable names and added the non-lowercase version to better detect the IDE on case-sensitive file systems. It still searches for the lowercase version as well.

I also improved the IDE detection to search in the jar directory in case someone copied the jar manually.