### PR TITLE
500ns per annotation improvement in checking if annotations are NonNull

### DIFF
--- a/src/core/lombok/core/handlers/HandlerUtil.java
+++ b/src/core/lombok/core/handlers/HandlerUtil.java
@@ -45,6 +45,7 @@ import lombok.core.AST;
 import lombok.core.AnnotationValues;
 import lombok.core.JavaIdentifiers;
 import lombok.core.LombokNode;
+import lombok.core.TypeLibrary;
 import lombok.core.configuration.AllowHelper;
 import lombok.core.configuration.CapitalizationStrategy;
 import lombok.core.configuration.ConfigurationKey;
@@ -80,6 +81,7 @@ public class HandlerUtil {
 	}
 	
 	public static final List<String> NONNULL_ANNOTATIONS, BASE_COPYABLE_ANNOTATIONS, JACKSON_COPY_TO_GETTER_ANNOTATIONS, JACKSON_COPY_TO_SETTER_ANNOTATIONS, JACKSON_COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS, JACKSON_COPY_TO_BUILDER_ANNOTATIONS;
+	public static final TypeLibrary NONNULL_TYPE_LIBRARY;
 	static {
 		// This is a list of annotations with a __highly specific meaning__: All annotations in this list indicate that passing null for the relevant item is __never__ acceptable, regardless of settings or circumstance.
 		// In other words, things like 'this models a database table, and the db table column has a nonnull constraint', or 'this represents a web form, and if this is null, the form is invalid' __do not count__ and should not be in this list;
@@ -120,7 +122,12 @@ public class HandlerUtil {
 			"org.springframework.lang.NonNull",
 			"reactor.util.annotation.NonNull",
 		}));
-		
+
+		TypeLibrary nonnullTypeLib = new TypeLibrary();
+		for (String ann : NONNULL_ANNOTATIONS) nonnullTypeLib.addType(ann);
+		nonnullTypeLib.lock();
+		NONNULL_TYPE_LIBRARY = nonnullTypeLib;
+
 		// This is a list of annotations that lombok will automatically 'copy' - be it to the method (when generating a getter for a field annotated with one of these), or to a parameter (generating a setter, with-er, or builder 'setter').
 		// You can't disable this behaviour, so the list should only contain annotations where 'copy it!' is the desired behaviour in at least 95%, preferably 98%, of all non-buggy usages.
 		// As a general rule, lombok takes on maintenance of adding all nullity-related annotations here, _if_ they fit the definition of language-level nullity as per {@see #NONNULL_ANNOTATIONS}. As a consequence, everything from the NONNULL list should probably

--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -771,21 +771,28 @@ public class EclipseHandlerUtil {
 	}
 	
 	public static boolean hasNonNullAnnotations(EclipseNode node) {
+		TypeResolver resolver = node.getImportListAsTypeResolver();
 		for (EclipseNode child : node.down()) {
 			if (child.getKind() != Kind.ANNOTATION) continue;
 			Annotation annotation = (Annotation) child.get();
-			for (String bn : NONNULL_ANNOTATIONS) if (typeMatches(bn, node, annotation.type)) return true;
+			TypeReference typeRef = annotation.type;
+			if (typeRef == null) continue;
+			char[][] tn = typeRef.getTypeName();
+			if (tn == null || tn.length == 0) continue;
+			if (resolver.typeRefToFullyQualifiedName(node, NONNULL_TYPE_LIBRARY, toQualifiedName(tn)) != null) return true;
 		}
 		return false;
 	}
-	
+
 	public static boolean hasNonNullAnnotations(EclipseNode node, List<Annotation> anns) {
 		if (anns == null) return false;
+		TypeResolver resolver = node.getImportListAsTypeResolver();
 		for (Annotation annotation : anns) {
 			TypeReference typeRef = annotation.type;
-			if (typeRef != null && typeRef.getTypeName() != null) {
-				for (String bn : NONNULL_ANNOTATIONS) if (typeMatches(bn, node, typeRef)) return true;
-			}
+			if (typeRef == null) continue;
+			char[][] tn = typeRef.getTypeName();
+			if (tn == null || tn.length == 0) continue;
+			if (resolver.typeRefToFullyQualifiedName(node, NONNULL_TYPE_LIBRARY, toQualifiedName(tn)) != null) return true;
 		}
 		return false;
 	}

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1709,24 +1709,26 @@ public class JavacHandlerUtil {
 	}
 	
 	public static boolean hasNonNullAnnotations(JavacNode node) {
+		TypeResolver resolver = node.getImportListAsTypeResolver();
 		for (JavacNode child : node.down()) {
 			if (child.getKind() == Kind.ANNOTATION) {
 				JCAnnotation annotation = (JCAnnotation) child.get();
 				String annotationTypeName = getTypeName(annotation.annotationType);
-				for (String nn : NONNULL_ANNOTATIONS) if (typeMatches(nn, node, annotationTypeName)) return true;
+				if (resolver.typeRefToFullyQualifiedName(node, NONNULL_TYPE_LIBRARY, annotationTypeName) != null) return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	public static boolean hasNonNullAnnotations(JavacNode node, List<JCAnnotation> anns) {
 		if (anns == null) return false;
+		TypeResolver resolver = node.getImportListAsTypeResolver();
 		for (JCAnnotation ann : anns) {
 			String annotationTypeName = getTypeName(ann.annotationType);
-			for (String nn : NONNULL_ANNOTATIONS) if (typeMatches(nn, node, annotationTypeName)) return true;
+			if (resolver.typeRefToFullyQualifiedName(node, NONNULL_TYPE_LIBRARY, annotationTypeName) != null) return true;
 		}
-		
+
 		return false;
 	}
 	


### PR DESCRIPTION
See #4017 for more information.

Local benchmarking on a modern 5GHz CPU results in approx 500ns improvement for each annotation that is checked that isn't a match.  For matches then the benefit depends on how far down the list of non-null annotations it is, but as demonstrated, the Android one that is first in the list also improves.

Projects using Spring, JPA or Swagger will probably find this notably improves build and rebuild times due to their heavy use of annotations.

```
Benchmark		Before (ns/op)	After (ns/op)	Improvement
noAnnotations		0.695			0.900		~same
androidNonNullFirst	127.2			112.3		1.1×
singleNonMatching	597.0			92.7		6.4× faster
singleNonNull		650.8			70.5		9.2× faster
manyNoMatch			1911.8			275.1		6.9× faster
manyLastMatch		2367.2			349.3		6.8× faster
```

resolves #4017 