### PR TITLE
Expand Jackson 3 support

### DIFF
--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -453,6 +453,9 @@ public class HandlerUtil {
 			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper",
 			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty",
 			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText",
+			"tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper",
+			"tools.jackson.dataformat.xml.annotation.JacksonXmlProperty",
+			"tools.jackson.dataformat.xml.annotation.JacksonXmlText",
 		}));
 		JACKSON_COPY_TO_SETTER_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"com.fasterxml.jackson.annotation.JacksonInject",
@@ -467,10 +470,13 @@ public class HandlerUtil {
 			"com.fasterxml.jackson.annotation.JsonUnwrapped",
 			"com.fasterxml.jackson.annotation.JsonView",
 			"com.fasterxml.jackson.databind.annotation.JsonDeserialize",
-			"tools.jackson.databind.annotation.JsonDeserialize",
 			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper",
 			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty",
 			"com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText",
+			"tools.jackson.databind.annotation.JsonDeserialize",
+			"tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper",
+			"tools.jackson.dataformat.xml.annotation.JacksonXmlProperty",
+			"tools.jackson.dataformat.xml.annotation.JacksonXmlText",
 		}));
 		JACKSON_COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS = Collections.unmodifiableList(Arrays.asList(new String[] {
 			"com.fasterxml.jackson.annotation.JsonAnySetter",

--- a/src/core/lombok/eclipse/handlers/HandleJacksonized.java
+++ b/src/core/lombok/eclipse/handlers/HandleJacksonized.java
@@ -90,9 +90,11 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 			return;
 		}
 		
+		List<JacksonVersion> jacksonVersions = readConfiguredJacksonVersions(annotationNode);
+		
 		boolean jacksonizedBuilder = builderAnnotationNode != null || superBuilderAnnotationNode != null;
 		if (jacksonizedBuilder) {
-			handleJacksonizedBuilder(ast, annotationNode, annotatedNode, tdNode, td, builderAnnotationNode, superBuilderAnnotationNode);
+			handleJacksonizedBuilder(ast, annotationNode, annotatedNode, tdNode, td, builderAnnotationNode, superBuilderAnnotationNode, jacksonVersions);
 		}
 		
 		if (accessorsAnnotationNode != null) {
@@ -100,7 +102,7 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 		}
 	}
 	
-	private void handleJacksonizedBuilder(Annotation ast, EclipseNode annotationNode, EclipseNode annotatedNode, EclipseNode tdNode, TypeDeclaration td, EclipseNode builderAnnotationNode, EclipseNode superBuilderAnnotationNode) {
+	private void handleJacksonizedBuilder(Annotation ast, EclipseNode annotationNode, EclipseNode annotatedNode, EclipseNode tdNode, TypeDeclaration td, EclipseNode builderAnnotationNode, EclipseNode superBuilderAnnotationNode, List<JacksonVersion> jacksonVersions) {
 		boolean isAbstract = (td.modifiers & ClassFileConstants.AccAbstract) != 0;
 		if (isAbstract) {
 			annotationNode.addError("Builders on abstract classes cannot be @Jacksonized (the builder would never be used).");
@@ -140,13 +142,6 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 		TypeReference builderClassExpression = namePlusTypeParamsToTypeReference(builderClassNode, null, p);
 		ClassLiteralAccess builderClassLiteralAccess = new ClassLiteralAccess(td.sourceEnd, builderClassExpression);
 		MemberValuePair builderMvp = new MemberValuePair("builder".toCharArray(), td.sourceStart, td.sourceEnd, builderClassLiteralAccess);
-		
-		List<JacksonVersion> jacksonVersions = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, Arrays.<JacksonVersion>asList());
-		
-		if (jacksonVersions.isEmpty()) {
-			annotationNode.addWarning("Ambiguous: Jackson2 and Jackson3 exist; define which variant(s) you want in 'lombok.config'. See https://projectlombok.org/features/experimental/Jacksonized");
-			jacksonVersions = Arrays.asList(JacksonVersion.TWO);
-		}
 		
 		if (jacksonVersions.contains(JacksonVersion.TWO)) {
 			td.annotations = addAnnotation(td, td.annotations, JacksonAnnotationType.JSON_DESERIALIZE2.getQualifiednameAsCharArrayArray(), builderMvp);
@@ -193,7 +188,7 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 		// Add @JsonProperty to all fields. It will be automatically copied to the getter/setters later.
 		for (EclipseNode eclipseNode : tdNode.down()) {
 			if (eclipseNode.getKind() == Kind.FIELD) {
-				if (hasAnnotation(eclipseNode, JacksonAnnotationType.JSON_PROPERTY2) || 
+				if (hasAnnotation(eclipseNode, JacksonAnnotationType.JSON_PROPERTY2) ||
 					hasAnnotation(eclipseNode, JacksonAnnotationType.JSON_IGNORE2)) {
 					return;
 				} else if (eclipseNode.isTransient()) {
@@ -211,18 +206,18 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 		if (astNode instanceof FieldDeclaration) {
 			FieldDeclaration fd = (FieldDeclaration) astNode;
 			StringLiteral fieldName = new StringLiteral(fd.name, 0, 0, 0);
-			((FieldDeclaration) astNode).annotations = addAnnotation(fieldNode.get(), fd.annotations, JacksonAnnotationType.JSON_PROPERTY2.getQualifiednameAsCharArrayArray(), fieldName);
+			fd.annotations = addAnnotation(fieldNode.get(), fd.annotations, JacksonAnnotationType.JSON_PROPERTY2.getQualifiednameAsCharArrayArray(), fieldName);
 		}
 	}
-	
+
 	private void createJsonIgnoreForField(EclipseNode fieldNode, EclipseNode annotationNode) {
 		ASTNode astNode = fieldNode.get();
 		if (astNode instanceof FieldDeclaration) {
 			FieldDeclaration fd = (FieldDeclaration) astNode;
-			((FieldDeclaration) astNode).annotations = addAnnotation(fieldNode.get(), fd.annotations, JacksonAnnotationType.JSON_IGNORE2.getQualifiednameAsCharArrayArray());
+			fd.annotations = addAnnotation(fieldNode.get(), fd.annotations, JacksonAnnotationType.JSON_IGNORE2.getQualifiednameAsCharArrayArray());
 		}
 	}
-	
+
 	private String getBuilderClassName(Annotation ast, EclipseNode annotationNode, EclipseNode annotatedNode, TypeDeclaration td, AnnotationValues<Builder> builderAnnotation) {
 		String builderClassName = builderAnnotation != null ? 
 			builderAnnotation.getInstance().builderClassName() : null;
@@ -245,6 +240,13 @@ public class HandleJacksonized extends EclipseAnnotationHandler<Jacksonized> {
 		if (builderAnnotation == null) builderClassName += "Impl"; // For @SuperBuilder, all Jackson annotations must be put on the BuilderImpl class.
 		
 		return builderClassName;
+	}
+	
+	private List<JacksonVersion> readConfiguredJacksonVersions(EclipseNode annotationNode) {
+		List<JacksonVersion> jacksonVersions = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, Arrays.<JacksonVersion>asList());
+		if (!jacksonVersions.isEmpty()) return jacksonVersions;
+		annotationNode.addWarning("Ambiguous: Jackson2 and Jackson3 exist; define which variant(s) you want in 'lombok.config'. See https://projectlombok.org/features/experimental/Jacksonized");
+		return Arrays.asList(JacksonVersion.TWO);
 	}
 	
 	private static final Annotation[] EMPTY_ANNOTATIONS_ARRAY = new Annotation[0];

--- a/src/core/lombok/javac/handlers/HandleJacksonized.java
+++ b/src/core/lombok/javac/handlers/HandleJacksonized.java
@@ -114,11 +114,12 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 		
 		// Add @JsonProperty to all non-transient fields. It will be automatically copied to the getter/setters later.
 		// Add @JsonIgnore to all transient fields. It will be automatically copied to the getter/setters later.
+		readConfiguredJacksonVersions(annotationNode);
 		for (JavacNode javacNode : tdNode.down()) {
 			if (javacNode.getKind() == Kind.FIELD) {
 				if (hasAnnotation(javacNode, JacksonAnnotationType.JSON_PROPERTY2) ||
 					hasAnnotation(javacNode, JacksonAnnotationType.JSON_IGNORE2)) {
-					
+
 					return;
 				} else if (javacNode.isTransient()) {
 					createJsonIgnoreForField(javacNode, annotationNode);
@@ -131,22 +132,21 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 	
 	private void createJsonPropertyForField(JavacNode fieldNode, JavacNode annotationNode) {
 		JavacTreeMaker maker = fieldNode.getTreeMaker();
-		
-		JCExpression jsonPropertyType = chainDots(fieldNode, JacksonAnnotationType.JSON_PROPERTY2);
-		JCAnnotation annotationJsonProperty = maker.Annotation(jsonPropertyType, List.<JCExpression>of(maker.Literal(fieldNode.getName())));
-		recursiveSetGeneratedBy(annotationJsonProperty, annotationNode);
-		JCVariableDecl fieldDecl = ((JCVariableDecl)fieldNode.get());
-		fieldDecl.mods.annotations = fieldDecl.mods.annotations.append(annotationJsonProperty);
+		List<JCExpression> args = List.<JCExpression>of(maker.Literal(fieldNode.getName()));
+		addFieldAnnotation(fieldNode, annotationNode, JacksonAnnotationType.JSON_PROPERTY2, args);
 	}
-	
+
 	private void createJsonIgnoreForField(JavacNode fieldNode, JavacNode annotationNode) {
+		addFieldAnnotation(fieldNode, annotationNode, JacksonAnnotationType.JSON_IGNORE2, List.<JCExpression>nil());
+	}
+
+	private void addFieldAnnotation(JavacNode fieldNode, JavacNode annotationNode, JacksonAnnotationType annotationType, List<JCExpression> args) {
 		JavacTreeMaker maker = fieldNode.getTreeMaker();
-		
-		JCExpression jsonPropertyType = chainDots(fieldNode, JacksonAnnotationType.JSON_IGNORE2);
-		JCAnnotation annotationJsonProperty = maker.Annotation(jsonPropertyType, List.<JCExpression>nil());
-		recursiveSetGeneratedBy(annotationJsonProperty, annotationNode);
-		JCVariableDecl fieldDecl = ((JCVariableDecl)fieldNode.get());
-		fieldDecl.mods.annotations = fieldDecl.mods.annotations.append(annotationJsonProperty);
+		JCExpression type = chainDots(fieldNode, annotationType);
+		JCAnnotation annotation = maker.Annotation(type, args);
+		recursiveSetGeneratedBy(annotation, annotationNode);
+		JCVariableDecl fieldDecl = (JCVariableDecl) fieldNode.get();
+		fieldDecl.mods.annotations = fieldDecl.mods.annotations.append(annotation);
 	}
 	
 	private void handleJacksonizedBuilder(JavacNode annotationNode, JavacNode annotatedNode, JavacNode tdNode, JCClassDecl td, JavacNode builderAnnotationNode, JavacNode superBuilderAnnotationNode) {
@@ -191,17 +191,12 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 			return;
 		}
 		
+		Collection<JacksonVersion> jacksonVersions = readConfiguredJacksonVersions(annotationNode);
+
 		// Insert @JsonDeserialize on annotated class.
 		if (hasAnnotation(tdNode, JacksonAnnotationType.JSON_DESERIALIZE2) || hasAnnotation(tdNode, JacksonAnnotationType.JSON_DESERIALIZE3)) {
 			annotationNode.addError("@JsonDeserialize already exists on class. Either delete @JsonDeserialize, or remove @Jacksonized and manually configure Jackson.");
 			return;
-		}
-		
-		Collection<JacksonVersion> jacksonVersions = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, Arrays.<JacksonVersion>asList());
-		
-		if (jacksonVersions.isEmpty()) {
-			annotationNode.addWarning("Ambiguous: Jackson2 and Jackson3 exist; define which variant(s) you want in 'lombok.config'. See https://projectlombok.org/features/experimental/Jacksonized");
-			jacksonVersions = Arrays.asList(JacksonVersion.TWO);
 		}
 		
 		if (jacksonVersions.contains(JacksonVersion.TWO)) {
@@ -278,6 +273,13 @@ public class HandleJacksonized extends JavacAnnotationHandler<Jacksonized> {
 		if (builderAnnotation == null) builderClassName += "Impl"; // For @SuperBuilder, all Jackson annotations must be put on the BuilderImpl class.
 		
 		return builderClassName;
+	}
+	
+	private Collection<JacksonVersion> readConfiguredJacksonVersions(JavacNode annotationNode) {
+		Collection<JacksonVersion> jacksonVersions = annotationNode.getAst().readConfigurationOr(ConfigurationKeys.JACKSONIZED_JACKSON_VERSION, Arrays.<JacksonVersion>asList());
+		if (!jacksonVersions.isEmpty()) return jacksonVersions;
+		annotationNode.addWarning("Ambiguous: Jackson2 and Jackson3 exist; define which variant(s) you want in 'lombok.config'. See https://projectlombok.org/features/experimental/Jacksonized");
+		return Arrays.asList(JacksonVersion.TWO);
 	}
 	
 	private static List<JCAnnotation> findJacksonAnnotationsOnClass(JavacNode node) {

--- a/test/transform/resource/after-delombok/JacksonizedAccessorsJackson3.java
+++ b/test/transform/resource/after-delombok/JacksonizedAccessorsJackson3.java
@@ -1,0 +1,109 @@
+//version 8: Jackson deps are at least Java7+.
+//CONF: lombok.jacksonized.jacksonVersion += 3
+class JacksonizedAccessorsJackson3 {
+	@com.fasterxml.jackson.annotation.JsonProperty("name")
+	private String name;
+	@com.fasterxml.jackson.annotation.JsonProperty("age")
+	private int age;
+	@com.fasterxml.jackson.annotation.JsonIgnore
+	private transient String password;
+	
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public JacksonizedAccessorsJackson3() {
+	}
+	
+	@com.fasterxml.jackson.annotation.JsonProperty("name")
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public String name() {
+		return this.name;
+	}
+	
+	@com.fasterxml.jackson.annotation.JsonProperty("age")
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public int age() {
+		return this.age;
+	}
+	
+	@com.fasterxml.jackson.annotation.JsonIgnore
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public String password() {
+		return this.password;
+	}
+	
+	/**
+	 * @return {@code this}.
+	 */
+	@com.fasterxml.jackson.annotation.JsonProperty("name")
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public JacksonizedAccessorsJackson3 name(final String name) {
+		this.name = name;
+		return this;
+	}
+	
+	/**
+	 * @return {@code this}.
+	 */
+	@com.fasterxml.jackson.annotation.JsonProperty("age")
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public JacksonizedAccessorsJackson3 age(final int age) {
+		this.age = age;
+		return this;
+	}
+	
+	/**
+	 * @return {@code this}.
+	 */
+	@com.fasterxml.jackson.annotation.JsonIgnore
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public JacksonizedAccessorsJackson3 password(final String password) {
+		this.password = password;
+		return this;
+	}
+	
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public boolean equals(final java.lang.Object o) {
+		if (o == this) return true;
+		if (!(o instanceof JacksonizedAccessorsJackson3)) return false;
+		final JacksonizedAccessorsJackson3 other = (JacksonizedAccessorsJackson3) o;
+		if (!other.canEqual((java.lang.Object) this)) return false;
+		if (this.age() != other.age()) return false;
+		final java.lang.Object this$name = this.name();
+		final java.lang.Object other$name = other.name();
+		if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
+		return true;
+	}
+	
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	protected boolean canEqual(final java.lang.Object other) {
+		return other instanceof JacksonizedAccessorsJackson3;
+	}
+	
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public int hashCode() {
+		final int PRIME = 59;
+		int result = 1;
+		result = result * PRIME + this.age();
+		final java.lang.Object $name = this.name();
+		result = result * PRIME + ($name == null ? 43 : $name.hashCode());
+		return result;
+	}
+	
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public java.lang.String toString() {
+		return "JacksonizedAccessorsJackson3(name=" + this.name() + ", age=" + this.age() + ", password=" + this.password() + ")";
+	}
+}

--- a/test/transform/resource/after-ecj/JacksonizedAccessorsJackson3.java
+++ b/test/transform/resource/after-ecj/JacksonizedAccessorsJackson3.java
@@ -1,0 +1,68 @@
+@lombok.Data @lombok.experimental.Accessors(fluent = true) @lombok.extern.jackson.Jacksonized class JacksonizedAccessorsJackson3 {
+  private @com.fasterxml.jackson.annotation.JsonProperty("name") String name;
+  private @com.fasterxml.jackson.annotation.JsonProperty("age") int age;
+  private transient @com.fasterxml.jackson.annotation.JsonIgnore String password;
+  public @com.fasterxml.jackson.annotation.JsonProperty("name") @java.lang.SuppressWarnings("all") @lombok.Generated String name() {
+    return this.name;
+  }
+  public @com.fasterxml.jackson.annotation.JsonProperty("age") @java.lang.SuppressWarnings("all") @lombok.Generated int age() {
+    return this.age;
+  }
+  public @com.fasterxml.jackson.annotation.JsonIgnore @java.lang.SuppressWarnings("all") @lombok.Generated String password() {
+    return this.password;
+  }
+  /**
+   * @return {@code this}.
+   */
+  public @com.fasterxml.jackson.annotation.JsonProperty("name") @java.lang.SuppressWarnings("all") @lombok.Generated JacksonizedAccessorsJackson3 name(final String name) {
+    this.name = name;
+    return this;
+  }
+  /**
+   * @return {@code this}.
+   */
+  public @com.fasterxml.jackson.annotation.JsonProperty("age") @java.lang.SuppressWarnings("all") @lombok.Generated JacksonizedAccessorsJackson3 age(final int age) {
+    this.age = age;
+    return this;
+  }
+  /**
+   * @return {@code this}.
+   */
+  public @com.fasterxml.jackson.annotation.JsonIgnore @java.lang.SuppressWarnings("all") @lombok.Generated JacksonizedAccessorsJackson3 password(final String password) {
+    this.password = password;
+    return this;
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated boolean equals(final java.lang.Object o) {
+    if ((o == this))
+        return true;
+    if ((! (o instanceof JacksonizedAccessorsJackson3)))
+        return false;
+    final JacksonizedAccessorsJackson3 other = (JacksonizedAccessorsJackson3) o;
+    if ((! other.canEqual((java.lang.Object) this)))
+        return false;
+    if ((this.age() != other.age()))
+        return false;
+    final java.lang.Object this$name = this.name();
+    final java.lang.Object other$name = other.name();
+    if (((this$name == null) ? (other$name != null) : (! this$name.equals(other$name))))
+        return false;
+    return true;
+  }
+  protected @java.lang.SuppressWarnings("all") @lombok.Generated boolean canEqual(final java.lang.Object other) {
+    return (other instanceof JacksonizedAccessorsJackson3);
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated int hashCode() {
+    final int PRIME = 59;
+    int result = 1;
+    result = ((result * PRIME) + this.age());
+    final java.lang.Object $name = this.name();
+    result = ((result * PRIME) + (($name == null) ? 43 : $name.hashCode()));
+    return result;
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+    return (((((("JacksonizedAccessorsJackson3(name=" + this.name()) + ", age=") + this.age()) + ", password=") + this.password()) + ")");
+  }
+  public @java.lang.SuppressWarnings("all") @lombok.Generated JacksonizedAccessorsJackson3() {
+    super();
+  }
+}

--- a/test/transform/resource/before/JacksonizedAccessorsJackson3.java
+++ b/test/transform/resource/before/JacksonizedAccessorsJackson3.java
@@ -1,0 +1,10 @@
+//version 8: Jackson deps are at least Java7+.
+//CONF: lombok.jacksonized.jacksonVersion += 3
+@lombok.Data
+@lombok.experimental.Accessors(fluent = true)
+@lombok.extern.jackson.Jacksonized
+class JacksonizedAccessorsJackson3 {
+	private String name;
+	private int age;
+	private transient String password;
+}

--- a/test/transform/resource/messages-delombok/JacksonizedAccessors.java.messages
+++ b/test/transform/resource/messages-delombok/JacksonizedAccessors.java.messages
@@ -1,0 +1,1 @@
+1 Ambiguous: Jackson2 and Jackson3 exist; define which variant(s) you want in 'lombok.config'. See https://projectlombok.org/features/experimental/Jacksonized

--- a/test/transform/resource/messages-delombok/JacksonizedAccessorsTransient.java.messages
+++ b/test/transform/resource/messages-delombok/JacksonizedAccessorsTransient.java.messages
@@ -1,0 +1,1 @@
+1 Ambiguous: Jackson2 and Jackson3 exist; define which variant(s) you want in 'lombok.config'. See https://projectlombok.org/features/experimental/Jacksonized

--- a/test/transform/resource/messages-ecj/JacksonizedAccessors.java.messages
+++ b/test/transform/resource/messages-ecj/JacksonizedAccessors.java.messages
@@ -1,0 +1,1 @@
+1 Ambiguous: Jackson2 and Jackson3 exist; define which variant(s) you want in 'lombok.config'. See https://projectlombok.org/features/experimental/Jacksonized

--- a/test/transform/resource/messages-ecj/JacksonizedAccessorsTransient.java.messages
+++ b/test/transform/resource/messages-ecj/JacksonizedAccessorsTransient.java.messages
@@ -1,0 +1,1 @@
+1 Ambiguous: Jackson2 and Jackson3 exist; define which variant(s) you want in 'lombok.config'. See https://projectlombok.org/features/experimental/Jacksonized

--- a/test/transform/resource/messages-ecj/JacksonizedSuperBuilderWithJsonDeserialize.java.messages
+++ b/test/transform/resource/messages-ecj/JacksonizedSuperBuilderWithJsonDeserialize.java.messages
@@ -1,1 +1,2 @@
+2 Ambiguous: Jackson2 and Jackson3 exist; define which variant(s) you want in 'lombok.config'. See https://projectlombok.org/features/experimental/Jacksonized
 2 @JsonDeserialize already exists on class. Either delete @JsonDeserialize, or remove @Jacksonized and manually configure Jackson.


### PR DESCRIPTION
Extends `@Jacksonized` to emit Jackson 3 (`tools.jackson.databind.*`) annotations
controlled by `lombok.jacksonized.jacksonVersion` in `lombok.config`.

Per the Jackson 3 migration guide, `jackson-annotations` (`com.fasterxml.jackson.annotation`)
is shared between Jackson 2 and 3. Only `jackson-databind `and format-specific annotations move to the new `tools.jackson` namespace. Therefore:

- `@JsonProperty`/ `@JsonIgnore` use `com.fasterxml.jackson.annotation` regardless of version
- `@JsonDeserialize` / `@JsonPOJOBuilder` emit `tools.jackson.databind.annotation` for Jackson 3

Changes:
- Update javac and Eclipse `HandleJacksonized` to generate Jackson 3 databind annotations
  (`@JsonDeserialize`, `@JsonPOJOBuilder`) for the builder path when configured
- Add `tools.jackson.databind.annotation` and `tools.jackson.dataformat.xml.annotation`
  equivalents to `HandlerUtil` annotation copy lists
- Add test cases and expected-message files for Jackson 3

Continues where #3960 left off. Addresses new comments on #3950 and partially addresses #4004 (`@Jacksonized @Accessors(fluent = true)` now works with Jackson 3).