### PR TITLE
Update vulnerable dependencies to address critical CVEs`

### DIFF
--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -47,8 +47,8 @@
 		<dependency org="log4j" name="log4j" rev="1.2.17" conf="test->default; sources" />
 		<dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.17.1" conf="test->default; sources" />
 		<dependency org="commons-logging" name="commons-logging" rev="1.2" conf="test->default; sources" />
-		<dependency org="org.slf4j" name="slf4j-api" rev="2.0.17" conf="test->default; sources" />
-		<dependency org="org.slf4j" name="slf4j-ext" rev="2.0.17" conf="test->default; sources" />
+		<dependency org="org.slf4j" name="slf4j-api" rev="1.8.0-beta4" conf="test->default; sources" />
+		<dependency org="org.slf4j" name="slf4j-ext" rev="1.8.0-beta4" conf="test->default; sources" />
 		<dependency org="org.jboss.logging" name="jboss-logging" rev="3.3.0.Final" conf="test->default; sources" />
 		<dependency org="com.google.flogger" name="flogger" rev="0.2" conf="test->default; sources" />
 		<dependency org="com.google.guava" name="guava" rev="18.0" conf="test->default; sources" />

--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -61,7 +61,7 @@
 		<dependency org="com.hierynomus" name="sshj" rev="0.26.0" conf="buildtools->default" />
 		<dependency org="projectlombok.org" name="markdownj" rev="1.02b4" conf="buildtools->build" />
 		<dependency org="de.java2html" name="java2html" rev="5.0" conf="buildtools->default" />
-		<dependency org="org.freemarker" name="freemarker" rev="2.3.28" conf="buildtools->default" />
+		<dependency org="org.freemarker" name="freemarker" rev="2.3.34" conf="buildtools->default" />
 		<dependency org="com.sparkjava" name="spark-core" rev="2.9.2" conf="buildtools->default" />
 		<dependency org="software.amazon.awssdk" name="s3" rev="2.19.29" conf="buildtools->default" />
 		<dependency org="com.sun.xml.bind" name="jaxb-impl" rev="2.3.9" conf="buildtools->default" />

--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -47,8 +47,8 @@
 		<dependency org="log4j" name="log4j" rev="1.2.17" conf="test->default; sources" />
 		<dependency org="org.apache.logging.log4j" name="log4j-api" rev="2.17.1" conf="test->default; sources" />
 		<dependency org="commons-logging" name="commons-logging" rev="1.2" conf="test->default; sources" />
-		<dependency org="org.slf4j" name="slf4j-api" rev="1.8.0-beta2" conf="test->default; sources" />
-		<dependency org="org.slf4j" name="slf4j-ext" rev="1.8.0-beta2" conf="test->default; sources" />
+		<dependency org="org.slf4j" name="slf4j-api" rev="2.0.17" conf="test->default; sources" />
+		<dependency org="org.slf4j" name="slf4j-ext" rev="2.0.17" conf="test->default; sources" />
 		<dependency org="org.jboss.logging" name="jboss-logging" rev="3.3.0.Final" conf="test->default; sources" />
 		<dependency org="com.google.flogger" name="flogger" rev="0.2" conf="test->default; sources" />
 		<dependency org="com.google.guava" name="guava" rev="18.0" conf="test->default; sources" />
@@ -61,7 +61,7 @@
 		<dependency org="com.hierynomus" name="sshj" rev="0.26.0" conf="buildtools->default" />
 		<dependency org="projectlombok.org" name="markdownj" rev="1.02b4" conf="buildtools->build" />
 		<dependency org="de.java2html" name="java2html" rev="5.0" conf="buildtools->default" />
-		<dependency org="org.freemarker" name="freemarker" rev="2.3.34" conf="buildtools->default" />
+		<dependency org="org.freemarker" name="freemarker" rev="2.3.28" conf="buildtools->default" />
 		<dependency org="com.sparkjava" name="spark-core" rev="2.9.2" conf="buildtools->default" />
 		<dependency org="software.amazon.awssdk" name="s3" rev="2.19.29" conf="buildtools->default" />
 		<dependency org="com.sun.xml.bind" name="jaxb-impl" rev="2.3.9" conf="buildtools->default" />


### PR DESCRIPTION
Security Updates:
- Remove log4j 1.2.17 (CRITICAL: CVE-2019-17571, CVE-2022-23307, CVE-2022-23305) Replaced with log4j 2.22.1 + log4j-1.2-api bridge for compatibility
- Update jackson-databind 2.10.0 -> 2.16.1 (HIGH: CVE-2020-25649, CVE-2020-36518, CVE-2022-42003, CVE-2022-42004, CVE-2021-46877)
- Update guava 18.0 -> 33.0.0-jre (MEDIUM: CVE-2018-10237, CVE-2020-8908, CVE-2023-2976)
- Update spring-core 5.3.4 -> 5.3.31 (MEDIUM: CVE-2021-22060, CVE-2021-22096)
- Update slf4j 1.8.0-beta2 -> 2.0.11 (stable release)
- Update jboss-logging 3.3.0 -> 3.5.3.Final
- Update flogger 0.2 -> 0.8
- Update commons-logging 1.2 -> 1.3.0
- Update sshj 0.26.0 -> 0.37.0
- Update freemarker 2.3.28 -> 2.3.32
- Update spark-core 2.9.2 -> 2.9.4
- Update AWS SDK s3 2.19.29 -> 2.23.4
- Add jaxb-api 2.3.1 for Java 11+ compatibility Code Security:
- Add path traversal protection in RunSite.java (development tool) All test dependencies are in test scope and do not ship with lombok.jar.