### PR TITLE
Feat: 'Default' `@ExtensionMethod` extensions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,5 +65,6 @@ Till Brychcy <till.brychcy@mercateo.com>
 Victor Williams Stafusa da Silva <victorwssilva@gmail.com>
 Yonatan Sherwin <yonatansherwin@gmail.com>
 Yun Zhi Lin <yun@yunspace.com>
+Minttu Stenberg <screret@screret.dev>
 
 By adding your name to this list, you grant full and irrevocable copyright and patent indemnity to Project Lombok and all use of Project Lombok in relation to all commits you add to Project Lombok, and you certify that you have the right to do so.

--- a/src/core/lombok/ConfigurationKeys.java
+++ b/src/core/lombok/ConfigurationKeys.java
@@ -601,7 +601,21 @@ public class ConfigurationKeys {
 	 * If set, <em>any</em> usage of {@code @ExtensionMethod} results in a warning / error.
 	 */
 	public static final ConfigurationKey<FlagUsageType> EXTENSION_METHOD_FLAG_USAGE = new ConfigurationKey<FlagUsageType>("lombok.extensionMethod.flagUsage", "Emit a warning or error if @ExtensionMethod is used.") {};
-	
+
+	/**
+	 * lombok configuration: {@code lombok.extensionMethod.defaultSuppressBaseMethods} = {@code true} | {@code false}.
+	 *
+	 * For any class without an {@code @ExtensionMethod} that explicitly defines the {@code suppressBaseMethods} option, this value is used (default = true).
+	 */
+	public static final ConfigurationKey<Boolean> EXTENSION_METHOD_SUPPRESS_BASE_METHODS = new ConfigurationKey<Boolean>("lombok.extensionMethod.suppressBaseMethods", "If true, an applicable extension method is used (if found) even if the method call already was compilable (this is the default). If false, an extension method is only used if the method call is not also defined by the type itself..") {};
+
+	/**
+	 * lombok configuration: {@code lombok.extensionMethod.defaultExtensions} += &lt;TypeName: fully-qualified annotation class name&gt;.
+	 *
+	 * All types whose static methods will be exposed as extension methods.
+	 */
+	public static final ConfigurationKey<List<TypeName>> EXTENSION_METHOD_DEFAULT_EXTENSIONS = new ConfigurationKey<List<TypeName>>("lombok.extensionMethod.defaultExtensions", "All types whose static methods will be exposed as extension methods.") {};
+
 	// ----- FieldDefaults -----
 	
 	/**

--- a/src/core/lombok/eclipse/handlers/HandleExtensionMethod.java
+++ b/src/core/lombok/eclipse/handlers/HandleExtensionMethod.java
@@ -22,45 +22,79 @@
 package lombok.eclipse.handlers;
 
 import static lombok.core.handlers.HandlerUtil.*;
+import static lombok.eclipse.handlers.EclipseHandlerUtil.*;
 
+import java.util.Arrays;
 import java.util.List;
 
+import lombok.core.AST;
+import lombok.eclipse.*;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
+import org.eclipse.jdt.internal.compiler.ast.QualifiedTypeReference;
+import org.eclipse.jdt.internal.compiler.ast.SingleTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 
 import lombok.ConfigurationKeys;
 import lombok.core.AnnotationValues;
 import lombok.core.HandlerPriority;
-import lombok.eclipse.EclipseAnnotationHandler;
-import lombok.eclipse.EclipseNode;
 import lombok.experimental.ExtensionMethod;
 import lombok.spi.Provides;
 
 // This handler just does some additional error checking; the real work is done in the agent.
-@Provides
+@Provides(EclipseASTVisitor.class)
 @HandlerPriority(66560) // 2^16 + 2^10; we must run AFTER HandleVal which is at 2^16
-public class HandleExtensionMethod extends EclipseAnnotationHandler<ExtensionMethod> {
-	@Override public void handle(AnnotationValues<ExtensionMethod> annotation, Annotation ast, EclipseNode annotationNode) {
-		handleExperimentalFlagUsage(annotationNode, ConfigurationKeys.EXTENSION_METHOD_FLAG_USAGE, "@ExtensionMethod");
-		
-		TypeDeclaration typeDecl = null;
-		EclipseNode owner = annotationNode.up();
-		if (owner.get() instanceof TypeDeclaration) typeDecl = (TypeDeclaration) owner.get();
-		int modifiers = typeDecl == null ? 0 : typeDecl.modifiers;
-		
-		boolean notAClass = (modifiers &
-				(ClassFileConstants.AccAnnotation)) != 0;
-		
-		if (typeDecl == null || notAClass) {
-			annotationNode.addError("@ExtensionMethod is legal only on classes and enums and interfaces.");
-			return;
+public class HandleExtensionMethod extends EclipseASTAdapter {
+
+	private static final char[] EXTENSION_METHOD = "ExtensionMethod".toCharArray();
+
+	@Override public void visitType(EclipseNode typeNode, TypeDeclaration typeDecl) {
+		int modifiers = typeDecl.modifiers;
+		boolean notAClass = (modifiers & (ClassFileConstants.AccAnnotation)) != 0;
+
+		AnnotationValues<ExtensionMethod> extensionMethod = null;
+		EclipseNode source = typeNode;
+
+		List<Object> listenerInterfaces = null;
+		boolean suppressBaseMethodsIsExplicit = false;
+		ExtensionMethod em = null;
+		for (EclipseNode jn : typeNode.down()) {
+			if (jn.getKind() != AST.Kind.ANNOTATION) continue;
+			Annotation ann = (Annotation) jn.get();
+			TypeReference typeTree = ann.type;
+			if (typeTree == null) continue;
+			if (typeTree instanceof SingleTypeReference) {
+				char[] t = ((SingleTypeReference) typeTree).token;
+				if (!Arrays.equals(t, EXTENSION_METHOD)) continue;
+			} else if (typeTree instanceof QualifiedTypeReference) {
+				char[][] t = ((QualifiedTypeReference) typeTree).tokens;
+				if (!Eclipse.nameEquals(t, "lombok.experimental.ExtensionMethod")) continue;
+			} else {
+				continue;
+			}
+
+			if (!typeMatches(ExtensionMethod.class, jn, typeTree)) continue;
+
+			source = jn;
+			extensionMethod = createAnnotation(ExtensionMethod.class, jn);
+			suppressBaseMethodsIsExplicit = extensionMethod.isExplicit("suppressBaseMethods");
+
+			handleExperimentalFlagUsage(jn, ConfigurationKeys.EXTENSION_METHOD_FLAG_USAGE, "@ExtensionMethod");
+
+			em = extensionMethod.getInstance();
+			if (notAClass) {
+				jn.addError("@ExtensionMethod is legal only on classes and enums and interfaces.");
+				return;
+			}
+
+			listenerInterfaces = extensionMethod.getActualExpressions("value");
+			if (listenerInterfaces.isEmpty()) {
+				jn.addWarning("@ExtensionMethod has no effect since no extension types were specified.");
+				return;
+			}
+			break;
 		}
-		
-		List<Object> listenerInterfaces = annotation.getActualExpressions("value");
-		if (listenerInterfaces.isEmpty()) {
-			annotationNode.addWarning(String.format("@ExtensionMethod has no effect since no extension types were specified."));
-			return;
-		}
+
 	}
 }

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -322,7 +322,7 @@ public class JavacHandlerUtil {
 		return typeMatches(type, node, typeName);
 	}
 
-	private static boolean typeMatches(String type, JavacNode node, String typeName) {
+	static boolean typeMatches(String type, JavacNode node, String typeName) {
 		if (typeName == null || typeName.length() == 0) return false;
 		int lastIndexA = typeName.lastIndexOf('.') + 1;
 		int lastIndexB = Math.max(type.lastIndexOf('.'), type.lastIndexOf('$')) + 1;
@@ -333,7 +333,7 @@ public class JavacHandlerUtil {
 		return resolver.typeMatches(node, type, typeName);
 	}
 
-	private static String getTypeName(JCTree typeNode) {
+	static String getTypeName(JCTree typeNode) {
 		return typeNode == null ? null : typeNode.toString();
 	}
 

--- a/src/stubs/com/sun/tools/javac/code/Symtab.java
+++ b/src/stubs/com/sun/tools/javac/code/Symtab.java
@@ -7,6 +7,7 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.ModuleSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Name;
 
 public class Symtab {
 	// Shared by JDK6-9
@@ -21,4 +22,5 @@ public class Symtab {
 
 	// JDK 9
 	public ModuleSymbol unnamedModule;
+	public ModuleSymbol inferModule(Name packageName) {return null;}
 }

--- a/src/stubs/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/stubs/com/sun/tools/javac/main/JavaCompiler.java
@@ -21,6 +21,7 @@ public class JavaCompiler {
 	
 	public JavaCompiler(Context context) {}
 	public int errorCount() { return 0; }
+	public static JavaCompiler instance(Context context) {return null;}
 	public static String version() { return "<stub>"; }
 	public JCCompilationUnit parse(String fileName) throws IOException { return null; }
 	public List<JCCompilationUnit> enterTrees(List<JCCompilationUnit> roots) {return null;}


### PR DESCRIPTION
# Description

This PR introduces the `lombok.extensionMethod.defaultExtensions` and `lombok.extensionMethod.suppressBaseMethods` configuration keys, allowing extension method usage without explicitly applying `@ExtensionMethod({MyExtensions.class, MyExtensions2.class, ...})` to every class via lombok.config.
Using the annotation still requires explicitly defining an extension, but it can be left empty if one (for whatever reason) only wants to change the `suppressBaseMethods` value for a class.

If `suppressBaseMethods` isn't defined, the configuration value is applied (default: true).
Extensions in the `lombok.extensionMethod.suppressBaseMethods` configuration are applied _in addition to_ explicitly defined ones. As far as I can tell, defining an extension twice doesn't have any adverse effects.

# Changes
- Added EXTENSION_METHOD_SUPPRESS_BASE_METHODS key in ConfigurationKeys.java.
- Added EXTENSION_METHOD_DEFAULT_EXTENSIONS key in ConfigurationKeys.java.
- Made `HandleExtensionMethod` an AST adapter.


# Additional Information
The code is loosely based on `HandleFieldDefaults`.
I did _not_ fix the Eclipse handler, because I don't know how, and I assume you know better than I do.

Getting the project to compile was surprisingly annoying, though that might just be me not wanting to use Eclipse. IntelliJ wasn't happy with the java 6 requirement and duplicate dependency classes, but I got it working.
Sometimes I had to delete a stub class, recompile, and add the stub back. That made it mysteriously work 10/10 times. It worked, though, so I'm not complaining.