### PR TITLE
[ci] GitHub Actions workflow to create Github Releases from git tags

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,21 @@
+name: Create GitHub Release
+# This workflow creates a GitHub release when a tag is pushed, such that folks can subscribe to releases in GitHub
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="${{ github.ref_name }}" \
+              --generate-notes

--- a/AUTHORS
+++ b/AUTHORS
@@ -60,6 +60,7 @@ Sasha Koning <askoning@gmail.com>
 Szymon Pacanowski <spacanowski@gmail.com>
 Taiki Sugawara <buzz.taiki@gmail.com>
 Takuya Murakami <tmurakam@tmurakam.org>
+Tim te Beek <timtebeek@gmail.com>
 Thomas Darimont <thomas.darimont@gmail.com>
 Till Brychcy <till.brychcy@mercateo.com>
 Victor Williams Stafusa da Silva <victorwssilva@gmail.com>


### PR DESCRIPTION
Hi! This a quick request to make it easier to track new releases right from GitHub. I'm a fan of the "Watch > Custom > Releases" option, and I imagine I'm not the only one.

<img width="474" height="427" alt="image" src="https://github.com/user-attachments/assets/6732bde6-adfc-4933-9d76-6d48c349ef3e" />

This workflow would run whenever a tag is pushed to create a matching release on this page of the repository:

- https://github.com/projectlombok/lombok/releases

No further changes to the release process needed; this just runs on tags and uses a built in support from GitHub tokens & CLI.

No harm of course if this is not to your liking; it was just as much effort to open a PR as an issue would have been, so feel free to adopt or close.

To see it in action: I'd previously added the same in
- https://github.com/apache/camel-upgrade-recipes/pull/53
- https://github.com/apache/camel-upgrade-recipes/releases