### PR TITLE
Support JSpecify @NullMarked/@Nullable at class level

### DIFF
--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2009-2025 The Project Lombok Authors.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -139,10 +139,10 @@ public class EclipseHandlerUtil {
 	private EclipseHandlerUtil() {
 		//Prevent instantiation
 	}
-	
+
 	/**
 	 * Generates an error in the Eclipse error log. Note that most people never look at it!
-	 * 
+	 *
 	 * @param cud The {@code CompilationUnitDeclaration} where the error occurred.
 	 *     An error will be generated on line 0 linking to the error log entry. Can be {@code null}.
 	 * @param message Human readable description of the problem.
@@ -152,30 +152,30 @@ public class EclipseHandlerUtil {
 		ProblemReporter.error(message, ex);
 		if (cud != null) EclipseAST.addProblemToCompilationResult(cud.getFileName(), cud.compilationResult, false, message + " - See error log.", 0, 0);
 	}
-	
+
 	/**
 	 * Generates a warning in the Eclipse error log. Note that most people never look at it!
-	 * 
+	 *
 	 * @param message Human readable description of the problem.
 	 * @param ex The associated exception. Can be {@code null}.
 	 */
 	public static void warning(String message, Throwable ex) {
 		ProblemReporter.warning(message, ex);
 	}
-	
+
 	public static ASTNode getGeneratedBy(ASTNode node) {
 		return ASTNode_generatedBy.get(node);
 	}
-	
+
 	public static boolean isGenerated(ASTNode node) {
 		return getGeneratedBy(node) != null;
 	}
-	
+
 	public static <T extends ASTNode> T setGeneratedBy(T node, ASTNode source) {
 		ASTNode_generatedBy.set(node, source);
 		return node;
 	}
-	
+
 	public static MarkerAnnotation generateDeprecatedAnnotation(ASTNode source) {
 		QualifiedTypeReference qtr = new QualifiedTypeReference(new char[][] {
 				{'j', 'a', 'v', 'a'}, {'l', 'a', 'n', 'g'}, {'D', 'e', 'p', 'r', 'e', 'c', 'a', 't', 'e', 'd'}}, poss(source, 3));
@@ -192,7 +192,7 @@ public class EclipseHandlerUtil {
 		setGeneratedBy(ma, source);
 		return ma;
 	}
-	
+
 	public static MarkerAnnotation generateNamedAnnotation(ASTNode source, String typeName) {
 		char[][] cc = fromQualifiedName(typeName);
 		QualifiedTypeReference qtr = new QualifiedTypeReference(cc, poss(source, cc.length));
@@ -209,7 +209,7 @@ public class EclipseHandlerUtil {
 		setGeneratedBy(ma, source);
 		return ma;
 	}
-	
+
 	public static boolean isFieldDeprecated(EclipseNode fieldNode) {
 		if (!(fieldNode.get() instanceof FieldDeclaration)) return false;
 		FieldDeclaration field = (FieldDeclaration) fieldNode.get();
@@ -224,15 +224,15 @@ public class EclipseHandlerUtil {
 		}
 		return false;
 	}
-	
+
 	public static CheckerFrameworkVersion getCheckerFrameworkVersion(EclipseNode node) {
 		CheckerFrameworkVersion cfv = node.getAst().readConfiguration(ConfigurationKeys.CHECKER_FRAMEWORK);
 		return cfv != null ? cfv : CheckerFrameworkVersion.NONE;
 	}
-	
+
 	/**
 	 * Checks if the given TypeReference node is likely to be a reference to the provided class.
-	 * 
+	 *
 	 * @param type An actual type. This method checks if {@code typeNode} is likely to be a reference to this type.
 	 * @param node A Lombok AST node. Any node in the appropriate compilation unit will do (used to get access to import statements).
 	 * @param typeRef A type reference to check.
@@ -240,10 +240,10 @@ public class EclipseHandlerUtil {
 	public static boolean typeMatches(Class<?> type, EclipseNode node, TypeReference typeRef) {
 		return typeMatches(type.getName(), node, typeRef);
 	}
-	
+
 	/**
 	 * Checks if the given TypeReference node is likely to be a reference to the provided class.
-	 * 
+	 *
 	 * @param type An actual type. This method checks if {@code typeNode} is likely to be a reference to this type.
 	 * @param node A Lombok AST node. Any node in the appropriate compilation unit will do (used to get access to import statements).
 	 * @param typeRef A type reference to check.
@@ -259,7 +259,7 @@ public class EclipseHandlerUtil {
 		TypeResolver resolver = node.getImportListAsTypeResolver();
 		return resolver.typeMatches(node, type, typeName);
 	}
-	
+
 	public static void sanityCheckForMethodGeneratingAnnotationsOnBuilderClass(EclipseNode typeNode, EclipseNode errorNode) {
 		List<String> disallowed = null;
 		for (EclipseNode child : typeNode.down()) {
@@ -272,7 +272,7 @@ public class EclipseHandlerUtil {
 				}
 			}
 		}
-		
+
 		int size = disallowed == null ? 0 : disallowed.size();
 		if (size == 0) return;
 		if (size == 1) {
@@ -284,10 +284,10 @@ public class EclipseHandlerUtil {
 		out.setLength(out.length() - 2);
 		errorNode.addError(out.append(" are not allowed on builder classes.").toString());
 	}
-	
+
 	public static Annotation copyAnnotation(Annotation annotation, ASTNode source) {
 		int pS = source.sourceStart, pE = source.sourceEnd;
-		
+
 		if (annotation instanceof MarkerAnnotation) {
 			MarkerAnnotation ann = new MarkerAnnotation(copyType(annotation.type, source), pS);
 			setGeneratedBy(ann, source);
@@ -295,7 +295,7 @@ public class EclipseHandlerUtil {
 			copyMemberValuePairName(ann, annotation);
 			return ann;
 		}
-		
+
 		if (annotation instanceof SingleMemberAnnotation) {
 			SingleMemberAnnotation ann = new SingleMemberAnnotation(copyType(annotation.type, source), pS);
 			setGeneratedBy(ann, source);
@@ -304,7 +304,7 @@ public class EclipseHandlerUtil {
 			copyMemberValuePairName(ann, annotation);
 			return ann;
 		}
-		
+
 		if (annotation instanceof NormalAnnotation) {
 			NormalAnnotation ann = new NormalAnnotation(copyType(annotation.type, source), pS);
 			setGeneratedBy(ann, source);
@@ -320,18 +320,18 @@ public class EclipseHandlerUtil {
 			copyMemberValuePairName(ann, annotation);
 			return ann;
 		}
-		
+
 		return annotation;
 	}
-	
+
 	private static void copyMemberValuePairName(Annotation source, Annotation target) {
 		if (ANNOTATION__MEMBER_VALUE_PAIR_NAME == null) return;
-		
+
 		try {
 			reflectSet(ANNOTATION__MEMBER_VALUE_PAIR_NAME, source, reflect(ANNOTATION__MEMBER_VALUE_PAIR_NAME, target));
 		} catch (Exception ignore) { /* Various eclipse versions don't have it */ }
 	}
-	
+
 	static class EclipseReflectiveMembers {
 		public static final Field STRING_LITERAL__LINE_NUMBER;
 		public static final Field ANNOTATION__MEMBER_VALUE_PAIR_NAME;
@@ -353,7 +353,7 @@ public class EclipseHandlerUtil {
 			COMPILATION_UNIT = getClass("org.eclipse.jdt.internal.core.CompilationUnit");
 			COMPILATION_UNIT_ORIGINAL_FROM_CLONE = COMPILATION_UNIT == null ? null : Permit.permissiveGetMethod(COMPILATION_UNIT, "originalFromClone");
 		}
-		
+
 		public static int reflectInt(Field f, Object o) {
 			try {
 				return ((Number) f.get(o)).intValue();
@@ -361,7 +361,7 @@ public class EclipseHandlerUtil {
 				throw new RuntimeException(e);
 			}
 		}
-		
+
 		public static void reflectSet(Field f, Object o, Object v) {
 			try {
 				f.set(o, v);
@@ -369,7 +369,7 @@ public class EclipseHandlerUtil {
 				throw new RuntimeException(e);
 			}
 		}
-		
+
 		public static Object reflect(Field f, Object o) {
 			try {
 				return f.get(o);
@@ -377,7 +377,7 @@ public class EclipseHandlerUtil {
 				throw new RuntimeException(e);
 			}
 		}
-		
+
 		private static Class<?> getClass(String fqn) {
 			try {
 				return Class.forName(fqn);
@@ -385,7 +385,7 @@ public class EclipseHandlerUtil {
 				return null;
 			}
 		}
-		
+
 		private static Field getField(Class<?> c, String fName) {
 			try {
 				return Permit.getField(c, fName);
@@ -394,32 +394,32 @@ public class EclipseHandlerUtil {
 			}
 		}
 	}
-	
+
 	public static Expression copyAnnotationMemberValue(Expression in) {
 		Expression out = copyAnnotationMemberValue0(in);
 		out.constant = in.constant;
 		return out;
 	}
-	
+
 	private static Expression copyAnnotationMemberValue0(Expression in) {
 		int s = in.sourceStart, e = in.sourceEnd;
-		
+
 		// literals
-		
+
 		if (in instanceof FalseLiteral) return new FalseLiteral(s, e);
 		if (in instanceof TrueLiteral) return new TrueLiteral(s, e);
 		if (in instanceof NullLiteral) return new NullLiteral(s, e);
-		
+
 		if (in instanceof CharLiteral) return new CharLiteral(((Literal) in).source(), s, e);
 		if (in instanceof DoubleLiteral) return new DoubleLiteral(((Literal) in).source(), s, e);
 		if (in instanceof FloatLiteral) return new FloatLiteral(((Literal) in).source(), s, e);
 		if (in instanceof IntLiteral) return IntLiteral.buildIntLiteral(((Literal) in).source(), s, e);
 		if (in instanceof LongLiteral) return LongLiteral.buildLongLiteral(((Literal) in).source(), s, e);
-		
+
 		if (in instanceof StringLiteral) return new StringLiteral(((Literal) in).source(), s, e, reflectInt(STRING_LITERAL__LINE_NUMBER, in) + 1);
-		
+
 		// enums and field accesses (as long as those are references to compile time constant literals that's also acceptable)
-		
+
 		if (in instanceof SingleNameReference) {
 			SingleNameReference snr = (SingleNameReference) in;
 			return new SingleNameReference(snr.token, pos(in));
@@ -428,10 +428,10 @@ public class EclipseHandlerUtil {
 			QualifiedNameReference qnr = (QualifiedNameReference) in;
 			return new QualifiedNameReference(qnr.tokens, poss(in, qnr.tokens.length), s, e);
 		}
-		
+
 		// class refs
 		if (in instanceof ClassLiteralAccess) return new ClassLiteralAccess(e, copyType(((ClassLiteralAccess) in).type));
-		
+
 		// arrays
 		if (in instanceof ArrayInitializer) {
 			ArrayInitializer out = new ArrayInitializer();
@@ -448,7 +448,7 @@ public class EclipseHandlerUtil {
 			}
 			return out;
 		}
-		
+
 		if (in instanceof BinaryExpression) {
 			BinaryExpression be = (BinaryExpression) in;
 			BinaryExpression out = new BinaryExpression(be);
@@ -459,10 +459,10 @@ public class EclipseHandlerUtil {
 			out.statementEnd = e;
 			return out;
 		}
-		
+
 		return in;
 	}
-	
+
 	/**
 	 * You can't share TypeParameter objects or bad things happen; for example, one 'T' resolves differently
 	 * from another 'T', even for the same T in a single class file. Unfortunately the TypeParameter type hierarchy
@@ -495,7 +495,7 @@ public class EclipseHandlerUtil {
 		}
 		return out;
 	}
-	
+
 	public static Annotation[] getTypeUseAnnotations(TypeReference from) {
 		Annotation[][] a;
 		try {
@@ -507,19 +507,19 @@ public class EclipseHandlerUtil {
 		Annotation[] b = a[a.length - 1];
 		return b.length == 0 ? null : b;
 	}
-	
+
 	public static void removeTypeUseAnnotations(TypeReference from) {
 		try {
 			reflectSet(TYPE_REFERENCE__ANNOTATIONS, from, null);
 		} catch (Exception ignore) {}
 	}
-	
+
 	public static TypeReference namePlusTypeParamsToTypeReference(EclipseNode type, TypeParameter[] params, long p) {
 		TypeDeclaration td = (TypeDeclaration) type.get();
 		boolean instance = (td.modifiers & MODIFIERS_INDICATING_STATIC) == 0;
 		return namePlusTypeParamsToTypeReference(type.up(), td.name, instance, params, p);
 	}
-	
+
 	public static TypeReference namePlusTypeParamsToTypeReference(EclipseNode parentType, char[] typeName, boolean instance, TypeParameter[] params, long p) {
 		if (params != null && params.length > 0) {
 			TypeReference[] refs = new TypeReference[params.length];
@@ -530,14 +530,14 @@ public class EclipseHandlerUtil {
 			}
 			return generateParameterizedTypeReference(parentType, typeName, instance, refs, p);
 		}
-		
+
 		return generateTypeReference(parentType, typeName, instance, p);
 	}
-	
+
 	public static TypeReference[] copyTypes(TypeReference[] refs) {
 		return copyTypes(refs, null);
 	}
-	
+
 	/**
 	 * Convenience method that creates a new array and copies each TypeReference in the source array via
 	 * {@link #copyType(TypeReference, ASTNode)}.
@@ -551,11 +551,11 @@ public class EclipseHandlerUtil {
 		}
 		return outs;
 	}
-	
+
 	public static TypeReference copyType(TypeReference ref) {
 		return copyType(ref, null);
 	}
-	
+
 	/**
 	 * You can't share TypeReference objects or subtle errors start happening.
 	 * Unfortunately the TypeReference type hierarchy is complicated and there's no clone
@@ -580,13 +580,13 @@ public class EclipseHandlerUtil {
 					}
 				}
 			}
-			
+
 			TypeReference typeRef = new ParameterizedQualifiedTypeReference(iRef.tokens, args, iRef.dimensions(), copy(iRef.sourcePositions));
 			copyTypeAnns(ref, typeRef);
 			if (source != null) setGeneratedBy(typeRef, source);
 			return typeRef;
 		}
-		
+
 		if (ref instanceof ArrayQualifiedTypeReference) {
 			ArrayQualifiedTypeReference iRef = (ArrayQualifiedTypeReference) ref;
 			TypeReference typeRef = new ArrayQualifiedTypeReference(iRef.tokens, iRef.dimensions(), copy(iRef.sourcePositions));
@@ -594,7 +594,7 @@ public class EclipseHandlerUtil {
 			if (source != null) setGeneratedBy(typeRef, source);
 			return typeRef;
 		}
-		
+
 		if (ref instanceof QualifiedTypeReference) {
 			QualifiedTypeReference iRef = (QualifiedTypeReference) ref;
 			TypeReference typeRef = new QualifiedTypeReference(iRef.tokens, copy(iRef.sourcePositions));
@@ -602,7 +602,7 @@ public class EclipseHandlerUtil {
 			if (source != null) setGeneratedBy(typeRef, source);
 			return typeRef;
 		}
-		
+
 		if (ref instanceof ParameterizedSingleTypeReference) {
 			ParameterizedSingleTypeReference iRef = (ParameterizedSingleTypeReference) ref;
 			TypeReference[] args = null;
@@ -614,13 +614,13 @@ public class EclipseHandlerUtil {
 					else args[idx++] = copyType(inRef, source);
 				}
 			}
-			
+
 			TypeReference typeRef = new ParameterizedSingleTypeReference(iRef.token, args, iRef.dimensions(), (long) iRef.sourceStart << 32 | iRef.sourceEnd);
 			copyTypeAnns(ref, typeRef);
 			if (source != null) setGeneratedBy(typeRef, source);
 			return typeRef;
 		}
-		
+
 		if (ref instanceof ArrayTypeReference) {
 			ArrayTypeReference iRef = (ArrayTypeReference) ref;
 			TypeReference typeRef = new ArrayTypeReference(iRef.token, iRef.dimensions(), (long) iRef.sourceStart << 32 | iRef.sourceEnd);
@@ -628,10 +628,10 @@ public class EclipseHandlerUtil {
 			if (source != null) setGeneratedBy(typeRef, source);
 			return typeRef;
 		}
-		
+
 		if (ref instanceof Wildcard) {
 			Wildcard original = (Wildcard) ref;
-			
+
 			Wildcard wildcard = new Wildcard(original.kind);
 			wildcard.sourceStart = original.sourceStart;
 			wildcard.sourceEnd = original.sourceEnd;
@@ -640,7 +640,7 @@ public class EclipseHandlerUtil {
 			if (source != null) setGeneratedBy(wildcard, source);
 			return wildcard;
 		}
-		
+
 		if (ref instanceof SingleTypeReference) {
 			SingleTypeReference iRef = (SingleTypeReference) ref;
 			TypeReference typeRef = new SingleTypeReference(iRef.token, (long) iRef.sourceStart << 32 | iRef.sourceEnd);
@@ -648,10 +648,10 @@ public class EclipseHandlerUtil {
 			if (source != null) setGeneratedBy(typeRef, source);
 			return typeRef;
 		}
-		
+
 		return ref;
 	}
-	
+
 	private static void copyTypeAnns(TypeReference in, TypeReference out) {
 		Annotation[][] a;
 		try {
@@ -659,12 +659,12 @@ public class EclipseHandlerUtil {
 		} catch (Exception e) {
 			return;
 		}
-		
+
 		if (a == null) {
 			reflectSet(TYPE_REFERENCE__ANNOTATIONS, out, null);
 			return;
 		}
-		
+
 		Annotation[][] b = new Annotation[a.length][];
 		for (int i = 0; i < a.length; i++) {
 			if (a[i] != null) {
@@ -674,10 +674,10 @@ public class EclipseHandlerUtil {
 				}
 			}
 		}
-		
+
 		reflectSet(TYPE_REFERENCE__ANNOTATIONS, out, b);
 	}
-	
+
 	public static Annotation[] copyAnnotations(ASTNode source, Annotation[]... allAnnotations) {
 		List<Annotation> result = null;
 		for (Annotation[] annotations : allAnnotations) {
@@ -688,10 +688,10 @@ public class EclipseHandlerUtil {
 				}
 			}
 		}
-		
+
 		return result == null ? null : result.toArray(new Annotation[0]);
 	}
-	
+
 	public static boolean hasAnnotation(Class<? extends java.lang.annotation.Annotation> type, EclipseNode node) {
 		if (node == null) return false;
 		if (type == null) return false;
@@ -709,7 +709,7 @@ public class EclipseHandlerUtil {
 			return false;
 		}
 	}
-	
+
 	public static boolean hasAnnotation(String type, EclipseNode node) {
 		if (node == null) return false;
 		if (type == null) return false;
@@ -727,7 +727,7 @@ public class EclipseHandlerUtil {
 			return false;
 		}
 	}
-	
+
 	public static EclipseNode findInnerClass(EclipseNode parent, String name) {
 		char[] c = name.toCharArray();
 		for (EclipseNode child : parent.down()) {
@@ -737,7 +737,7 @@ public class EclipseHandlerUtil {
 		}
 		return null;
 	}
-	
+
 	public static EclipseNode findAnnotation(Class<? extends java.lang.annotation.Annotation> type, EclipseNode node) {
 		if (node == null) return null;
 		if (type == null) return null;
@@ -755,7 +755,7 @@ public class EclipseHandlerUtil {
 			return null;
 		}
 	}
-	
+
 	public static String scanForNearestAnnotation(EclipseNode node, String... anns) {
 		while (node != null) {
 			for (EclipseNode ann : node.down()) {
@@ -766,10 +766,10 @@ public class EclipseHandlerUtil {
 			}
 			node = node.up();
 		}
-		
+
 		return null;
 	}
-	
+
 	public static boolean hasNonNullAnnotations(EclipseNode node) {
 		for (EclipseNode child : node.down()) {
 			if (child.getKind() != Kind.ANNOTATION) continue;
@@ -778,7 +778,7 @@ public class EclipseHandlerUtil {
 		}
 		return false;
 	}
-	
+
 	public static boolean hasNonNullAnnotations(EclipseNode node, List<Annotation> anns) {
 		if (anns == null) return false;
 		for (Annotation annotation : anns) {
@@ -789,9 +789,39 @@ public class EclipseHandlerUtil {
 		}
 		return false;
 	}
-	
+
+	public static boolean hasNullableAnnotations(EclipseNode node) {
+		return hasAnnotation("org.jspecify.annotations.Nullable", node);
+	}
+
+	public static boolean isNullMarked(EclipseNode typeNode) {
+		return hasAnnotation("org.jspecify.annotations.NullMarked", typeNode);
+	}
+
+	/**
+	 * Find the parent class or interface.
+	 */
+	public static EclipseNode getParentTypeNode(EclipseNode childOfType) {
+		EclipseNode typeNode = childOfType;
+		while (typeNode != null && typeNode.getKind() != Kind.TYPE) typeNode = typeNode.up();
+		return typeNode;
+	}
+
+	/**
+	 * Return true if the specified field or parameter node is determined as non-null according
+	 * to JSpecify rules.
+	 * Currently supports @NullMarked on class. To support annotations on package-info.java, we
+	 * would need to place each type node under a package node. Supporting NullMarked on the type
+	 * seems adequate for now, and gives the option to opt-in to null assertions on a per class basis
+	 * (i.e. have NullMarked be the default but allow a custom annotation to trigger null checks at
+	 * system boundaries only).
+	 */
+	public static boolean isJSpecifyNonNull(boolean isNullMarked, EclipseNode node) {
+		return isNullMarked && !hasNullableAnnotations(node);
+	}
+
 	private static final Annotation[] EMPTY_ANNOTATIONS_ARRAY = new Annotation[0];
-	
+
 	/**
 	 * Searches the given field node for annotations and returns each one that is 'copyable' (either via configuration or from the base list).
 	 */
@@ -800,7 +830,7 @@ public class EclipseHandlerUtil {
 		List<TypeName> configuredCopyable = node.getAst().readConfiguration(ConfigurationKeys.COPYABLE_ANNOTATIONS);
 		for (EclipseNode child : node.down()) {
 			if (child.getKind() != Kind.ANNOTATION) continue;
-			
+
 			Annotation annotation = (Annotation) child.get();
 			TypeReference typeRef = annotation.type;
 			boolean match = false;
@@ -818,10 +848,10 @@ public class EclipseHandlerUtil {
 		}
 		return result.toArray(EMPTY_ANNOTATIONS_ARRAY);
 	}
-	
+
 	/**
 	 * Searches the given field node for annotations that are specifically intended to be copied to the getter.
-	 * 
+	 *
 	 * @param forceCopyJacksonAnnotations If {@code true}, always copy the annotations regardless of regardless of lombok configuration key {@code lombok.copyJacksonAnnotationsToAccessors}.
 	 */
 	public static Annotation[] findCopyableToGetterAnnotations(EclipseNode node, boolean forceCopyJacksonAnnotations) {
@@ -831,10 +861,10 @@ public class EclipseHandlerUtil {
 		}
 		return findAnnotationsInList(node, JACKSON_COPY_TO_GETTER_ANNOTATIONS);
 	}
-	
+
 	/**
 	 * Searches the given field node for annotations that are specifically intended to be copied to the setter.
-	 * 
+	 *
 	 * @param forceCopyJacksonAnnotations If {@code true}, always copy the annotations regardless of regardless of lombok configuration key {@code lombok.copyJacksonAnnotationsToAccessors}.
 	 */
 	public static Annotation[] findCopyableToSetterAnnotations(EclipseNode node, boolean forceCopyJacksonAnnotations) {
@@ -844,14 +874,14 @@ public class EclipseHandlerUtil {
 		}
 		return findAnnotationsInList(node, JACKSON_COPY_TO_SETTER_ANNOTATIONS);
 	}
-	
+
 	/**
 	 * Searches the given field node for annotations that are specifically intended to be copied to the builder's singular method.
 	 */
 	public static Annotation[] findCopyableToBuilderSingularSetterAnnotations(EclipseNode node) {
 		return findAnnotationsInList(node, JACKSON_COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS);
 	}
-	
+
 	/**
 	 * Searches the given field node for annotations that are in the given list, and returns those.
 	 */
@@ -859,7 +889,7 @@ public class EclipseHandlerUtil {
 		List<Annotation> result = new ArrayList<Annotation>();
 		for (EclipseNode child : node.down()) {
 			if (child.getKind() != Kind.ANNOTATION) continue;
-			
+
 			Annotation annotation = (Annotation) child.get();
 			TypeReference typeRef = annotation.type;
 			if (typeRef != null && typeRef.getTypeName() != null) {
@@ -871,31 +901,31 @@ public class EclipseHandlerUtil {
 		}
 		return result.toArray(EMPTY_ANNOTATIONS_ARRAY);
 	}
-	
+
 	/**
 	 * Checks if the provided annotation type is likely to be the intended type for the given annotation node.
-	 * 
+	 *
 	 * This is a guess, but a decent one.
 	 */
 	public static boolean annotationTypeMatches(Class<? extends java.lang.annotation.Annotation> type, EclipseNode node) {
 		if (node.getKind() != Kind.ANNOTATION) return false;
 		return typeMatches(type, node, ((Annotation) node.get()).type);
 	}
-	
+
 	/**
 	 * Checks if the provided annotation type is likely to be the intended type for the given annotation node.
-	 * 
+	 *
 	 * This is a guess, but a decent one.
 	 */
 	public static boolean annotationTypeMatches(String type, EclipseNode node) {
 		if (node.getKind() != Kind.ANNOTATION) return false;
 		return typeMatches(type, node, ((Annotation) node.get()).type);
 	}
-	
+
 	public static TypeReference cloneSelfType(EclipseNode context) {
 		return cloneSelfType(context, null);
 	}
-	
+
 	public static TypeReference cloneSelfType(EclipseNode context, ASTNode source) {
 		int pS = source == null ? 0 : source.sourceStart, pE = source == null ? 0 : source.sourceEnd;
 		long p = (long) pS << 32 | pE;
@@ -920,7 +950,7 @@ public class EclipseHandlerUtil {
 		if (result != null && source != null) setGeneratedBy(result, source);
 		return result;
 	}
-	
+
 	public static TypeReference generateParameterizedTypeReference(EclipseNode type, TypeReference[] typeParams, long p) {
 		TypeDeclaration td = (TypeDeclaration) type.get();
 		char[][] tn = getQualifiedInnerName(type.up(), td.name);
@@ -934,7 +964,7 @@ public class EclipseHandlerUtil {
 		if (instance) fillOuterTypeParams(rr, tnLen - 2, type.up(), p);
 		return new ParameterizedQualifiedTypeReference(tn, rr, 0, ps);
 	}
-	
+
 	public static TypeReference generateParameterizedTypeReference(EclipseNode parent, char[] name, boolean instance, TypeReference[] typeParams, long p) {
 		char[][] tn = getQualifiedInnerName(parent, name);
 		if (tn.length == 1) return new ParameterizedSingleTypeReference(tn[0], typeParams, 0, p);
@@ -946,12 +976,12 @@ public class EclipseHandlerUtil {
 		if (instance) fillOuterTypeParams(rr, tnLen - 2, parent, p);
 		return new ParameterizedQualifiedTypeReference(tn, rr, 0, ps);
 	}
-	
+
 	private static final int MODIFIERS_INDICATING_STATIC = ClassFileConstants.AccInterface | ClassFileConstants.AccStatic | ClassFileConstants.AccEnum | Eclipse.AccRecord;
-	
+
 	/**
 	 * This class will add type params to fully qualified chain of type references for inner types, such as {@code GrandParent.Parent.Child}; this is needed only as long as the chain does not involve static.
-	 * 
+	 *
 	 * @return {@code true} if at least one parameterization is actually added, {@code false} otherwise.
 	 */
 	private static boolean fillOuterTypeParams(TypeReference[][] rr, int idx, EclipseNode node, long p) {
@@ -971,12 +1001,12 @@ public class EclipseHandlerUtil {
 			rr[idx] = trs;
 			filled = true;
 		}
-		
+
 		if ((td.modifiers & MODIFIERS_INDICATING_STATIC) != 0) return filled; // Once we hit a static class, no further typeparams needed.
 		boolean f2 = fillOuterTypeParams(rr, idx - 1, node.up(), p);
 		return f2 || filled;
 	}
-	
+
 	public static NameReference generateNameReference(EclipseNode type, long p) {
 		char[][] tn = getQualifiedInnerName(type.up(), ((TypeDeclaration) type.get()).name);
 		if (tn.length == 1) return new SingleNameReference(tn[0], p);
@@ -987,7 +1017,7 @@ public class EclipseHandlerUtil {
 		int se = (int) p;
 		return new QualifiedNameReference(tn, ps, ss, se);
 	}
-	
+
 	public static NameReference generateNameReference(EclipseNode parent, char[] name, long p) {
 		char[][] tn = getQualifiedInnerName(parent, name);
 		if (tn.length == 1) return new SingleNameReference(tn[0], p);
@@ -998,7 +1028,7 @@ public class EclipseHandlerUtil {
 		int se = (int) p;
 		return new QualifiedNameReference(tn, ps, ss, se);
 	}
-	
+
 	public static TypeReference generateTypeReference(EclipseNode type, long p) {
 		TypeDeclaration td = (TypeDeclaration) type.get();
 		char[][] tn = getQualifiedInnerName(type.up(), td.name);
@@ -1006,42 +1036,42 @@ public class EclipseHandlerUtil {
 		int tnLen = tn.length;
 		long[] ps = new long[tnLen];
 		for (int i = 0; i < tnLen; i++) ps[i] = p;
-		
-		
+
+
 		boolean instance = (td.modifiers & MODIFIERS_INDICATING_STATIC) == 0 && type.up() != null && type.up().get() instanceof TypeDeclaration;
 		if (instance) {
 			TypeReference[][] trs = new TypeReference[tn.length][];
 			boolean filled = fillOuterTypeParams(trs, trs.length - 2, type.up(), p);
 			if (filled) return new ParameterizedQualifiedTypeReference(tn, trs, 0, ps);
 		}
-		
+
 		return new QualifiedTypeReference(tn, ps);
 	}
-	
+
 	public static TypeReference generateTypeReference(EclipseNode parent, char[] name, boolean instance, long p) {
 		char[][] tn = getQualifiedInnerName(parent, name);
 		if (tn.length == 1) return new SingleTypeReference(tn[0], p);
 		int tnLen = tn.length;
 		long[] ps = new long[tnLen];
 		for (int i = 0; i < tnLen; i++) ps[i] = p;
-		
+
 		if (instance && parent != null && parent.get() instanceof TypeDeclaration) {
 			TypeReference[][] trs = new TypeReference[tn.length][];
 			if (fillOuterTypeParams(trs, tn.length - 2, parent, p)) return new ParameterizedQualifiedTypeReference(tn, trs, 0, ps);
 		}
-		
+
 		return new QualifiedTypeReference(tn, ps);
 	}
-	
+
 	/**
 	 * Generate a chain of names for the enclosing classes.
-	 * 
+	 *
 	 * Given for example {@code class Outer { class Inner {} }} this would generate {@code char[][] { "Outer", "Inner" }}.
 	 * For method local and top level types, this generates a size-1 char[][] where the only char[] element is {@code name} itself.
 	 */
 	public static char[][] getQualifiedInnerName(EclipseNode parent, char[] name) {
 		int count = 0;
-		
+
 		EclipseNode n = parent;
 		while (n != null && n.getKind() == Kind.TYPE && n.get() instanceof TypeDeclaration) {
 			TypeDeclaration td = (TypeDeclaration) n.get();
@@ -1049,23 +1079,23 @@ public class EclipseHandlerUtil {
 			count++;
 			n = n.up();
 		}
-		
+
 		if (count == 0) return new char[][] { name };
 		char[][] res = new char[count + 1][];
 		res[count] = name;
-		
+
 		n = parent;
 		while (count > 0) {
 			TypeDeclaration td = (TypeDeclaration) n.get();
 			res[--count] = td.name;
 			n = n.up();
 		}
-		
+
 		return res;
 	}
-	
+
 	private static final char[] OBJECT_SIG = "Ljava/lang/Object;".toCharArray();
-	
+
 	private static int compare(char[] a, char[] b) {
 		if (a == null) return b == null ? 0 : -1;
 		if (b == null) return +1;
@@ -1076,7 +1106,7 @@ public class EclipseHandlerUtil {
 		}
 		return a.length < b.length ? -1 : a.length > b.length ? +1 : 0;
 	}
-	
+
 	public static TypeReference makeType(TypeBinding binding, ASTNode pos, boolean allowCompound) {
 		Object[] arr = null;
 		if (binding.getClass() == EclipseReflectiveMembers.INTERSECTION_BINDING1) {
@@ -1084,7 +1114,7 @@ public class EclipseHandlerUtil {
 		} else if (binding.getClass() == EclipseReflectiveMembers.INTERSECTION_BINDING2) {
 			arr = (Object[]) EclipseReflectiveMembers.reflect(EclipseReflectiveMembers.INTERSECTION_BINDING_TYPES2, binding);
 		}
-		
+
 		if (arr != null) {
 			// Is there a class? Alphabetically lowest wins.
 			TypeBinding winner = null;
@@ -1098,9 +1128,9 @@ public class EclipseHandlerUtil {
 					else if (tb.isTypeVariable()) level = 20;
 					else if (tb.isWildcard()) level = 15;
 					else level = 10;
-					
+
 					if (level == 50 && compare(tb.signature(), OBJECT_SIG) == 0) level = 1;
-					
+
 					if (winLevel > level) continue;
 					if (winLevel < level) {
 						winner = tb;
@@ -1114,11 +1144,11 @@ public class EclipseHandlerUtil {
 		}
 		int dims = binding.dimensions();
 		binding = binding.leafComponentType();
-		
+
 		// Primitives
-		
+
 		char[] base = null;
-		
+
 		switch (binding.id) {
 		case TypeIds.T_int:
 			base = TypeConstants.INT;
@@ -1150,7 +1180,7 @@ public class EclipseHandlerUtil {
 		case TypeIds.T_null:
 			return null;
 		}
-		
+
 		if (base != null) {
 			if (dims > 0) {
 				TypeReference result = new ArrayTypeReference(base, dims, pos(pos));
@@ -1161,7 +1191,7 @@ public class EclipseHandlerUtil {
 			setGeneratedBy(result, pos);
 			return result;
 		}
-		
+
 		if (binding.isAnonymousType()) {
 			ReferenceBinding ref = (ReferenceBinding)binding;
 			ReferenceBinding[] supers = ref.superInterfaces();
@@ -1173,11 +1203,11 @@ public class EclipseHandlerUtil {
 			}
 			return makeType(supers[0], pos, false);
 		}
-		
+
 		if (binding instanceof CaptureBinding) {
 			return makeType(((CaptureBinding)binding).wildcard, pos, allowCompound);
 		}
-		
+
 		if (binding.isUnboundWildcard()) {
 			if (!allowCompound) {
 				TypeReference result = new QualifiedTypeReference(TypeConstants.JAVA_LANG_OBJECT, poss(pos, 3));
@@ -1191,7 +1221,7 @@ public class EclipseHandlerUtil {
 				return out;
 			}
 		}
-		
+
 		if (binding.isWildcard()) {
 			WildcardBinding wildcard = (WildcardBinding) binding;
 			if (wildcard.boundKind == Wildcard.EXTENDS) {
@@ -1223,17 +1253,17 @@ public class EclipseHandlerUtil {
 				return result;
 			}
 		}
-		
+
 		// Keep moving up via 'binding.enclosingType()' and gather generics from each binding. We stop after a local type, or a static type, or a top-level type.
 		// Finally, add however many nullTypeArgument[] arrays as that are missing, inverse the list, toArray it, and use that as PTR's typeArgument argument.
-		
+
 		List<TypeReference[]> params = new ArrayList<TypeReference[]>();
 		/* Calculate generics */
 		if (!(binding instanceof RawTypeBinding)) {
 			TypeBinding b = binding;
 			while (true) {
 				boolean isFinalStop = b.isLocalType() || !b.isMemberType() || b.enclosingType() == null;
-				
+
 				TypeReference[] tyParams = null;
 				if (b instanceof ParameterizedTypeBinding) {
 					ParameterizedTypeBinding paramized = (ParameterizedTypeBinding) b;
@@ -1244,15 +1274,15 @@ public class EclipseHandlerUtil {
 						}
 					}
 				}
-				
+
 				params.add(tyParams);
 				if (isFinalStop) break;
 				b = b.enclosingType();
 			}
 		}
-		
+
 		char[][] parts;
-		
+
 		if (binding.isTypeVariable()) {
 			parts = new char[][] { binding.shortReadableName() };
 		} else if (binding.isLocalType()) {
@@ -1266,12 +1296,12 @@ public class EclipseHandlerUtil {
 			for (ptr = 0; ptr < pkg.length; ptr++) parts[ptr] = pkg[ptr].toCharArray();
 			for (; ptr < pkg.length + name.length; ptr++) parts[ptr] = name[ptr - pkg.length].toCharArray();
 		}
-		
+
 		while (params.size() < parts.length) params.add(null);
 		Collections.reverse(params);
-		
+
 		boolean isParamized = false;
-		
+
 		for (TypeReference[] tyParams : params) {
 			if (tyParams != null) {
 				isParamized = true;
@@ -1289,7 +1319,7 @@ public class EclipseHandlerUtil {
 			setGeneratedBy(result, pos);
 			return result;
 		}
-		
+
 		if (dims > 0) {
 			if (parts.length > 1) {
 				TypeReference result = new ArrayQualifiedTypeReference(parts, dims, poss(pos, parts.length));
@@ -1300,7 +1330,7 @@ public class EclipseHandlerUtil {
 			setGeneratedBy(result, pos);
 			return result;
 		}
-		
+
 		if (parts.length > 1) {
 			TypeReference result = new QualifiedTypeReference(parts, poss(pos, parts.length));
 			setGeneratedBy(result, pos);
@@ -1310,24 +1340,24 @@ public class EclipseHandlerUtil {
 		setGeneratedBy(result, pos);
 		return result;
 	}
-	
+
 	/**
 	 * Provides AnnotationValues with the data it needs to do its thing.
 	 */
 	public static <A extends java.lang.annotation.Annotation> AnnotationValues<A>
 		createAnnotation(Class<A> type, final EclipseNode annotationNode) {
-		
+
 		final Annotation annotation = (Annotation) annotationNode.get();
 		Map<String, AnnotationValue> values = new HashMap<String, AnnotationValue>();
-		
+
 		MemberValuePair[] memberValuePairs = annotation.memberValuePairs();
-		
+
 		if (memberValuePairs != null) for (final MemberValuePair pair : memberValuePairs) {
 			List<String> raws = new ArrayList<String>();
 			List<Object> expressionValues = new ArrayList<Object>();
 			List<Object> guesses = new ArrayList<Object>();
 			Expression[] expressions = null;
-			
+
 			char[] n = pair.name;
 			String mName = (n == null || n.length == 0) ? "value" : new String(pair.name);
 			final Expression rhs = pair.value;
@@ -1337,41 +1367,41 @@ public class EclipseHandlerUtil {
 				expressions = new Expression[] { rhs };
 			}
 			if (expressions != null) for (Expression ex : expressions) {
-				raws.add(ex.toString()); 
+				raws.add(ex.toString());
 				expressionValues.add(ex);
 				guesses.add(calculateValue(ex));
 			}
-			
+
 			final Expression[] exprs = expressions;
 			values.put(mName, new AnnotationValue(annotationNode, raws, expressionValues, guesses, true) {
 				@Override public void setError(String message, int valueIdx) {
 					Expression ex;
 					if (valueIdx == -1) ex = rhs;
 					else ex = exprs != null ? exprs[valueIdx] : null;
-					
+
 					if (ex == null) ex = annotation;
-					
+
 					int sourceStart = ex.sourceStart;
 					int sourceEnd = ex.sourceEnd;
-					
+
 					annotationNode.addError(message, sourceStart, sourceEnd);
 				}
-				
+
 				@Override public void setWarning(String message, int valueIdx) {
 					Expression ex;
 					if (valueIdx == -1) ex = rhs;
 					else ex = exprs != null ? exprs[valueIdx] : null;
-					
+
 					if (ex == null) ex = annotation;
-					
+
 					int sourceStart = ex.sourceStart;
 					int sourceEnd = ex.sourceEnd;
-					
+
 					annotationNode.addWarning(message, sourceStart, sourceEnd);
 				}
 			});
 		}
-		
+
 		for (Method m : type.getDeclaredMethods()) {
 			if (!Modifier.isPublic(m.getModifiers())) continue;
 			String name = m.getName();
@@ -1386,10 +1416,10 @@ public class EclipseHandlerUtil {
 				});
 			}
 		}
-		
+
 		return new AnnotationValues<A>(type, values, annotationNode);
 	}
-	
+
 	/**
 	 * Turns an {@code AccessLevel} instance into the flag bit used by eclipse.
 	 */
@@ -1409,33 +1439,33 @@ public class EclipseHandlerUtil {
 			return ClassFileConstants.AccPrivate;
 		}
 	}
-	
+
 	private static class GetterMethod {
 		private final char[] name;
 		private final TypeReference type;
-		
+
 		GetterMethod(char[] name, TypeReference type) {
 			this.name = name;
 			this.type = type;
 		}
 	}
-	
+
 	static void registerCreatedLazyGetter(FieldDeclaration field, char[] methodName, TypeReference returnType) {
 		if (isBoolean(returnType)) {
 			FieldDeclaration_booleanLazyGetter.set(field, true);
 		}
 	}
-	
+
 	public static boolean isBoolean(TypeReference typeReference) {
 		return nameEquals(typeReference.getTypeName(), "boolean") && typeReference.dimensions() == 0;
 	}
-	
+
 	private static GetterMethod findGetter(EclipseNode field) {
 		FieldDeclaration fieldDeclaration = (FieldDeclaration) field.get();
 		boolean forceBool = FieldDeclaration_booleanLazyGetter.get(fieldDeclaration);
 		TypeReference fieldType = fieldDeclaration.type;
 		boolean isBoolean = forceBool || isBoolean(fieldType);
-		
+
 		EclipseNode typeNode = field.up();
 		for (String potentialGetterName : toAllGetterNames(field, isBoolean)) {
 			for (EclipseNode potentialGetter : typeNode.down()) {
@@ -1450,11 +1480,11 @@ public class EclipseHandlerUtil {
 				return new GetterMethod(method.selector, method.returnType);
 			}
 		}
-		
+
 		// Check if the field has a @Getter annotation.
-		
+
 		boolean hasGetterAnnotation = false;
-		
+
 		for (EclipseNode child : field.down()) {
 			if (child.getKind() == Kind.ANNOTATION && annotationTypeMatches(Getter.class, child)) {
 				AnnotationValues<Getter> ann = createAnnotation(Getter.class, child);
@@ -1462,12 +1492,12 @@ public class EclipseHandlerUtil {
 				hasGetterAnnotation = true;
 			}
 		}
-		
+
 		// Check if the class has a @Getter annotation.
-		
+
 		if (!hasGetterAnnotation && HandleGetter.fieldQualifiesForGetterGeneration(field)) {
 			//Check if the class has @Getter or @Data annotation.
-			
+
 			EclipseNode containingType = field.up();
 			if (containingType != null) for (EclipseNode child : containingType.down()) {
 				if (child.getKind() == Kind.ANNOTATION && annotationTypeMatches(Data.class, child)) hasGetterAnnotation = true;
@@ -1478,20 +1508,20 @@ public class EclipseHandlerUtil {
 				}
 			}
 		}
-		
+
 		if (hasGetterAnnotation) {
 			String getterName = toGetterName(field, isBoolean);
 			if (getterName == null) return null;
 			return new GetterMethod(getterName.toCharArray(), fieldType);
 		}
-		
+
 		return null;
 	}
-	
+
 	static boolean lookForGetter(EclipseNode field, FieldAccess fieldAccess) {
 		if (fieldAccess == FieldAccess.GETTER) return true;
 		if (fieldAccess == FieldAccess.ALWAYS_FIELD) return false;
-		
+
 		// If @Getter(lazy = true) is used, then using it is mandatory.
 		for (EclipseNode child : field.down()) {
 			if (child.getKind() != Kind.ANNOTATION) continue;
@@ -1502,28 +1532,28 @@ public class EclipseHandlerUtil {
 		}
 		return false;
 	}
-	
+
 	static TypeReference getFieldType(EclipseNode field, FieldAccess fieldAccess) {
 		if (field.get() instanceof MethodDeclaration) return ((MethodDeclaration) field.get()).returnType;
-		
+
 		boolean lookForGetter = lookForGetter(field, fieldAccess);
-		
+
 		GetterMethod getter = lookForGetter ? findGetter(field) : null;
 		if (getter == null) {
 			return ((FieldDeclaration) field.get()).type;
 		}
-		
+
 		return getter.type;
 	}
-	
+
 	static Expression createFieldAccessor(EclipseNode field, FieldAccess fieldAccess, ASTNode source) {
 		int pS = source == null ? 0 : source.sourceStart, pE = source == null ? 0 : source.sourceEnd;
 		long p = (long) pS << 32 | pE;
-		
+
 		boolean lookForGetter = lookForGetter(field, fieldAccess);
-		
+
 		GetterMethod getter = lookForGetter ? findGetter(field) : null;
-		
+
 		if (getter == null) {
 			FieldDeclaration fieldDecl = (FieldDeclaration)field.get();
 			FieldReference ref = new FieldReference(fieldDecl.name, p);
@@ -1539,14 +1569,14 @@ public class EclipseHandlerUtil {
 			} else {
 				ref.receiver = new ThisReference(pS, pE);
 			}
-			
+
 			if (source != null) {
 				setGeneratedBy(ref, source);
 				setGeneratedBy(ref.receiver, source);
 			}
 			return ref;
 		}
-		
+
 		MessageSend call = new MessageSend();
 		setGeneratedBy(call, source);
 		call.sourceStart = pS; call.statementEnd = call.sourceEnd = pE;
@@ -1555,28 +1585,28 @@ public class EclipseHandlerUtil {
 		call.selector = getter.name;
 		return call;
 	}
-	
+
 	static Expression createFieldAccessor(EclipseNode field, FieldAccess fieldAccess, ASTNode source, char[] receiver) {
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		long p = (long)pS << 32 | pE;
-		
+
 		boolean lookForGetter = lookForGetter(field, fieldAccess);
-		
+
 		GetterMethod getter = lookForGetter ? findGetter(field) : null;
-		
+
 		if (getter == null) {
 			NameReference ref;
-			
+
 			char[][] tokens = new char[2][];
 			tokens[0] = receiver;
 			tokens[1] = field.getName().toCharArray();
 			long[] poss = {p, p};
-			
+
 			ref = new QualifiedNameReference(tokens, poss, pS, pE);
 			setGeneratedBy(ref, source);
 			return ref;
 		}
-		
+
 		MessageSend call = new MessageSend();
 		setGeneratedBy(call, source);
 		call.sourceStart = pS; call.statementEnd = call.sourceEnd = pE;
@@ -1585,11 +1615,11 @@ public class EclipseHandlerUtil {
 		call.selector = getter.name;
 		return call;
 	}
-	
+
 	static Expression createMethodAccessor(EclipseNode method, ASTNode source) {
 		int pS = source == null ? 0 : source.sourceStart, pE = source == null ? 0 : source.sourceEnd;
 		long p = (long) pS << 32 | pE;
-		
+
 		MethodDeclaration methodDecl = (MethodDeclaration) method.get();
 		MessageSend call = new MessageSend();
 		setGeneratedBy(call, source);
@@ -1604,15 +1634,15 @@ public class EclipseHandlerUtil {
 				setGeneratedBy(call.receiver, source);
 			}
 		}
-		
+
 		call.selector = methodDecl.selector;
 		return call;
 	}
-	
+
 	static Expression createMethodAccessor(EclipseNode method, ASTNode source, char[] receiver) {
 		int pS = source == null ? 0 : source.sourceStart, pE = source == null ? 0 : source.sourceEnd;
 		long p = (long) pS << 32 | pE;
-		
+
 		MethodDeclaration methodDecl = (MethodDeclaration) method.get();
 		MessageSend call = new MessageSend();
 		setGeneratedBy(call, source);
@@ -1622,12 +1652,12 @@ public class EclipseHandlerUtil {
 		call.selector = methodDecl.selector;
 		return call;
 	}
-	
+
 	/** Serves as return value for the methods that check for the existence of fields and methods. */
 	public enum MemberExistsResult {
 		NOT_EXISTS, EXISTS_BY_LOMBOK, EXISTS_BY_USER;
 	}
-	
+
 	/**
 	 * Translates the given field into all possible getter names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllGetterNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -1635,7 +1665,7 @@ public class EclipseHandlerUtil {
 	public static List<String> toAllGetterNames(EclipseNode field, boolean isBoolean) {
 		return HandlerUtil.toAllGetterNames(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * Translates the given field into all possible getter names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllGetterNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -1643,25 +1673,25 @@ public class EclipseHandlerUtil {
 	public static List<String> toAllGetterNames(EclipseNode field, boolean isBoolean, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toAllGetterNames(field.getAst(), accessors, field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * @return the likely getter name for the stated field. (e.g. private boolean foo; to isFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toGetterName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toGetterName(EclipseNode field, boolean isBoolean) {
 		return HandlerUtil.toGetterName(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * @return the likely getter name for the stated field. (e.g. private boolean foo; to isFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toGetterName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toGetterName(EclipseNode field, boolean isBoolean, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toGetterName(field.getAst(), accessors, field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * Translates the given field into all possible setter names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllSetterNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -1669,7 +1699,7 @@ public class EclipseHandlerUtil {
 	public static java.util.List<String> toAllSetterNames(EclipseNode field, boolean isBoolean) {
 		return HandlerUtil.toAllSetterNames(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * Translates the given field into all possible setter names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllSetterNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -1677,25 +1707,25 @@ public class EclipseHandlerUtil {
 	public static java.util.List<String> toAllSetterNames(EclipseNode field, boolean isBoolean, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toAllSetterNames(field.getAst(), accessors, field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * @return the likely setter name for the stated field. (e.g. private boolean foo; to setFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toSetterName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toSetterName(EclipseNode field, boolean isBoolean) {
 		return HandlerUtil.toSetterName(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * @return the likely setter name for the stated field. (e.g. private boolean foo; to setFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toSetterName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toSetterName(EclipseNode field, boolean isBoolean, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toSetterName(field.getAst(), accessors, field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * Translates the given field into all possible with names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllWithNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -1703,7 +1733,7 @@ public class EclipseHandlerUtil {
 	public static java.util.List<String> toAllWithNames(EclipseNode field, boolean isBoolean) {
 		return HandlerUtil.toAllWithNames(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * Translates the given field into all possible with names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllWithNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -1711,7 +1741,7 @@ public class EclipseHandlerUtil {
 	public static java.util.List<String> toAllWithNames(EclipseNode field, boolean isBoolean, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toAllWithNames(field.getAst(), accessors, field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * Translates the given field into all possible withBy names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllWithByNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -1719,7 +1749,7 @@ public class EclipseHandlerUtil {
 	public static java.util.List<String> toAllWithByNames(EclipseNode field, boolean isBoolean) {
 		return HandlerUtil.toAllWithByNames(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * Translates the given field into all possible withBy names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllWithByNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -1727,43 +1757,43 @@ public class EclipseHandlerUtil {
 	public static java.util.List<String> toAllWithByNames(EclipseNode field, boolean isBoolean, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toAllWithByNames(field.getAst(), accessors, field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * @return the likely with name for the stated field. (e.g. private boolean foo; to withFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toWithName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toWithName(EclipseNode field, boolean isBoolean) {
 		return HandlerUtil.toWithName(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * @return the likely with name for the stated field. (e.g. private boolean foo; to withFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toWithName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toWithName(EclipseNode field, boolean isBoolean, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toWithName(field.getAst(), accessors, field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * @return the likely withBy name for the stated field. (e.g. private boolean foo; to withFooBy).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toWithByName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toWithByName(EclipseNode field, boolean isBoolean) {
 		return HandlerUtil.toWithByName(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * @return the likely withBy name for the stated field. (e.g. private boolean foo; to withFooBy).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toWithByName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toWithByName(EclipseNode field, boolean isBoolean, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toWithByName(field.getAst(), accessors, field.getName(), isBoolean);
 	}
-	
+
 	/**
 	 * When generating a setter/getter/wither, should it be made final?
 	 */
@@ -1779,7 +1809,7 @@ public class EclipseHandlerUtil {
 		if ((((FieldDeclaration) field.get()).modifiers & ClassFileConstants.AccStatic) != 0) return false;
 		return shouldReturnThis0(accessors, field.getAst());
 	}
-	
+
 	/**
 	 * Checks if the field should be included in operations that work on 'all' fields:
 	 *    If the field is static, or starts with a '$', or is actually an enum constant, 'false' is returned, indicating you should skip it.
@@ -1787,23 +1817,23 @@ public class EclipseHandlerUtil {
 	public static boolean filterField(FieldDeclaration declaration) {
 		return filterField(declaration, true);
 	}
-	
+
 	public static boolean filterField(FieldDeclaration declaration, boolean skipStatic) {
 		// Skip the fake fields that represent enum constants.
 		if (declaration.initialization instanceof AllocationExpression &&
 				((AllocationExpression) declaration.initialization).enumConstant != null) return false;
-		
+
 		if (declaration.type == null) return false;
-		
+
 		// Skip fields that start with $
 		if (declaration.name.length > 0 && declaration.name[0] == '$') return false;
-		
+
 		// Skip static fields.
 		if (skipStatic && (declaration.modifiers & ClassFileConstants.AccStatic) != 0) return false;
-		
+
 		return true;
 	}
-	
+
 	public static char[] removePrefixFromField(EclipseNode field) {
 		List<String> prefixes = null;
 		for (EclipseNode node : field.down()) {
@@ -1813,7 +1843,7 @@ public class EclipseHandlerUtil {
 				break;
 			}
 		}
-		
+
 		if (prefixes == null) {
 			EclipseNode current = field.up();
 			outer:
@@ -1828,26 +1858,26 @@ public class EclipseHandlerUtil {
 				current = current.up();
 			}
 		}
-		
+
 		if (prefixes == null) prefixes = field.getAst().readConfiguration(ConfigurationKeys.ACCESSORS_PREFIX);
 		if (!prefixes.isEmpty()) {
 			CharSequence newName = removePrefix(field.getName(), prefixes);
 			if (newName != null) return newName.toString().toCharArray();
 		}
-		
+
 		return ((FieldDeclaration) field.get()).name;
 	}
-	
+
 	public static AnnotationValues<Accessors> getAccessorsForField(EclipseNode field) {
 		AnnotationValues<Accessors> values = null;
-		
+
 		for (EclipseNode node : field.down()) {
 			if (annotationTypeMatches(Accessors.class, node)) {
 				values = createAnnotation(Accessors.class, node);
 				break;
 			}
 		}
-		
+
 		EclipseNode current = field.up();
 		while (current != null) {
 			for (EclipseNode node : current.down()) {
@@ -1858,19 +1888,19 @@ public class EclipseHandlerUtil {
 			}
 			current = current.up();
 		}
-		
+
 		return values == null ? AnnotationValues.of(Accessors.class, field) : values;
 	}
-	
+
 	public static EclipseNode upToTypeNode(EclipseNode node) {
 		if (node == null) throw new NullPointerException("node");
 		while (node != null && !(node.get() instanceof TypeDeclaration)) node = node.up();
 		return node;
 	}
-	
+
 	/**
 	 * Checks if there is a field with the provided name.
-	 * 
+	 *
 	 * @param fieldName the field name to check for.
 	 * @param node Any node that represents the Type (TypeDeclaration) to look in, or any child node thereof.
 	 */
@@ -1888,21 +1918,21 @@ public class EclipseHandlerUtil {
 				}
 			}
 		}
-		
+
 		return MemberExistsResult.NOT_EXISTS;
 	}
-	
+
 	/**
 	 * Wrapper for {@link #methodExists(String, EclipseNode, boolean, int)} with {@code caseSensitive} = {@code true}.
 	 */
 	public static MemberExistsResult methodExists(String methodName, EclipseNode node, int params) {
 		return methodExists(methodName, node, true, params);
 	}
-	
+
 	/**
 	 * Checks if there is a method with the provided name. In case of multiple methods (overloading), only
 	 * the first method decides if EXISTS_BY_USER or EXISTS_BY_LOMBOK is returned.
-	 * 
+	 *
 	 * @param methodName the method name to check for.
 	 * @param node Any node that represents the Type (TypeDeclaration) to look in, or any child node thereof.
 	 * @param caseSensitive If the search should be case sensitive.
@@ -1912,7 +1942,7 @@ public class EclipseHandlerUtil {
 		while (node != null && !(node.get() instanceof TypeDeclaration)) {
 			node = node.up();
 		}
-		
+
 		if (node != null && node.get() instanceof TypeDeclaration) {
 			TypeDeclaration typeDecl = (TypeDeclaration)node.get();
 			if (typeDecl.methods != null) top: for (AbstractMethodDeclaration def : typeDecl.methods) {
@@ -1933,33 +1963,33 @@ public class EclipseHandlerUtil {
 									maxArgs = minArgs;
 								}
 							}
-							
+
 							if (params < minArgs || params > maxArgs) continue;
 						}
-						
-						
+
+
 						if (isTolerate(node, def)) continue top;
-						
+
 						return getGeneratedBy(def) == null ? MemberExistsResult.EXISTS_BY_USER : MemberExistsResult.EXISTS_BY_LOMBOK;
 					}
 				}
 			}
 		}
-		
+
 		return MemberExistsResult.NOT_EXISTS;
 	}
-	
+
 	public static boolean isTolerate(EclipseNode node, AbstractMethodDeclaration def) {
 		if (def.annotations != null) for (Annotation anno : def.annotations) {
 			if (typeMatches(Tolerate.class, node, anno.type)) return true;
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Checks if there is a (non-default) constructor. In case of multiple constructors (overloading), only
 	 * the first constructor decides if EXISTS_BY_USER or EXISTS_BY_LOMBOK is returned.
-	 * 
+	 *
 	 * @param node Any node that represents the Type (TypeDeclaration) to look in, or any child node thereof.
 	 */
 	public static MemberExistsResult constructorExists(EclipseNode node) {
@@ -1973,10 +2003,10 @@ public class EclipseHandlerUtil {
 				return getGeneratedBy(def) == null ? MemberExistsResult.EXISTS_BY_USER : MemberExistsResult.EXISTS_BY_LOMBOK;
 			}
 		}
-		
+
 		return MemberExistsResult.NOT_EXISTS;
 	}
-	
+
 	/**
 	 * Inserts a field into an existing type. The type must represent a {@code TypeDeclaration}.
 	 * The field carries the &#64;{@link SuppressWarnings}("all") annotation.
@@ -1986,13 +2016,13 @@ public class EclipseHandlerUtil {
 		field.annotations = addGenerated(type, field, field.annotations);
 		return injectField(type, field);
 	}
-	
+
 	/**
 	 * Inserts a field into an existing type. The type must represent a {@code TypeDeclaration}.
 	 */
 	public static EclipseNode injectField(EclipseNode type, FieldDeclaration field) {
 		TypeDeclaration parent = (TypeDeclaration) type.get();
-		
+
 		if (parent.fields == null) {
 			parent.fields = new FieldDeclaration[1];
 			parent.fields[0] = field;
@@ -2010,20 +2040,20 @@ public class EclipseHandlerUtil {
 			newArray[index] = field;
 			parent.fields = newArray;
 		}
-		
+
 		if (isEnumConstant(field) || (field.modifiers & Modifier.STATIC) != 0) {
 			if (!hasClinit(parent)) {
 				parent.addClinit();
 			}
 		}
-		
+
 		return type.add(field, Kind.FIELD);
 	}
-	
+
 	public static boolean isEnumConstant(final FieldDeclaration field) {
 		return ((field.initialization instanceof AllocationExpression) && (((AllocationExpression) field.initialization).enumConstant == field));
 	}
-	
+
 	/**
 	 * Inserts a method into an existing type. The type must represent a {@code TypeDeclaration}.
 	 */
@@ -2031,7 +2061,7 @@ public class EclipseHandlerUtil {
 		method.annotations = addSuppressWarningsAll(type, method, method.annotations);
 		method.annotations = addGenerated(type, method, method.annotations);
 		TypeDeclaration parent = (TypeDeclaration) type.get();
-		
+
 		if (parent.methods == null) {
 			parent.methods = new AbstractMethodDeclaration[1];
 			parent.methods[0] = method;
@@ -2041,12 +2071,12 @@ public class EclipseHandlerUtil {
 					if (parent.methods[i] instanceof ConstructorDeclaration &&
 							(parent.methods[i].bits & ASTNode.IsDefaultConstructor) != 0) {
 						EclipseNode tossMe = type.getNodeFor(parent.methods[i]);
-						
+
 						AbstractMethodDeclaration[] withoutGeneratedConstructor = new AbstractMethodDeclaration[parent.methods.length - 1];
-						
+
 						System.arraycopy(parent.methods, 0, withoutGeneratedConstructor, 0, i);
 						System.arraycopy(parent.methods, i + 1, withoutGeneratedConstructor, i, parent.methods.length - i - 1);
-						
+
 						parent.methods = withoutGeneratedConstructor;
 						if (tossMe != null) tossMe.up().removeChild(tossMe);
 						break;
@@ -2060,13 +2090,13 @@ public class EclipseHandlerUtil {
 			newArray[parent.methods.length] = method;
 			parent.methods = newArray;
 		}
-		
+
 		return type.add(method, Kind.METHOD);
 	}
-	
+
 	/**
 	 * Adds an inner type (class, interface, enum) to the given type. Cannot inject top-level types.
-	 * 
+	 *
 	 * @param typeNode parent type to inject new type into
 	 * @param type New type (class, interface, etc) to inject.
 	 */
@@ -2074,7 +2104,7 @@ public class EclipseHandlerUtil {
 		type.annotations = addSuppressWarningsAll(typeNode, type, type.annotations);
 		type.annotations = addGenerated(typeNode, type, type.annotations);
 		TypeDeclaration parent = (TypeDeclaration) typeNode.get();
-		
+
 		if (parent.memberTypes == null) {
 			parent.memberTypes = new TypeDeclaration[] { type };
 		} else {
@@ -2083,10 +2113,10 @@ public class EclipseHandlerUtil {
 			newArray[parent.memberTypes.length] = type;
 			parent.memberTypes = newArray;
 		}
-		
+
 		return typeNode.add(type, Kind.TYPE);
 	}
-	
+
 	static final char[] ALL = "all".toCharArray();
 	static final char[] UNCHECKED = "unchecked".toCharArray();
 	private static final char[] JUSTIFICATION = "justification".toCharArray();
@@ -2096,22 +2126,22 @@ public class EclipseHandlerUtil {
 	private static final char[][] JAKARTA_ANNOTATION_GENERATED = Eclipse.fromQualifiedName("jakarta.annotation.Generated");
 	private static final char[][] LOMBOK_GENERATED = Eclipse.fromQualifiedName("lombok.Generated");
 	private static final char[][] EDU_UMD_CS_FINDBUGS_ANNOTATIONS_SUPPRESSFBWARNINGS = Eclipse.fromQualifiedName("edu.umd.cs.findbugs.annotations.SuppressFBWarnings");
-	
+
 	public static Annotation[] addSuppressWarningsAll(EclipseNode node, ASTNode source, Annotation[] originalAnnotationArray) {
 		Annotation[] anns = originalAnnotationArray;
-		
+
 		if (!Boolean.FALSE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_SUPPRESSWARNINGS_ANNOTATIONS))) {
 			anns = addAnnotation(source, anns, TypeConstants.JAVA_LANG_SUPPRESSWARNINGS, new StringLiteral(ALL, 0, 0, 0));
 		}
-		
+
 		if (Boolean.TRUE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_FINDBUGS_SUPPRESSWARNINGS_ANNOTATIONS))) {
 			MemberValuePair mvp = new MemberValuePair(JUSTIFICATION, 0, 0, new StringLiteral(GENERATED_CODE, 0, 0, 0));
 			anns = addAnnotation(source, anns, EDU_UMD_CS_FINDBUGS_ANNOTATIONS_SUPPRESSFBWARNINGS, mvp);
 		}
-		
+
 		return anns;
 	}
-	
+
 	public static Annotation[] addGenerated(EclipseNode node, ASTNode source, Annotation[] originalAnnotationArray) {
 		Annotation[] result = originalAnnotationArray;
 		if (HandlerUtil.shouldAddGenerated(node)) {
@@ -2125,26 +2155,26 @@ public class EclipseHandlerUtil {
 		}
 		return result;
 	}
-	
+
 	static Annotation[] addAnnotation(ASTNode source, Annotation[] originalAnnotationArray, char[][] annotationTypeFqn) {
 		return addAnnotation(source, originalAnnotationArray, annotationTypeFqn, (ASTNode[]) null);
 	}
-	
+
 	static Annotation[] addAnnotation(ASTNode source, Annotation[] originalAnnotationArray, char[][] annotationTypeFqn, ASTNode... args) {
 		char[] simpleName = annotationTypeFqn[annotationTypeFqn.length - 1];
-		
+
 		if (originalAnnotationArray != null) for (Annotation ann : originalAnnotationArray) {
 			if (ann.type instanceof QualifiedTypeReference) {
 				char[][] t = ((QualifiedTypeReference) ann.type).tokens;
 				if (Arrays.deepEquals(t, annotationTypeFqn)) return originalAnnotationArray;
 			}
-			
+
 			if (ann.type instanceof SingleTypeReference) {
 				char[] lastToken = ((SingleTypeReference) ann.type).token;
 				if (Arrays.equals(lastToken, simpleName)) return originalAnnotationArray;
 			}
 		}
-		
+
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		TypeReference qualifiedType = generateQualifiedTypeRef(source, annotationTypeFqn);
 		Annotation ann;
@@ -2182,7 +2212,7 @@ public class EclipseHandlerUtil {
 		newAnnotationArray[originalAnnotationArray.length] = ann;
 		return newAnnotationArray;
 	}
-	
+
 	public static void addCheckerFrameworkReturnsReceiver(TypeReference returnType, ASTNode source, CheckerFrameworkVersion cfv) {
 		if (cfv.generateReturnsReceiver()) {
 			Annotation rrAnn = generateNamedAnnotation(source, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER);
@@ -2191,7 +2221,7 @@ public class EclipseHandlerUtil {
 			returnType.annotations[levels-1] = new Annotation[] {rrAnn};
 		}
 	}
-	
+
 	private static boolean arrayHasOnlyElementsOfType(Object[] array, Class<?> clazz) {
 		for (Object element : array) {
 			if (!clazz.isInstance(element))
@@ -2207,55 +2237,55 @@ public class EclipseHandlerUtil {
 	public static Statement generateNullCheck(TypeReference type, char[] variable, EclipseNode sourceNode, String customMessage) {
 		NullCheckExceptionType exceptionType = sourceNode.getAst().readConfiguration(ConfigurationKeys.NON_NULL_EXCEPTION_TYPE);
 		if (exceptionType == null) exceptionType = NullCheckExceptionType.NULL_POINTER_EXCEPTION;
-		
+
 		ASTNode source = sourceNode.get();
-		
+
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		long p = (long) pS << 32 | pE;
-		
+
 		if (type != null && isPrimitive(type)) return null;
 		SingleNameReference varName = new SingleNameReference(variable, p);
 		setGeneratedBy(varName, source);
-		
+
 		StringLiteral message = new StringLiteral(exceptionType.toExceptionMessage(new String(variable), customMessage).toCharArray(), pS, pE, 0);
 		setGeneratedBy(message, source);
-		
+
 		LombokImmutableList<String> method = exceptionType.getMethod();
 		if (method != null) {
-			
+
 			MessageSend invocation = new MessageSend();
 			invocation.sourceStart = pS; invocation.sourceEnd = pE;
 			setGeneratedBy(invocation, source);
-			
+
 			char[][] utilityTypeName = new char[method.size() - 1][];
 			for (int i = 0; i < method.size() - 1; i++) {
 				utilityTypeName[i] = method.get(i).toCharArray();
 			}
-			
+
 			invocation.receiver = new QualifiedNameReference(utilityTypeName, new long[method.size() - 1], pS, pE);
 			setGeneratedBy(invocation.receiver, source);
 			invocation.selector = method.get(method.size() - 1).toCharArray();
 			invocation.arguments = new Expression[] {varName, message};
 			return invocation;
 		}
-		
+
 		AllocationExpression exception = new AllocationExpression();
 		setGeneratedBy(exception, source);
-		
+
 		NullLiteral nullLiteral = new NullLiteral(pS, pE);
 		setGeneratedBy(nullLiteral, source);
-		
-		int equalOperator = exceptionType == NullCheckExceptionType.ASSERTION ? OperatorIds.NOT_EQUAL : OperatorIds.EQUAL_EQUAL; 
+
+		int equalOperator = exceptionType == NullCheckExceptionType.ASSERTION ? OperatorIds.NOT_EQUAL : OperatorIds.EQUAL_EQUAL;
 		EqualExpression equalExpression = new EqualExpression(varName, nullLiteral, equalOperator);
 		equalExpression.sourceStart = pS; equalExpression.statementEnd = equalExpression.sourceEnd = pE;
 		setGeneratedBy(equalExpression, source);
-		
+
 		if (exceptionType == NullCheckExceptionType.ASSERTION) {
 			Statement assertStatement = new AssertStatement(message, equalExpression, pS);
 			setGeneratedBy(assertStatement, source);
 			return assertStatement;
 		}
-		
+
 		String exceptionTypeStr = exceptionType.getExceptionType();
 		int partCount = 1;
 		for (int i = 0; i < exceptionTypeStr.length(); i++) if (exceptionTypeStr.charAt(i) == '.') partCount++;
@@ -2264,10 +2294,10 @@ public class EclipseHandlerUtil {
 		exception.type = new QualifiedTypeReference(fromQualifiedName(exceptionTypeStr), ps);
 		setGeneratedBy(exception.type, source);
 		exception.arguments = new Expression[] {message};
-		
+
 		ThrowStatement throwStatement = new ThrowStatement(exception, pS, pE);
 		setGeneratedBy(throwStatement, source);
-		
+
 		Block throwBlock = new Block(0);
 		throwBlock.statements = new Statement[] {throwStatement};
 		throwBlock.sourceStart = pS; throwBlock.sourceEnd = pE;
@@ -2276,17 +2306,17 @@ public class EclipseHandlerUtil {
 		setGeneratedBy(ifStatement, source);
 		return ifStatement;
 	}
-	
+
 	/**
 	 * Generates a new statement that checks if the given variable is null, and if so, throws a specified exception with the
 	 * variable name as message.
-	 * 
+	 *
 	 * @param exName The name of the exception to throw; normally {@code java.lang.NullPointerException}.
 	 */
 	public static Statement generateNullCheck(AbstractVariableDeclaration variable, EclipseNode sourceNode, String customMessage) {
 		return generateNullCheck(variable.type, variable.name, sourceNode, customMessage);
 	}
-	
+
 	/**
 	 * Create an annotation of the given name, and is marked as being generated by the given source.
 	 */
@@ -2301,13 +2331,13 @@ public class EclipseHandlerUtil {
 		setGeneratedBy(ann, source);
 		return ann;
 	}
-	
+
 	/**
 	 * Given a list of field names and a node referring to a type, finds each name in the list that does not match a field within the type.
 	 */
 	public static List<Integer> createListOfNonExistentFields(List<String> list, EclipseNode type, boolean excludeStandard, boolean excludeTransient) {
 		boolean[] matched = new boolean[list.size()];
-		
+
 		for (EclipseNode child : type.down()) {
 			if (list.isEmpty()) break;
 			if (child.getKind() != Kind.FIELD) continue;
@@ -2319,20 +2349,20 @@ public class EclipseHandlerUtil {
 			int idx = list.indexOf(child.getName());
 			if (idx > -1) matched[idx] = true;
 		}
-		
+
 		List<Integer> problematic = new ArrayList<Integer>();
 		for (int i = 0 ; i < list.size() ; i++) {
 			if (!matched[i]) problematic.add(i);
 		}
-		
+
 		return problematic;
 	}
-	
+
 	/**
 	 * In eclipse 3.7+, the CastExpression constructor was changed from a really weird version to
 	 * a less weird one. Unfortunately that means we need to use reflection as we want to be compatible
 	 * with eclipse versions before 3.7 and 3.7+.
-	 * 
+	 *
 	 * @param ref The {@code foo} in {@code (String)foo}.
 	 * @param castTo The {@code String} in {@code (String)foo}.
 	 */
@@ -2343,7 +2373,7 @@ public class EclipseHandlerUtil {
 				result = castExpressionConstructor.newInstance(ref, castTo);
 			} else {
 				Expression castToConverted = castTo;
-				
+
 				if (castTo.getClass() == SingleTypeReference.class && !isPrimitive(castTo)) {
 					SingleTypeReference str = (SingleTypeReference) castTo;
 					//Why a SingleNameReference instead of a SingleTypeReference you ask? I don't know. It seems dumb. Ask the ecj guys.
@@ -2359,7 +2389,7 @@ public class EclipseHandlerUtil {
 					castToConverted.bits = (castToConverted.bits & ~Binding.VARIABLE) | Binding.TYPE;
 					setGeneratedBy(castToConverted, source);
 				}
-				
+
 				result = castExpressionConstructor.newInstance(ref, castToConverted);
 			}
 		} catch (InvocationTargetException e) {
@@ -2369,35 +2399,35 @@ public class EclipseHandlerUtil {
 		} catch (InstantiationException e) {
 			throw Lombok.sneakyThrow(e);
 		}
-		
+
 		result.sourceStart = source.sourceStart;
 		result.sourceEnd = source.sourceEnd;
 		result.statementEnd = source.sourceEnd;
-		
+
 		setGeneratedBy(result, source);
 		return result;
 	}
-	
+
 	private static final Constructor<CastExpression> castExpressionConstructor;
 	private static final boolean castExpressionConstructorIsTypeRefBased;
-	
+
 	static {
 		Constructor<?> constructor = null;
 		for (Constructor<?> ctor : CastExpression.class.getConstructors()) {
 			if (ctor.getParameterTypes().length != 2) continue;
 			constructor = ctor;
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		Constructor<CastExpression> castExpressionConstructor_ = (Constructor<CastExpression>) constructor;
 		castExpressionConstructor = castExpressionConstructor_;
-		
+
 		castExpressionConstructorIsTypeRefBased =
 				(castExpressionConstructor.getParameterTypes()[1] == TypeReference.class);
 	}
-	
+
 	/**
-	 * In eclipse 3.7+, IntLiterals are created using a factory-method 
+	 * In eclipse 3.7+, IntLiterals are created using a factory-method
 	 * Unfortunately that means we need to use reflection as we want to be compatible
 	 * with eclipse versions before 3.7.
 	 */
@@ -2409,24 +2439,24 @@ public class EclipseHandlerUtil {
 		} else {
 			result = (IntLiteral) Permit.invokeSneaky(intLiteralFactoryMethod, null, token, pS, pE);
 		}
-		
+
 		if (source != null) setGeneratedBy(result, source);
 		return result;
 	}
-	
+
 	private static final Constructor<IntLiteral> intLiteralConstructor;
 	private static final Method intLiteralFactoryMethod;
-	
+
 	static {
 		Class<?>[] parameterTypes = {char[].class, int.class, int.class};
 		Constructor<IntLiteral> intLiteralConstructor_ = null;
 		Method intLiteralFactoryMethod_ = null;
-		try { 
+		try {
 			intLiteralConstructor_ = Permit.getConstructor(IntLiteral.class, parameterTypes);
 		} catch (Throwable ignore) {
 			// probably eclipse 3.7++
 		}
-		try { 
+		try {
 			intLiteralFactoryMethod_ = Permit.getMethod(IntLiteral.class, "buildIntLiteral", parameterTypes);
 		} catch (Throwable ignore) {
 			// probably eclipse versions before 3.7
@@ -2434,13 +2464,13 @@ public class EclipseHandlerUtil {
 		intLiteralConstructor = intLiteralConstructor_;
 		intLiteralFactoryMethod = intLiteralFactoryMethod_;
 	}
-	
+
 	private static boolean isAllValidOnXCharacters(char[] in) {
 		if (in == null || in.length == 0) return false;
 		for (char c : in) if (c != '_' && c != 'X' && c != 'x' && c != '$') return false;
 		return true;
 	}
-	
+
 	public static void addError(String errorName, EclipseNode node) {
 		if (node.getLatestJavaSpecSupported() < 8) {
 			node.addError("The correct format is " + errorName + "_={@SomeAnnotation, @SomeOtherAnnotation})");
@@ -2448,7 +2478,7 @@ public class EclipseHandlerUtil {
 			node.addError("The correct format is " + errorName + "=@__({@SomeAnnotation, @SomeOtherAnnotation}))");
 		}
 	}
-	
+
 	public static List<Annotation> unboxAndRemoveAnnotationParameter(Annotation annotation, String annotationName, String errorName, EclipseNode errorNode) {
 		if ("value".equals(annotationName)) {
 			// We can't unbox this, because SingleMemberAnnotation REQUIRES a value, and this method
@@ -2463,14 +2493,14 @@ public class EclipseHandlerUtil {
 			// CompletionOnAnnotationMemberValuePair from triggering this handler.
 			return Collections.emptyList();
 		}
-		
+
 		NormalAnnotation normalAnnotation = (NormalAnnotation) annotation;
 		MemberValuePair[] pairs = normalAnnotation.memberValuePairs;
-		
+
 		if (pairs == null) return Collections.emptyList();
-		
+
 		char[] nameAsCharArray = annotationName.toCharArray();
-		
+
 		top:
 		for (int i = 0; i < pairs.length; i++) {
 			boolean allowRaw;
@@ -2492,9 +2522,9 @@ public class EclipseHandlerUtil {
 			normalAnnotation.memberValuePairs = newPairs;
 			// We have now removed the annotation parameter and stored the value,
 			// which we must now unbox. It's either annotations, or @__(annotations).
-			
+
 			Expression content = null;
-			
+
 			if (value instanceof ArrayInitializer) {
 				if (!allowRaw) {
 					addError(errorName, errorNode);
@@ -2532,12 +2562,12 @@ public class EclipseHandlerUtil {
 					}
 				}
 			}
-			
+
 			if (content == null) {
 				addError(errorName, errorNode);
 				return Collections.emptyList();
 			}
-			
+
 			if (content instanceof Annotation) {
 				return Collections.singletonList((Annotation) content);
 			} else if (content instanceof ArrayInitializer) {
@@ -2556,18 +2586,18 @@ public class EclipseHandlerUtil {
 				return Collections.emptyList();
 			}
 		}
-		
+
 		return Collections.emptyList();
 	}
-	
+
 	public static NameReference createNameReference(String name, Annotation source) {
 		return generateQualifiedNameRef(source, fromQualifiedName(name));
 	}
-	
+
 	private static long[] copy(long[] array) {
 		return array == null ? null : array.clone();
 	}
-	
+
 	public static <T> T[] concat(T[] first, T[] second, Class<T> type) {
 		if (first == null)
 			return second;
@@ -2582,12 +2612,12 @@ public class EclipseHandlerUtil {
 		System.arraycopy(second, 0, result, first.length, second.length);
 		return result;
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	private static <T> T[] newArray(Class<T> type, int length) {
 		return (T[]) Array.newInstance(type, length);
 	}
-	
+
 	public static boolean isDirectDescendantOfObject(EclipseNode typeNode) {
 		if (!(typeNode.get() instanceof TypeDeclaration)) throw new IllegalArgumentException("not a type node");
 		TypeDeclaration typeDecl = (TypeDeclaration) typeNode.get();
@@ -2595,51 +2625,51 @@ public class EclipseHandlerUtil {
 		String p = typeDecl.superclass.toString();
 		return p.equals("Object") || p.equals("java.lang.Object");
 	}
-	
+
 	public static void createRelevantNullableAnnotation(EclipseNode typeNode, MethodDeclaration mth) {
 		NullAnnotationLibrary lib = typeNode.getAst().readConfiguration(ConfigurationKeys.ADD_NULL_ANNOTATIONS);
 		if (lib == null) return;
-		
+
 		applyAnnotationToMethodDecl(typeNode, mth, lib.getNullableAnnotation(), lib.isTypeUse());
 	}
-	
+
 	public static void createRelevantNonNullAnnotation(EclipseNode typeNode, MethodDeclaration mth) {
 		NullAnnotationLibrary lib = typeNode.getAst().readConfiguration(ConfigurationKeys.ADD_NULL_ANNOTATIONS);
 		if (lib == null) return;
-		
+
 		applyAnnotationToMethodDecl(typeNode, mth, lib.getNonNullAnnotation(), lib.isTypeUse());
 	}
-	
+
 	public static void createRelevantNullableAnnotation(EclipseNode typeNode, Argument arg, MethodDeclaration mth) {
 		NullAnnotationLibrary lib = typeNode.getAst().readConfiguration(ConfigurationKeys.ADD_NULL_ANNOTATIONS);
 		if (lib == null) return;
-		
+
 		applyAnnotationToVarDecl(typeNode, arg, mth, lib.getNullableAnnotation(), lib.isTypeUse());
 	}
-	
+
 	public static void createRelevantNullableAnnotation(EclipseNode typeNode, Argument arg, MethodDeclaration mth, List<NullAnnotationLibrary> applied) {
 		NullAnnotationLibrary lib = typeNode.getAst().readConfiguration(ConfigurationKeys.ADD_NULL_ANNOTATIONS);
 		if (lib == null || applied.contains(lib)) return;
-		
+
 		applyAnnotationToVarDecl(typeNode, arg, mth, lib.getNullableAnnotation(), lib.isTypeUse());
 	}
-	
+
 	public static void createRelevantNonNullAnnotation(EclipseNode typeNode, Argument arg, MethodDeclaration mth) {
 		NullAnnotationLibrary lib = typeNode.getAst().readConfiguration(ConfigurationKeys.ADD_NULL_ANNOTATIONS);
 		if (lib == null) return;
-		
+
 		applyAnnotationToVarDecl(typeNode, arg, mth, lib.getNonNullAnnotation(), lib.isTypeUse());
 	}
-	
+
 	private static void applyAnnotationToMethodDecl(EclipseNode typeNode, MethodDeclaration mth, String annType, boolean typeUse) {
 		if (annType == null) return;
-		
+
 		int partCount = 1;
 		for (int i = 0; i < annType.length(); i++) if (annType.charAt(i) == '.') partCount++;
 		long[] ps = new long[partCount];
 		Arrays.fill(ps, 0L);
 		Annotation ann = new MarkerAnnotation(new QualifiedTypeReference(Eclipse.fromQualifiedName(annType), ps), 0);
-		
+
 		if (!typeUse || mth.returnType == null || mth.returnType.getTypeName().length < 2) {
 			Annotation[] a = mth.annotations;
 			if (a == null) a = new Annotation[1];
@@ -2667,13 +2697,13 @@ public class EclipseHandlerUtil {
 	}
 	private static void applyAnnotationToVarDecl(EclipseNode typeNode, Argument arg, MethodDeclaration mth, String annType, boolean typeUse) {
 		if (annType == null) return;
-		
+
 		int partCount = 1;
 		for (int i = 0; i < annType.length(); i++) if (annType.charAt(i) == '.') partCount++;
 		long[] ps = new long[partCount];
 		Arrays.fill(ps, 0L);
 		Annotation ann = new MarkerAnnotation(new QualifiedTypeReference(Eclipse.fromQualifiedName(annType), ps), 0);
-		
+
 		if (!typeUse || arg.type.getTypeName().length < 2) {
 			Annotation[] a = arg.annotations;
 			if (a == null) a = new Annotation[1];
@@ -2701,57 +2731,57 @@ public class EclipseHandlerUtil {
 			mth.bits |= Eclipse.HasTypeAnnotations;
 		}
 	}
-	
+
 	public static NameReference generateQualifiedNameRef(ASTNode source, char[]... varNames) {
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		long p = (long)pS << 32 | pE;
-		
+
 		NameReference ref;
-		
+
 		if (varNames.length > 1) ref = new QualifiedNameReference(varNames, new long[varNames.length], pS, pE);
 		else ref = new SingleNameReference(varNames[0], p);
 		setGeneratedBy(ref, source);
 		return ref;
 	}
-	
+
 	public static TypeReference generateQualifiedTypeRef(ASTNode source, char[]... varNames) {
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		long p = (long)pS << 32 | pE;
-		
+
 		TypeReference ref;
-		
+
 		long[] poss = Eclipse.poss(source, varNames.length);
 		if (varNames.length > 1) ref = new QualifiedTypeReference(varNames, poss);
 		else ref = new SingleTypeReference(varNames[0], p);
 		setGeneratedBy(ref, source);
 		return ref;
 	}
-	
+
 	public static TypeReference createTypeReference(String typeName, ASTNode source) {
 		return generateQualifiedTypeRef(source, fromQualifiedName(typeName));
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node is an actual class and not some other type declaration (so, not an annotation definition, interface, enum, or record).
 	 */
 	public static boolean isClass(EclipseNode typeNode) {
 		return isTypeAndDoesNotHaveFlags(typeNode, ClassFileConstants.AccInterface | ClassFileConstants.AccEnum | ClassFileConstants.AccAnnotation | AccRecord);
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node is an actual class or enum and not some other type declaration (so, not an annotation definition, interface, or record).
 	 */
 	public static boolean isClassOrEnum(EclipseNode typeNode) {
 		return isTypeAndDoesNotHaveFlags(typeNode, ClassFileConstants.AccInterface | ClassFileConstants.AccAnnotation | AccRecord);
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node is an actual class, an enum or a record and not some other type declaration (so, not an annotation definition or interface).
 	 */
 	public static boolean isClassEnumOrRecord(EclipseNode typeNode) {
 		return isTypeAndDoesNotHaveFlags(typeNode, ClassFileConstants.AccInterface | ClassFileConstants.AccAnnotation);
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node is a record declaration (so, not an annotation definition, interface, enum, or plain class).
 	 */
@@ -2759,21 +2789,21 @@ public class EclipseHandlerUtil {
 		ASTNode node = typeNode.get();
 		return node instanceof TypeDeclaration && isRecord((TypeDeclaration) node);
 	}
-	
+
 	/**
 	 * Returns {@code true} If the provided node is a field declaration, and represents a field in a {@code record} declaration.
 	 */
 	public static boolean isRecordField(EclipseNode fieldNode) {
 		return fieldNode.getKind() == Kind.FIELD && (((FieldDeclaration) fieldNode.get()).modifiers & AccRecord) != 0;
 	}
-	
+
 	/**
 	 * Returns {@code true} If the provided node is a field declaration, and represents a field in a {@code record} declaration.
 	 */
 	public static boolean isRecordField(FieldDeclaration fieldDeclaration) {
 		return (fieldDeclaration.modifiers & AccRecord) != 0;
 	}
-	
+
 	/**
 	 * Returns {@code true) if the provided node is a type declaration <em>and</em> is <strong>not</strong> of any kind indicated by the flags (the intent is to pass flags usch as `ClassFileConstants.AccEnum`).
 	 */
@@ -2783,14 +2813,14 @@ public class EclipseHandlerUtil {
 		int modifiers = typeDecl == null ? 0 : typeDecl.modifiers;
 		return (modifiers & flags) == 0;
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node supports static methods and types (top level or static class)
 	 */
 	public static boolean isStaticAllowed(EclipseNode typeNode) {
 		return typeNode.isStatic() || typeNode.up() == null || typeNode.up().getKind() == Kind.COMPILATION_UNIT || isRecord(typeNode);
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided type declaration is a record declaration (so, not an annotation definition, interface, enum, or plain class).
 	 */
@@ -2798,7 +2828,7 @@ public class EclipseHandlerUtil {
 		int modifiers = typeDecl == null ? 0 : typeDecl.modifiers;
 		return (modifiers & AccRecord) != 0;
 	}
-	
+
 	public static AbstractVariableDeclaration[] getRecordComponents(TypeDeclaration typeDeclaration) {
 		if (typeDeclaration == null || (typeDeclaration.modifiers & AccRecord) == 0) return null;
 		try {
@@ -2808,11 +2838,11 @@ public class EclipseHandlerUtil {
 		}
 		return null;
 	}
-	
+
 	public static Annotation[][] getRecordFieldAnnotations(TypeDeclaration typeDeclaration) {
 		if (typeDeclaration.fields == null) return null;
 		Annotation[][] annotations = new Annotation[typeDeclaration.fields.length][];
-		
+
 		AbstractVariableDeclaration[] recordComponents = getRecordComponents(typeDeclaration);
 		if (recordComponents != null) {
 			int j = 0;
@@ -2824,16 +2854,16 @@ public class EclipseHandlerUtil {
 		}
 		return annotations;
 	}
-	
+
 	private static final Pattern JAVADOC_PATTERN = Pattern.compile("^\\s*\\/\\*\\*(.*?)\\*\\/", Pattern.MULTILINE | Pattern.DOTALL);
 	private static final Pattern LEADING_ASTERISKS_PATTERN = Pattern.compile("^\\s*\\* ?", Pattern.MULTILINE);
 
 	public static String getDocComment(EclipseNode eclipseNode) {
 		if (eclipseNode.getAst().getSource() == null) return null;
-		
+
 		int start = -1;
 		int end = -1;
-		
+
 		final ASTNode node = eclipseNode.get();
 		if (node instanceof FieldDeclaration) {
 			FieldDeclaration fieldDeclaration = (FieldDeclaration) node;
@@ -2856,18 +2886,18 @@ public class EclipseHandlerUtil {
 		}
 		return null;
 	}
-	
+
 	public static void setDocComment(EclipseNode typeNode, EclipseNode eclipseNode, String doc) {
 		setDocComment((CompilationUnitDeclaration) eclipseNode.top().get(), (TypeDeclaration) typeNode.get(), eclipseNode.get(), doc);
 	}
-	
+
 	public static void setDocComment(CompilationUnitDeclaration cud, EclipseNode eclipseNode, String doc) {
 		setDocComment(cud, (TypeDeclaration) upToTypeNode(eclipseNode).get(), eclipseNode.get(), doc);
 	}
-	
+
 	public static void setDocComment(CompilationUnitDeclaration cud, TypeDeclaration type, ASTNode node, String doc) {
 		if (doc == null) return;
-		
+
 		ICompilationUnit compilationUnit = cud.compilationResult.compilationUnit;
 		if (compilationUnit == null) return;
 		if (compilationUnit.getClass().equals(COMPILATION_UNIT)) {
@@ -2875,7 +2905,7 @@ public class EclipseHandlerUtil {
 				compilationUnit = (ICompilationUnit) Permit.invoke(COMPILATION_UNIT_ORIGINAL_FROM_CLONE, compilationUnit);
 			} catch (Throwable t) { }
 		}
-		
+
 		Map<String, String> docs = EcjAugments.CompilationUnit_javadoc.setIfAbsent(compilationUnit, new HashMap<String, String>());
 		if (node instanceof AbstractMethodDeclaration) {
 			AbstractMethodDeclaration methodDeclaration = (AbstractMethodDeclaration) node;
@@ -2884,7 +2914,7 @@ public class EclipseHandlerUtil {
 			docs.put(signature, String.format("/**%n%s%n */", doc.replaceAll("$\\r?\\n", "").replaceAll("(?m)^", " * ")));
 		}
 	}
-	
+
 	public static String getSignature(TypeDeclaration type, AbstractMethodDeclaration methodDeclaration) {
 		StringBuilder sb = new StringBuilder();
 		sb.append(type.name);
@@ -2900,7 +2930,7 @@ public class EclipseHandlerUtil {
 		sb.append(")");
 		return sb.toString();
 	}
-	
+
 	public static enum CopyJavadoc {
 		VERBATIM {
 			@Override public String apply(final EclipseNode node) {
@@ -2934,9 +2964,9 @@ public class EclipseHandlerUtil {
 				return applySetter(node, "WITHBY|WITH_BY");
 			}
 		};
-		
+
 		public abstract String apply(final EclipseNode node);
-		
+
 		private static String applySetter(EclipseNode node, String sectionName) {
 			String javadoc = getDocComment(node);
 			// step 1: Check if there is a 'SETTER' section. If yes, that becomes the new method's javadoc.
@@ -2948,38 +2978,38 @@ public class EclipseHandlerUtil {
 			return shouldReturnThis(node, EclipseHandlerUtil.getAccessorsForField(node)) ? addReturnsThisIfNeeded(out) : out;
 		}
 	}
-	
+
 	/**
 	 * Copies javadoc on one node to the other.
-	 * 
+	 *
 	 * This one is a shortcut for {@link EclipseHandlerUtil#copyJavadoc(EclipseNode, ASTNode, TypeDeclaration, CopyJavadoc, boolean)}
 	 * if source and target node are in the same type.
 	 */
 	public static void copyJavadoc(EclipseNode from, ASTNode to, CopyJavadoc copyMode) {
 		copyJavadoc(from, to, (TypeDeclaration) upToTypeNode(from).get(), copyMode, false);
 	}
-	
+
 	/**
 	 * Copies javadoc on one node to the other.
-	 * 
+	 *
 	 * This one is a shortcut for {@link EclipseHandlerUtil#copyJavadoc(EclipseNode, ASTNode, TypeDeclaration, CopyJavadoc, boolean)}
 	 * if source and target node are in the same type.
 	 */
 	public static void copyJavadoc(EclipseNode from, ASTNode to, CopyJavadoc copyMode, boolean forceAddReturn) {
 		copyJavadoc(from, to, (TypeDeclaration) upToTypeNode(from).get(), copyMode, forceAddReturn);
 	}
-	
+
 	public static void copyJavadoc(EclipseNode from, ASTNode to, TypeDeclaration type, CopyJavadoc copyMode) {
 		copyJavadoc(from, to, type, copyMode, false);
 	}
-	
+
 	/**
 	 * Copies javadoc on one node to the other.
-	 * 
+	 *
 	 * in 'GETTER' copyMode, first a 'GETTER' segment is searched for. If it exists, that will become the javadoc for the 'to' node, and this section is
 	 * stripped out of the 'from' node. If no 'GETTER' segment is found, then the entire javadoc is taken minus any {@code @param} lines and other sections.
 	 * any {@code @return} lines are stripped from 'from'.
-	 * 
+	 *
 	 * in 'SETTER' mode, stripping works similarly to 'GETTER' mode, except {@code param} are copied and stripped from the original and {@code @return} are skipped.
 	 */
 	public static void copyJavadoc(EclipseNode from, ASTNode to, TypeDeclaration type, CopyJavadoc copyMode, boolean forceAddReturn) {
@@ -2993,7 +3023,7 @@ public class EclipseHandlerUtil {
 			setDocComment(cud, type, to, newJavadoc);
 		} catch (Exception ignore) {}
 	}
-	
+
 	public static void copyJavadocFromParam(EclipseNode from, MethodDeclaration to, TypeDeclaration type, String param) {
 		try {
 			CompilationUnitDeclaration cud = (CompilationUnitDeclaration) from.top().get();
@@ -3008,7 +3038,7 @@ public class EclipseHandlerUtil {
 	 */
 	public static EclipseNode getAnnotatedMethod(EclipseNode node) {
 		if (node == null || node.getKind() != Kind.ANNOTATION) return null;
-		
+
 		EclipseNode result = node.up();
 		if (result.getKind() == Kind.ARGUMENT) {
 			result = node.up();
@@ -3024,13 +3054,13 @@ public class EclipseHandlerUtil {
 	 */
 	public static boolean hasParsedBody(EclipseNode method) {
 		if (method == null || method.getKind() != Kind.METHOD) return false;
-		
+
 		boolean isCompleteParse = method.getAst().isCompleteParse();
 		if (isCompleteParse) return true;
-		
+
 		AbstractMethodDeclaration methodDecl = (AbstractMethodDeclaration) method.get();
 		if (methodDecl.statements != null) return true;
-		
+
 		// If the method is part of a field initializer it was parsed
 		EclipseNode parent = method.up();
 		while (parent != null) {

--- a/src/core/lombok/eclipse/handlers/HandleConstructor.java
+++ b/src/core/lombok/eclipse/handlers/HandleConstructor.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2010-2024 The Project Lombok Authors.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -87,36 +87,36 @@ public class HandleConstructor {
 	public static class HandleNoArgsConstructor extends EclipseAnnotationHandler<NoArgsConstructor> {
 		private static final String NAME = NoArgsConstructor.class.getSimpleName();
 		private HandleConstructor handleConstructor = new HandleConstructor();
-		
+
 		@Override public void handle(AnnotationValues<NoArgsConstructor> annotation, Annotation ast, EclipseNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.NO_ARGS_CONSTRUCTOR_FLAG_USAGE, "@NoArgsConstructor", ConfigurationKeys.ANY_CONSTRUCTOR_FLAG_USAGE, "any @xArgsConstructor");
-			
+
 			EclipseNode typeNode = annotationNode.up();
 			if (!checkLegality(typeNode, annotationNode, NAME)) return;
 			NoArgsConstructor ann = annotation.getInstance();
 			AccessLevel level = ann.access();
 			String staticName = ann.staticName();
 			if (level == AccessLevel.NONE) return;
-			
+
 			boolean force = ann.force();
-			
+
 			List<Annotation> onConstructor = unboxAndRemoveAnnotationParameter(ast, "onConstructor", "@NoArgsConstructor(onConstructor", annotationNode);
 			if (!onConstructor.isEmpty()) {
 				handleFlagUsage(annotationNode, ConfigurationKeys.ON_X_FLAG_USAGE, "@NoArgsConstructor(onConstructor=...)");
 			}
-			
+
 			handleConstructor.generateConstructor(typeNode, level, Collections.<EclipseNode>emptyList(), force, staticName, SkipIfConstructorExists.NO, onConstructor, annotationNode);
 		}
 	}
-	
+
 	@Provides
 	public static class HandleRequiredArgsConstructor extends EclipseAnnotationHandler<RequiredArgsConstructor> {
 		private static final String NAME = RequiredArgsConstructor.class.getSimpleName();
 		private HandleConstructor handleConstructor = new HandleConstructor();
-		
+
 		@Override public void handle(AnnotationValues<RequiredArgsConstructor> annotation, Annotation ast, EclipseNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.REQUIRED_ARGS_CONSTRUCTOR_FLAG_USAGE, "@RequiredArgsConstructor", ConfigurationKeys.ANY_CONSTRUCTOR_FLAG_USAGE, "any @xArgsConstructor");
-			
+
 			EclipseNode typeNode = annotationNode.up();
 			if (!checkLegality(typeNode, annotationNode, NAME)) return;
 			RequiredArgsConstructor ann = annotation.getInstance();
@@ -126,27 +126,27 @@ public class HandleConstructor {
 			if (annotation.isExplicit("suppressConstructorProperties")) {
 				annotationNode.addError("This deprecated feature is no longer supported. Remove it; you can create a lombok.config file with 'lombok.anyConstructor.suppressConstructorProperties = true'.");
 			}
-			
+
 			List<Annotation> onConstructor = unboxAndRemoveAnnotationParameter(ast, "onConstructor", "@RequiredArgsConstructor(onConstructor", annotationNode);
 			if (!onConstructor.isEmpty()) {
 				handleFlagUsage(annotationNode, ConfigurationKeys.ON_X_FLAG_USAGE, "@RequiredArgsConstructor(onConstructor=...)");
 			}
-			
+
 			handleConstructor.generateConstructor(
 				typeNode, level, findRequiredFields(typeNode), false, staticName, SkipIfConstructorExists.NO,
 				onConstructor, annotationNode);
 		}
 	}
-	
+
 	@Provides
 	public static class HandleAllArgsConstructor extends EclipseAnnotationHandler<AllArgsConstructor> {
 		private static final String NAME = AllArgsConstructor.class.getSimpleName();
 
 		private HandleConstructor handleConstructor = new HandleConstructor();
-		
+
 		@Override public void handle(AnnotationValues<AllArgsConstructor> annotation, Annotation ast, EclipseNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.ALL_ARGS_CONSTRUCTOR_FLAG_USAGE, "@AllArgsConstructor", ConfigurationKeys.ANY_CONSTRUCTOR_FLAG_USAGE, "any @xArgsConstructor");
-			
+
 			EclipseNode typeNode = annotationNode.up();
 			if (!checkLegality(typeNode, annotationNode, NAME)) return;
 			AllArgsConstructor ann = annotation.getInstance();
@@ -156,22 +156,22 @@ public class HandleConstructor {
 			if (annotation.isExplicit("suppressConstructorProperties")) {
 				annotationNode.addError("This deprecated feature is no longer supported. Remove it; you can create a lombok.config file with 'lombok.anyConstructor.suppressConstructorProperties = true'.");
 			}
-			
+
 			List<Annotation> onConstructor = unboxAndRemoveAnnotationParameter(ast, "onConstructor", "@AllArgsConstructor(onConstructor", annotationNode);
 			if (!onConstructor.isEmpty()) {
 				handleFlagUsage(annotationNode, ConfigurationKeys.ON_X_FLAG_USAGE, "@AllArgsConstructor(onConstructor=...)");
 			}
-			
+
 			handleConstructor.generateConstructor(
 				typeNode, level, findAllFields(typeNode), false, staticName, SkipIfConstructorExists.NO,
 				onConstructor, annotationNode);
 		}
 	}
-	
+
 	private static List<EclipseNode> findRequiredFields(EclipseNode typeNode) {
 		return findFields(typeNode, true);
 	}
-	
+
 	private static List<EclipseNode> findFields(EclipseNode typeNode, boolean nullMarked) {
 		List<EclipseNode> fields = new ArrayList<EclipseNode>();
 		for (EclipseNode child : typeNode.down()) {
@@ -184,72 +184,72 @@ public class HandleConstructor {
 		}
 		return fields;
 	}
-	
+
 	static List<EclipseNode> findAllFields(EclipseNode typeNode) {
 		return findAllFields(typeNode, false);
 	}
-	
+
 	static List<EclipseNode> findAllFields(EclipseNode typeNode, boolean evenFinalInitialized) {
 		List<EclipseNode> fields = new ArrayList<EclipseNode>();
 		for (EclipseNode child : typeNode.down()) {
 			if (child.getKind() != Kind.FIELD) continue;
 			FieldDeclaration fieldDecl = (FieldDeclaration) child.get();
 			if (!filterField(fieldDecl)) continue;
-			
+
 			if (!evenFinalInitialized && ((fieldDecl.modifiers & ClassFileConstants.AccFinal) != 0) && fieldDecl.initialization != null) continue;
-			
+
 			fields.add(child);
 		}
 		return fields;
 	}
-	
+
 	static boolean checkLegality(EclipseNode typeNode, EclipseNode errorNode, String name) {
 		if (!isClassOrEnum(typeNode)) {
 			errorNode.addError(name + " is only supported on a class or an enum.");
 			return false;
 		}
-		
+
 		return true;
 	}
-	
+
 	public enum SkipIfConstructorExists {
 		YES, NO, I_AM_BUILDER;
 	}
-	
+
 	public void generateExtraNoArgsConstructor(EclipseNode typeNode, EclipseNode sourceNode) {
 		if (!isDirectDescendantOfObject(typeNode)) return;
-		
+
 		Boolean v = typeNode.getAst().readConfiguration(ConfigurationKeys.NO_ARGS_CONSTRUCTOR_EXTRA_PRIVATE);
 		if (v == null || !v) return;
-		
+
 		generate(typeNode, AccessLevel.PRIVATE, Collections.<EclipseNode>emptyList(), true, null, SkipIfConstructorExists.NO, Collections.<Annotation>emptyList(), sourceNode, true);
 	}
-	
+
 	public void generateRequiredArgsConstructor(
 			EclipseNode typeNode, AccessLevel level, String staticName, SkipIfConstructorExists skipIfConstructorExists,
 			List<Annotation> onConstructor, EclipseNode sourceNode) {
-		
+
 		generateConstructor(typeNode, level, findRequiredFields(typeNode), false, staticName, skipIfConstructorExists, onConstructor, sourceNode);
 	}
-	
+
 	public void generateAllArgsConstructor(
 			EclipseNode typeNode, AccessLevel level, String staticName, SkipIfConstructorExists skipIfConstructorExists,
 			List<Annotation> onConstructor, EclipseNode sourceNode) {
-		
+
 		generateConstructor(typeNode, level, findAllFields(typeNode), false, staticName, skipIfConstructorExists, onConstructor, sourceNode);
 	}
-	
+
 	public void generateConstructor(
 		EclipseNode typeNode, AccessLevel level, List<EclipseNode> fieldsToParam, boolean forceDefaults, String staticName, SkipIfConstructorExists skipIfConstructorExists,
 		List<Annotation> onConstructor, EclipseNode sourceNode) {
-		
+
 		generate(typeNode, level, fieldsToParam, forceDefaults, staticName, skipIfConstructorExists, onConstructor, sourceNode, false);
 	}
-	
+
 	public void generate(
 			EclipseNode typeNode, AccessLevel level, List<EclipseNode> fieldsToParam, boolean forceDefaults, String staticName, SkipIfConstructorExists skipIfConstructorExists,
 			List<Annotation> onConstructor, EclipseNode sourceNode, boolean noArgs) {
-			
+
 		ASTNode source = sourceNode.get();
 		boolean staticConstrRequired = staticName != null && !staticName.equals("");
 
@@ -259,11 +259,11 @@ public class HandleConstructor {
 					boolean skipGeneration = (annotationTypeMatches(NoArgsConstructor.class, child) ||
 						annotationTypeMatches(AllArgsConstructor.class, child) ||
 						annotationTypeMatches(RequiredArgsConstructor.class, child));
-					
+
 					if (!skipGeneration && skipIfConstructorExists == SkipIfConstructorExists.YES) {
 						skipGeneration = annotationTypeMatches(Builder.class, child);
 					}
-					
+
 					if (skipGeneration) {
 						if (staticConstrRequired) {
 							// @Data has asked us to generate a constructor, but we're going to skip this instruction, as an explicit 'make a constructor' annotation
@@ -279,9 +279,9 @@ public class HandleConstructor {
 				}
 			}
 		}
-		
+
 		if (noArgs && noArgsConstructorExists(typeNode)) return;
-		
+
 		if (!(skipIfConstructorExists != SkipIfConstructorExists.NO && constructorExists(typeNode) != MemberExistsResult.NOT_EXISTS)) {
 			ConstructorDeclaration constr = createConstructor(
 				staticConstrRequired ? AccessLevel.PRIVATE : level, typeNode, fieldsToParam, forceDefaults,
@@ -291,7 +291,7 @@ public class HandleConstructor {
 		}
 		generateStaticConstructor(staticConstrRequired, typeNode, staticName, level, fieldsToParam, source);
 	}
-	
+
 	private void generateStaticConstructor(boolean staticConstrRequired, EclipseNode typeNode, String staticName, AccessLevel level, Collection<EclipseNode> fields, ASTNode source) {
 		if (staticConstrRequired) {
 			MethodDeclaration staticConstr = createStaticConstructor(level, staticName, typeNode, fields, source);
@@ -299,10 +299,10 @@ public class HandleConstructor {
 			generateConstructorJavadoc(typeNode, constructorNode, fields);
 		}
 	}
-	
+
 	private static boolean noArgsConstructorExists(EclipseNode node) {
 		node = EclipseHandlerUtil.upToTypeNode(node);
-		
+
 		if (node != null && node.get() instanceof TypeDeclaration) {
 			TypeDeclaration typeDecl = (TypeDeclaration)node.get();
 			if (typeDecl.methods != null) for (AbstractMethodDeclaration def : typeDecl.methods) {
@@ -312,20 +312,20 @@ public class HandleConstructor {
 				}
 			}
 		}
-		
+
 		for (EclipseNode child : node.down()) {
 			if (annotationTypeMatches(NoArgsConstructor.class, child)) return true;
 			if (annotationTypeMatches(RequiredArgsConstructor.class, child) && findRequiredFields(node).isEmpty()) return true;
 			if (annotationTypeMatches(AllArgsConstructor.class, child) && findAllFields(node).isEmpty()) return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	private static final char[][] JAVA_BEANS_CONSTRUCTORPROPERTIES = new char[][] { "java".toCharArray(), "beans".toCharArray(), "ConstructorProperties".toCharArray() };
 	public static Annotation[] createConstructorProperties(ASTNode source, Collection<EclipseNode> fields) {
 		if (fields.isEmpty()) return null;
-		
+
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		long p = (long) pS << 32 | pE;
 		long[] poss = new long[3];
@@ -334,12 +334,12 @@ public class HandleConstructor {
 		setGeneratedBy(constructorPropertiesType, source);
 		SingleMemberAnnotation ann = new SingleMemberAnnotation(constructorPropertiesType, pS);
 		ann.declarationSourceEnd = pE;
-		
+
 		ArrayInitializer fieldNames = new ArrayInitializer();
 		fieldNames.sourceStart = pS;
 		fieldNames.sourceEnd = pE;
 		fieldNames.expressions = new Expression[fields.size()];
-		
+
 		int ctr = 0;
 		for (EclipseNode field : fields) {
 			char[] fieldName = removePrefixFromField(field);
@@ -347,13 +347,13 @@ public class HandleConstructor {
 			setGeneratedBy(fieldNames.expressions[ctr], source);
 			ctr++;
 		}
-		
+
 		ann.memberValue = fieldNames;
 		setGeneratedBy(ann, source);
 		setGeneratedBy(ann.memberValue, source);
 		return new Annotation[] { ann };
 	}
-	
+
 	private static final char[] DEFAULT_PREFIX = {'$', 'd', 'e', 'f', 'a', 'u', 'l', 't', '$'};
 	private static final char[] prefixWith(char[] prefix, char[] name) {
 		char[] out = new char[prefix.length + name.length];
@@ -361,22 +361,22 @@ public class HandleConstructor {
 		System.arraycopy(name, 0, out, prefix.length, name.length);
 		return out;
 	}
-	
+
 	@SuppressWarnings("deprecation") public static ConstructorDeclaration createConstructor(
 		AccessLevel level, EclipseNode type, Collection<EclipseNode> fieldsToParam, boolean forceDefaults,
 		EclipseNode sourceNode, List<Annotation> onConstructor) {
-		
+
 		ASTNode source = sourceNode.get();
 		TypeDeclaration typeDeclaration = ((TypeDeclaration) type.get());
 		long p = (long) source.sourceStart << 32 | source.sourceEnd;
-		
+
 		boolean isEnum = (((TypeDeclaration) type.get()).modifiers & ClassFileConstants.AccEnum) != 0;
-		
+
 		if (isEnum) level = AccessLevel.PRIVATE;
-		
+
 		List<EclipseNode> fieldsToDefault = fieldsNeedingBuilderDefaults(type, fieldsToParam);
 		List<EclipseNode> fieldsToExplicit = forceDefaults ? fieldsNeedingExplicitDefaults(type, fieldsToParam) : Collections.<EclipseNode>emptyList();
-		
+
 		boolean addConstructorProperties;
 		if (fieldsToParam.isEmpty()) {
 			addConstructorProperties = false;
@@ -385,9 +385,9 @@ public class HandleConstructor {
 			addConstructorProperties = v != null ? v.booleanValue() :
 				Boolean.FALSE.equals(type.getAst().readConfiguration(ConfigurationKeys.ANY_CONSTRUCTOR_SUPPRESS_CONSTRUCTOR_PROPERTIES));
 		}
-		
+
 		ConstructorDeclaration constructor = new ConstructorDeclaration(((CompilationUnitDeclaration) type.top().get()).compilationResult);
-		
+
 		constructor.modifiers = toEclipseModifier(level);
 		constructor.selector = typeDeclaration.name;
 		constructor.constructorCall = new ExplicitConstructorCall(ExplicitConstructorCall.ImplicitSuper);
@@ -399,11 +399,11 @@ public class HandleConstructor {
 		constructor.bodyStart = constructor.declarationSourceStart = constructor.sourceStart = source.sourceStart;
 		constructor.bodyEnd = constructor.declarationSourceEnd = constructor.sourceEnd = source.sourceEnd;
 		constructor.arguments = null;
-		
+
 		List<Argument> params = new ArrayList<Argument>();
 		List<Statement> assigns = new ArrayList<Statement>();
 		List<Statement> nullChecks = new ArrayList<Statement>();
-		
+		boolean isNullMarked = isNullMarked(type);
 		for (EclipseNode fieldNode : fieldsToParam) {
 			FieldDeclaration field = (FieldDeclaration) fieldNode.get();
 			char[] rawName = field.name;
@@ -412,16 +412,16 @@ public class HandleConstructor {
 			int s = (int) (p >> 32);
 			int e = (int) p;
 			thisX.receiver = new ThisReference(s, e);
-			
+
 			Expression assignmentExpr = new SingleNameReference(fieldName, p);
-			
+
 			Assignment assignment = new Assignment(thisX, assignmentExpr, (int) p);
 			assignment.sourceStart = (int) (p >> 32); assignment.sourceEnd = assignment.statementEnd = (int) (p >> 32);
 			assigns.add(assignment);
 			long fieldPos = (((long) field.sourceStart) << 32) | field.sourceEnd;
 			Argument parameter = new Argument(fieldName, fieldPos, copyType(field.type, source), Modifier.FINAL);
 			Annotation[] copyableAnnotations = findCopyableAnnotations(fieldNode);
-			if (hasNonNullAnnotations(fieldNode)) {
+			if (hasNonNullAnnotations(fieldNode) || isJSpecifyNonNull(isNullMarked, fieldNode)) {
 				Statement nullCheck = generateNullCheck(parameter, sourceNode, null);
 				if (nullCheck != null) nullChecks.add(nullCheck);
 			}
@@ -432,7 +432,7 @@ public class HandleConstructor {
 			}
 			params.add(parameter);
 		}
-		
+
 		for (EclipseNode fieldNode : fieldsToExplicit) {
 			FieldDeclaration field = (FieldDeclaration) fieldNode.get();
 			char[] rawName = field.name;
@@ -440,14 +440,14 @@ public class HandleConstructor {
 			int s = (int) (p >> 32);
 			int e = (int) p;
 			thisX.receiver = new ThisReference(s, e);
-			
+
 			Expression assignmentExpr = getDefaultExpr(field.type, s, e);
-			
+
 			Assignment assignment = new Assignment(thisX, assignmentExpr, (int) p);
 			assignment.sourceStart = (int) (p >> 32); assignment.sourceEnd = assignment.statementEnd = (int) (p >> 32);
 			assigns.add(assignment);
 		}
-		
+
 		for (EclipseNode fieldNode : fieldsToDefault) {
 			FieldDeclaration field = (FieldDeclaration) fieldNode.get();
 			char[] rawName = field.name;
@@ -455,35 +455,35 @@ public class HandleConstructor {
 			int s = (int) (p >> 32);
 			int e = (int) p;
 			thisX.receiver = new ThisReference(s, e);
-			
+
 			MessageSend inv = new MessageSend();
 			inv.sourceStart = source.sourceStart;
 			inv.sourceEnd = source.sourceEnd;
 			inv.receiver = new SingleNameReference(((TypeDeclaration) type.get()).name, 0L);
 			inv.selector = prefixWith(DEFAULT_PREFIX, removePrefixFromField(fieldNode));
-			
+
 			Assignment assignment = new Assignment(thisX, inv, (int) p);
 			assignment.sourceStart = (int) (p >> 32); assignment.sourceEnd = assignment.statementEnd = (int) (p >> 32);
 			assigns.add(assignment);
 		}
-		
+
 		nullChecks.addAll(assigns);
 		constructor.statements = nullChecks.isEmpty() ? null : nullChecks.toArray(new Statement[0]);
 		constructor.arguments = params.isEmpty() ? null : params.toArray(new Argument[0]);
-		
+
 		/* Generate annotations that must  be put on the generated method, and attach them. */ {
 			Annotation[] constructorProperties = null;
 			if (addConstructorProperties && !isLocalType(type)) constructorProperties = createConstructorProperties(source, fieldsToParam);
-			
+
 			constructor.annotations = copyAnnotations(source,
 				onConstructor.toArray(new Annotation[0]),
 				constructorProperties);
 		}
-		
+
 		constructor.traverse(new SetGeneratedByVisitor(source), typeDeclaration.scope);
 		return constructor;
 	}
-	
+
 	private static List<EclipseNode> fieldsNeedingBuilderDefaults(EclipseNode type, Collection<EclipseNode> fieldsToParam) {
 		List<EclipseNode> out = new ArrayList<EclipseNode>();
 		top:
@@ -496,7 +496,7 @@ public class HandleConstructor {
 		}
 		return out;
 	}
-	
+
 	private static List<EclipseNode> fieldsNeedingExplicitDefaults(EclipseNode type, Collection<EclipseNode> fieldsToParam) {
 		List<EclipseNode> out = new ArrayList<EclipseNode>();
 		top:
@@ -512,7 +512,7 @@ public class HandleConstructor {
 		}
 		return out;
 	}
-	
+
 	private static Expression getDefaultExpr(TypeReference type, int s, int e) {
 		boolean array = type instanceof ArrayTypeReference;
 		if (array) return new NullLiteral(s, e);
@@ -524,23 +524,23 @@ public class HandleConstructor {
 		if (Arrays.equals(TypeConstants.LONG, lastToken)) return LongLiteral.buildLongLiteral(new char[] {'0',  'L'}, s, e);
 		if (Arrays.equals(TypeConstants.FLOAT, lastToken)) return new FloatLiteral(new char[] {'0', 'F'}, s, e);
 		if (Arrays.equals(TypeConstants.DOUBLE, lastToken)) return new DoubleLiteral(new char[] {'0', 'D'}, s, e);
-		
+
 		return new NullLiteral(s, e);
 	}
-	
+
 	public static boolean isLocalType(EclipseNode type) {
 		Kind kind = type.up().getKind();
 		if (kind == Kind.COMPILATION_UNIT) return false;
 		if (kind == Kind.TYPE) return isLocalType(type.up());
 		return true;
 	}
-	
+
 	public MethodDeclaration createStaticConstructor(AccessLevel level, String name, EclipseNode type, Collection<EclipseNode> fields, ASTNode source) {
 		int pS = source.sourceStart, pE = source.sourceEnd;
 		long p = (long) pS << 32 | pE;
-		
+
 		MethodDeclaration constructor = new MethodDeclaration(((CompilationUnitDeclaration) type.top().get()).compilationResult);
-		
+
 		constructor.modifiers = toEclipseModifier(level) | ClassFileConstants.AccStatic;
 		TypeDeclaration typeDecl = (TypeDeclaration) type.get();
 		constructor.returnType = EclipseHandlerUtil.namePlusTypeParamsToTypeReference(type, typeDecl.typeParameters, p);
@@ -556,19 +556,19 @@ public class HandleConstructor {
 		constructor.bits |= ECLIPSE_DO_NOT_TOUCH_FLAG;
 		constructor.bodyStart = constructor.declarationSourceStart = constructor.sourceStart = source.sourceStart;
 		constructor.bodyEnd = constructor.declarationSourceEnd = constructor.sourceEnd = source.sourceEnd;
-		
+
 		List<Argument> params = new ArrayList<Argument>();
 		List<Expression> assigns = new ArrayList<Expression>();
 		AllocationExpression statement = new AllocationExpression();
 		statement.sourceStart = pS; statement.sourceEnd = pE;
 		statement.type = copyType(constructor.returnType, source);
-		
+
 		for (EclipseNode fieldNode : fields) {
 			FieldDeclaration field = (FieldDeclaration) fieldNode.get();
 			long fieldPos = (((long) field.sourceStart) << 32) | field.sourceEnd;
 			SingleNameReference nameRef = new SingleNameReference(field.name, fieldPos);
 			assigns.add(nameRef);
-			
+
 			Argument parameter = new Argument(field.name, fieldPos, copyType(field.type, source), Modifier.FINAL);
 			parameter.annotations = copyAnnotations(source, findCopyableAnnotations(fieldNode));
 			if (parameter.annotations != null) {
@@ -577,33 +577,33 @@ public class HandleConstructor {
 			}
 			params.add(parameter);
 		}
-		
+
 		statement.arguments = assigns.isEmpty() ? null : assigns.toArray(new Expression[0]);
 		constructor.arguments = params.isEmpty() ? null : params.toArray(new Argument[0]);
 		constructor.statements = new Statement[] { new ReturnStatement(statement, (int) (p >> 32), (int)p) };
-		
+
 		createRelevantNonNullAnnotation(type, constructor);
 		constructor.traverse(new SetGeneratedByVisitor(source), typeDecl.scope);
 		return constructor;
 	}
-	
+
 	private void generateConstructorJavadoc(EclipseNode typeNode, EclipseNode constructorNode, Collection<EclipseNode> fields) {
 		try {
 			if (fields.isEmpty()) return;
-		
+
 			String constructorJavadoc = getConstructorJavadocHeader(typeNode.getName());
 			boolean fieldDescriptionAdded = false;
 			for (EclipseNode fieldNode : fields) {
 				String paramName = String.valueOf(removePrefixFromField(fieldNode));
 				String fieldJavadoc = getDocComment(fieldNode);
 				String paramJavadoc = getConstructorParameterJavadoc(paramName, fieldJavadoc);
-				
+
 				if (paramJavadoc == null) {
 					paramJavadoc = "@param " + paramName;
 				} else {
 					fieldDescriptionAdded = true;
 				}
-				
+
 				constructorJavadoc = addJavadocLine(constructorJavadoc, paramJavadoc);
 			}
 			if (fieldDescriptionAdded) {

--- a/src/core/lombok/eclipse/handlers/HandleSetter.java
+++ b/src/core/lombok/eclipse/handlers/HandleSetter.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2009-2025 The Project Lombok Authors.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -66,7 +66,7 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 @Provides
 public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 	private static final String SETTER_NODE_NOT_SUPPORTED_ERR = "@Setter is only supported on a class or a field.";
-	
+
 	public boolean generateSetterForType(EclipseNode typeNode, EclipseNode pos, AccessLevel level, boolean checkForTypeLevelSetter, List<Annotation> onMethod, List<Annotation> onParam) {
 		if (checkForTypeLevelSetter) {
 			if (hasAnnotation(Setter.class, typeNode)) {
@@ -74,32 +74,32 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 				return true;
 			}
 		}
-		
+
 		if (!isClass(typeNode)) {
 			pos.addError(SETTER_NODE_NOT_SUPPORTED_ERR);
 			return false;
 		}
-		
+
 		for (EclipseNode field : typeNode.down()) {
 			if (field.getKind() != Kind.FIELD) continue;
 			FieldDeclaration fieldDecl = (FieldDeclaration) field.get();
 			if (!filterField(fieldDecl)) continue;
-			
+
 			//Skip final fields.
 			if ((fieldDecl.modifiers & ClassFileConstants.AccFinal) != 0) continue;
-			
+
 			generateSetterForField(field, pos, level, onMethod, onParam);
 		}
 		return true;
 	}
-	
+
 	/**
 	 * Generates a setter on the stated field.
-	 * 
+	 *
 	 * Used by {@link HandleData}.
-	 * 
+	 *
 	 * The difference between this call and the handle method is as follows:
-	 * 
+	 *
 	 * If there is a {@code lombok.Setter} annotation on the field, it is used and the
 	 * same rules apply (e.g. warning if the method already exists, stated access level applies).
 	 * If not, the setter is still generated if it isn't already there, though there will not
@@ -110,24 +110,24 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 			//The annotation will make it happen, so we can skip it.
 			return;
 		}
-		
+
 		// If a fluent setter should be generated, force-copy annotations from the field.
 		AnnotationValues<Accessors> accessorsForField = EclipseHandlerUtil.getAccessorsForField(fieldNode);
 		// Copying Jackson annotations is required for fluent accessors (otherwise Jackson would not find the accessor).
 		Annotation[] copyableToSetterAnnotations = findCopyableToSetterAnnotations(fieldNode, accessorsForField.isExplicit("fluent"));
 		onMethod = new ArrayList<Annotation>(onMethod);
 		onMethod.addAll(Arrays.asList(copyableToSetterAnnotations));
-		
+
 		createSetterForField(level, fieldNode, sourceNode, false, onMethod, onParam);
 	}
-	
+
 	@Override public void handle(AnnotationValues<Setter> annotation, Annotation ast, EclipseNode annotationNode) {
 		handleFlagUsage(annotationNode, ConfigurationKeys.SETTER_FLAG_USAGE, "@Setter");
-		
+
 		EclipseNode node = annotationNode.up();
 		AccessLevel level = annotation.getInstance().value();
 		if (level == AccessLevel.NONE || node == null) return;
-		
+
 		List<Annotation> onMethod = unboxAndRemoveAnnotationParameter(ast, "onMethod", "@Setter(onMethod", annotationNode);
 		if (!onMethod.isEmpty()) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.ON_X_FLAG_USAGE, "@Setter(onMethod=...)");
@@ -136,7 +136,7 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 		if (!onParam.isEmpty()) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.ON_X_FLAG_USAGE, "@Setter(onParam=...)");
 		}
-		
+
 		switch (node.getKind()) {
 		case FIELD:
 			createSetterForFields(level, annotationNode.upFromAnnotationToFields(), annotationNode, true, onMethod, onParam);
@@ -146,38 +146,38 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 			break;
 		}
 	}
-	
+
 	public void createSetterForFields(AccessLevel level, Collection<EclipseNode> fieldNodes, EclipseNode sourceNode, boolean whineIfExists, List<Annotation> onMethod, List<Annotation> onParam) {
 		for (EclipseNode fieldNode : fieldNodes) {
 			createSetterForField(level, fieldNode, sourceNode, whineIfExists, onMethod, onParam);
 		}
 	}
-	
+
 	public void createSetterForField(
 			AccessLevel level, EclipseNode fieldNode, EclipseNode sourceNode,
 			boolean whineIfExists, List<Annotation> onMethod,
 			List<Annotation> onParam) {
-		
+
 		ASTNode source = sourceNode.get();
 		if (fieldNode.getKind() != Kind.FIELD) {
 			sourceNode.addError(SETTER_NODE_NOT_SUPPORTED_ERR);
 			return;
 		}
-		
+
 		FieldDeclaration field = (FieldDeclaration) fieldNode.get();
 		TypeReference fieldType = copyType(field.type, source);
 		boolean isBoolean = isBoolean(fieldType);
 		AnnotationValues<Accessors> accessors = getAccessorsForField(fieldNode);
 		String setterName = toSetterName(fieldNode, isBoolean, accessors);
 		boolean shouldReturnThis = shouldReturnThis(fieldNode, accessors);
-		
+
 		if (setterName == null) {
 			fieldNode.addWarning("Not generating setter for this field: It does not fit your @Accessors prefix list.");
 			return;
 		}
-		
+
 		int modifier = toEclipseModifier(level) | (field.modifiers & ClassFileConstants.AccStatic);
-		
+
 		for (String altName : toAllSetterNames(fieldNode, isBoolean, accessors)) {
 			switch (methodExists(altName, fieldNode, false, 1)) {
 			case EXISTS_BY_LOMBOK:
@@ -195,7 +195,7 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 				//continue scanning the other alt names.
 			}
 		}
-		
+
 		MethodDeclaration method = createSetter((TypeDeclaration) fieldNode.up().get(), false, fieldNode, setterName, null, null, shouldReturnThis, modifier, sourceNode, onMethod, onParam);
 		injectMethod(fieldNode.up(), method);
 	}
@@ -203,7 +203,7 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 	static MethodDeclaration createSetter(TypeDeclaration parent, boolean deprecate, EclipseNode fieldNode, String name, char[] paramName, char[] booleanFieldToSet, boolean shouldReturnThis, int modifier, EclipseNode sourceNode, List<Annotation> onMethod, List<Annotation> onParam) {
 		ASTNode source = sourceNode.get();
 		int pS = source.sourceStart, pE = source.sourceEnd;
-		
+
 		TypeReference returnType = null;
 		ReturnStatement returnThis = null;
 		if (shouldReturnThis) {
@@ -212,11 +212,11 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 			ThisReference thisRef = new ThisReference(pS, pE);
 			returnThis = new ReturnStatement(thisRef, pS, pE);
 		}
-		
+
 		MethodDeclaration d = createSetter(parent, deprecate, fieldNode, name, paramName, booleanFieldToSet, returnType, returnThis, modifier, sourceNode, onMethod, onParam);
 		return d;
 	}
-	
+
 	static MethodDeclaration createSetter(TypeDeclaration parent, boolean deprecate, EclipseNode fieldNode, String name, char[] paramName, char[] booleanFieldToSet, TypeReference returnType, Statement returnStatement, int modifier, EclipseNode sourceNode, List<Annotation> onMethod, List<Annotation> onParam) {
 		FieldDeclaration field = (FieldDeclaration) fieldNode.get();
 		if (paramName == null) paramName = field.name;
@@ -252,21 +252,21 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 		assignment.sourceStart = pS; assignment.sourceEnd = assignment.statementEnd = pE;
 		method.bodyStart = method.declarationSourceStart = method.sourceStart = source.sourceStart;
 		method.bodyEnd = method.declarationSourceEnd = method.sourceEnd = source.sourceEnd;
-		
+
 		Annotation[] copyableAnnotations = findCopyableAnnotations(fieldNode);
 		List<Statement> statements = new ArrayList<Statement>(5);
-		if (!hasNonNullAnnotations(fieldNode) && !hasNonNullAnnotations(fieldNode, onParam)) {
+		if (!hasNonNullAnnotations(fieldNode) && !hasNonNullAnnotations(fieldNode, onParam) && !isJSpecifyNonNull(isNullMarked(getParentTypeNode(fieldNode)), fieldNode)) {
 			statements.add(assignment);
 		} else {
 			Statement nullCheck = generateNullCheck(field.type, paramName, sourceNode, null);
 			if (nullCheck != null) statements.add(nullCheck);
 			statements.add(assignment);
 		}
-		
+
 		if (booleanFieldToSet != null) {
 			statements.add(new Assignment(new SingleNameReference(booleanFieldToSet, p), new TrueLiteral(pS, pE), pE));
 		}
-		
+
 		if (returnType != null && returnStatement != null) {
 			statements.add(returnStatement);
 		}
@@ -276,9 +276,9 @@ public class HandleSetter extends EclipseAnnotationHandler<Setter> {
 			param.bits |= Eclipse.HasTypeAnnotations;
 			method.bits |= Eclipse.HasTypeAnnotations;
 		}
-		
+
 		if (returnType != null && returnStatement != null) createRelevantNonNullAnnotation(sourceNode, method);
-		
+
 		method.traverse(new SetGeneratedByVisitor(source), parent.scope);
 		copyJavadoc(fieldNode, method, CopyJavadoc.SETTER, returnStatement != null);
 		return method;

--- a/src/core/lombok/javac/handlers/HandleConstructor.java
+++ b/src/core/lombok/javac/handlers/HandleConstructor.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2010-2024 The Project Lombok Authors.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -65,10 +65,10 @@ public class HandleConstructor {
 	public static class HandleNoArgsConstructor extends JavacAnnotationHandler<NoArgsConstructor> {
 		private static final String NAME = NoArgsConstructor.class.getSimpleName();
 		private HandleConstructor handleConstructor = new HandleConstructor();
-		
+
 		@Override public void handle(AnnotationValues<NoArgsConstructor> annotation, JCAnnotation ast, JavacNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.NO_ARGS_CONSTRUCTOR_FLAG_USAGE, "@NoArgsConstructor", ConfigurationKeys.ANY_CONSTRUCTOR_FLAG_USAGE, "any @xArgsConstructor");
-			
+
 			deleteAnnotationIfNeccessary(annotationNode, NoArgsConstructor.class);
 			deleteImportFromCompilationUnit(annotationNode, "lombok.AccessLevel");
 			JavacNode typeNode = annotationNode.up();
@@ -85,15 +85,15 @@ public class HandleConstructor {
 			handleConstructor.generateConstructor(typeNode, level, onConstructor, List.<JavacNode>nil(), force, staticName, SkipIfConstructorExists.NO, annotationNode);
 		}
 	}
-	
+
 	@Provides
 	public static class HandleRequiredArgsConstructor extends JavacAnnotationHandler<RequiredArgsConstructor> {
 		private static final String NAME = RequiredArgsConstructor.class.getSimpleName();
 		private HandleConstructor handleConstructor = new HandleConstructor();
-		
+
 		@Override public void handle(AnnotationValues<RequiredArgsConstructor> annotation, JCAnnotation ast, JavacNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.REQUIRED_ARGS_CONSTRUCTOR_FLAG_USAGE, "@RequiredArgsConstructor", ConfigurationKeys.ANY_CONSTRUCTOR_FLAG_USAGE, "any @xArgsConstructor");
-			
+
 			deleteAnnotationIfNeccessary(annotationNode, RequiredArgsConstructor.class);
 			deleteImportFromCompilationUnit(annotationNode, "lombok.AccessLevel");
 			JavacNode typeNode = annotationNode.up();
@@ -109,19 +109,19 @@ public class HandleConstructor {
 			if (annotation.isExplicit("suppressConstructorProperties")) {
 				annotationNode.addError("This deprecated feature is no longer supported. Remove it; you can create a lombok.config file with 'lombok.anyConstructor.suppressConstructorProperties = true'.");
 			}
-			
+
 			handleConstructor.generateConstructor(typeNode, level, onConstructor, findRequiredFields(typeNode), false, staticName, SkipIfConstructorExists.NO, annotationNode);
 		}
 	}
-	
+
 	@Provides
 	public static class HandleAllArgsConstructor extends JavacAnnotationHandler<AllArgsConstructor> {
 		private static final String NAME = AllArgsConstructor.class.getSimpleName();
 		private HandleConstructor handleConstructor = new HandleConstructor();
-		
+
 		@Override public void handle(AnnotationValues<AllArgsConstructor> annotation, JCAnnotation ast, JavacNode annotationNode) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.ALL_ARGS_CONSTRUCTOR_FLAG_USAGE, "@AllArgsConstructor", ConfigurationKeys.ANY_CONSTRUCTOR_FLAG_USAGE, "any @xArgsConstructor");
-			
+
 			deleteAnnotationIfNeccessary(annotationNode, AllArgsConstructor.class);
 			deleteImportFromCompilationUnit(annotationNode, "lombok.AccessLevel");
 			JavacNode typeNode = annotationNode.up();
@@ -140,15 +140,15 @@ public class HandleConstructor {
 			handleConstructor.generateConstructor(typeNode, level, onConstructor, findAllFields(typeNode), false, staticName, SkipIfConstructorExists.NO, annotationNode);
 		}
 	}
-	
+
 	public static List<JavacNode> findRequiredFields(JavacNode typeNode) {
 		return findFields(typeNode, true);
 	}
-	
+
 	public static List<JavacNode> findFinalFields(JavacNode typeNode) {
 		return findFields(typeNode, false);
 	}
-	
+
 	public static List<JavacNode> findFields(JavacNode typeNode, boolean nullMarked) {
 		ListBuffer<JavacNode> fields = new ListBuffer<JavacNode>();
 		for (JavacNode child : typeNode.down()) {
@@ -165,11 +165,11 @@ public class HandleConstructor {
 		}
 		return fields.toList();
 	}
-	
+
 	public static List<JavacNode> findAllFields(JavacNode typeNode) {
 		return findAllFields(typeNode, false);
 	}
-	
+
 	public static List<JavacNode> findAllFields(JavacNode typeNode, boolean evenFinalInitialized) {
 		ListBuffer<JavacNode> fields = new ListBuffer<JavacNode>();
 		for (JavacNode child : typeNode.down()) {
@@ -186,51 +186,51 @@ public class HandleConstructor {
 		}
 		return fields.toList();
 	}
-	
+
 	public static boolean checkLegality(JavacNode typeNode, JavacNode errorNode, String name) {
 		if (!isClassOrEnum(typeNode)) {
 			errorNode.addError(name + " is only supported on a class or an enum.");
 			return false;
 		}
-		
+
 		return true;
 	}
-	
+
 	public enum SkipIfConstructorExists {
 		YES, NO, I_AM_BUILDER;
 	}
-	
+
 	public void generateExtraNoArgsConstructor(JavacNode typeNode, JavacNode source) {
 		if (!isDirectDescendantOfObject(typeNode)) return;
-		
+
 		Boolean v = typeNode.getAst().readConfiguration(ConfigurationKeys.NO_ARGS_CONSTRUCTOR_EXTRA_PRIVATE);
 		if (v == null || !v) return;
-		
+
 		generate(typeNode, AccessLevel.PRIVATE, List.<JCAnnotation>nil(), List.<JavacNode>nil(), true, null, SkipIfConstructorExists.NO, source, true);
 	}
-	
+
 	public void generateRequiredArgsConstructor(JavacNode typeNode, AccessLevel level, String staticName, SkipIfConstructorExists skipIfConstructorExists, JavacNode source) {
 		generateConstructor(typeNode, level, List.<JCAnnotation>nil(), findRequiredFields(typeNode), false, staticName, skipIfConstructorExists, source);
 	}
-	
+
 	public void generateAllArgsConstructor(JavacNode typeNode, AccessLevel level, String staticName, SkipIfConstructorExists skipIfConstructorExists, JavacNode source) {
 		generateConstructor(typeNode, level, List.<JCAnnotation>nil(), findAllFields(typeNode), false, staticName, skipIfConstructorExists, source);
 	}
-	
+
 	public void generateConstructor(JavacNode typeNode, AccessLevel level, List<JCAnnotation> onConstructor, List<JavacNode> fields, boolean allToDefault, String staticName, SkipIfConstructorExists skipIfConstructorExists, JavacNode source) {
 		generate(typeNode, level, onConstructor, fields, allToDefault, staticName, skipIfConstructorExists, source, false);
 	}
 
 	private void generate(JavacNode typeNode, AccessLevel level, List<JCAnnotation> onConstructor, List<JavacNode> fields, boolean allToDefault, String staticName, SkipIfConstructorExists skipIfConstructorExists, JavacNode source, boolean noArgs) {
 		boolean staticConstrRequired = staticName != null && !staticName.equals("");
-		
+
 		if (skipIfConstructorExists != SkipIfConstructorExists.NO) {
 			for (JavacNode child : typeNode.down()) {
 				if (child.getKind() == Kind.ANNOTATION) {
 					boolean skipGeneration = annotationTypeMatches(NoArgsConstructor.class, child) ||
 						annotationTypeMatches(AllArgsConstructor.class, child) ||
 						annotationTypeMatches(RequiredArgsConstructor.class, child);
-					
+
 					if (!skipGeneration && skipIfConstructorExists == SkipIfConstructorExists.YES) {
 						skipGeneration = annotationTypeMatches(Builder.class, child);
 					}
@@ -247,9 +247,9 @@ public class HandleConstructor {
 				}
 			}
 		}
-		
+
 		if (noArgs && noArgsConstructorExists(typeNode)) return;
-		
+
 		if (!(skipIfConstructorExists != SkipIfConstructorExists.NO && constructorExists(typeNode) != MemberExistsResult.NOT_EXISTS)) {
 			JCMethodDecl constr = createConstructor(staticConstrRequired ? AccessLevel.PRIVATE : level, onConstructor, typeNode, fields, allToDefault, source);
 			generateConstructorJavadoc(constr, typeNode, fields);
@@ -257,7 +257,7 @@ public class HandleConstructor {
 		}
 		generateStaticConstructor(staticConstrRequired, typeNode, staticName, level, allToDefault, fields, source);
 	}
-	
+
 	private void generateStaticConstructor(boolean staticConstrRequired, JavacNode typeNode, String staticName, AccessLevel level, boolean allToDefault, List<JavacNode> fields, JavacNode source) {
 		if (staticConstrRequired) {
 			JCMethodDecl staticConstr = createStaticConstructor(staticName, level, typeNode, allToDefault ? List.<JavacNode>nil() : fields, source);
@@ -265,10 +265,10 @@ public class HandleConstructor {
 			injectMethod(typeNode, staticConstr);
 		}
 	}
-	
+
 	private static boolean noArgsConstructorExists(JavacNode node) {
 		node = upToTypeNode(node);
-		
+
 		if (node != null && node.get() instanceof JCClassDecl) {
 			for (JCTree def : ((JCClassDecl) node.get()).defs) {
 				if (def instanceof JCMethodDecl) {
@@ -277,16 +277,16 @@ public class HandleConstructor {
 				}
 			}
 		}
-		
+
 		for (JavacNode child : node.down()) {
 			if (annotationTypeMatches(NoArgsConstructor.class, child)) return true;
 			if (annotationTypeMatches(RequiredArgsConstructor.class, child) && findRequiredFields(node).isEmpty()) return true;
 			if (annotationTypeMatches(AllArgsConstructor.class, child) && findAllFields(node).isEmpty()) return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	public static void addConstructorProperties(JCModifiers mods, JavacNode node, List<JavacNode> fields) {
 		if (fields.isEmpty()) return;
 		JavacTreeMaker maker = node.getTreeMaker();
@@ -300,18 +300,18 @@ public class HandleConstructor {
 		JCAnnotation annotation = maker.Annotation(constructorPropertiesType, List.of(fieldNamesArray));
 		mods.annotations = mods.annotations.append(annotation);
 	}
-	
+
 	@SuppressWarnings("deprecation") public static JCMethodDecl createConstructor(AccessLevel level, List<JCAnnotation> onConstructor, JavacNode typeNode, List<JavacNode> fieldsToParam, boolean forceDefaults, JavacNode source) {
 		JavacTreeMaker maker = typeNode.getTreeMaker();
-		
+
 		boolean isEnum = (((JCClassDecl) typeNode.get()).mods.flags & Flags.ENUM) != 0;
 		if (isEnum) level = AccessLevel.PRIVATE;
-		
+
 		boolean addConstructorProperties;
-		
+
 		List<JavacNode> fieldsToDefault = fieldsNeedingBuilderDefaults(typeNode, fieldsToParam);
 		List<JavacNode> fieldsToExplicit = forceDefaults ? fieldsNeedingExplicitDefaults(typeNode, fieldsToParam) : List.<JavacNode>nil();
-		
+
 		if (fieldsToParam.isEmpty()) {
 			addConstructorProperties = false;
 		} else {
@@ -319,11 +319,11 @@ public class HandleConstructor {
 			addConstructorProperties = v != null ? v.booleanValue() :
 				Boolean.FALSE.equals(typeNode.getAst().readConfiguration(ConfigurationKeys.ANY_CONSTRUCTOR_SUPPRESS_CONSTRUCTOR_PROPERTIES));
 		}
-		
+
 		ListBuffer<JCStatement> nullChecks = new ListBuffer<JCStatement>();
 		ListBuffer<JCStatement> assigns = new ListBuffer<JCStatement>();
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
-		
+
 		for (JavacNode fieldNode : fieldsToParam) {
 			JCVariableDecl field = (JCVariableDecl) fieldNode.get();
 			Name fieldName = removePrefixFromField(fieldNode);
@@ -341,7 +341,7 @@ public class HandleConstructor {
 			JCExpression assign = maker.Assign(thisX, maker.Ident(fieldName));
 			assigns.append(maker.Exec(assign));
 		}
-		
+
 		for (JavacNode fieldNode : fieldsToExplicit) {
 			JCVariableDecl field = (JCVariableDecl) fieldNode.get();
 			Name rawName = field.name;
@@ -349,7 +349,7 @@ public class HandleConstructor {
 			JCExpression assign = maker.Assign(thisX, getDefaultExpr(maker, field.vartype));
 			assigns.append(maker.Exec(assign));
 		}
-		
+
 		for (JavacNode fieldNode : fieldsToDefault) {
 			JCVariableDecl field = (JCVariableDecl) fieldNode.get();
 			Name rawName = field.name;
@@ -359,7 +359,7 @@ public class HandleConstructor {
 			JCExpression assign = maker.Assign(thisX, maker.Apply(List.<JCExpression>nil(), maker.Select(maker.Ident(((JCClassDecl) typeNode.get()).name), nameOfDefaultProvider), List.<JCExpression>nil()));
 			assigns.append(maker.Exec(assign));
 		}
-		
+
 		JCModifiers mods = maker.Modifiers(toJavacModifier(level), List.<JCAnnotation>nil());
 		if (addConstructorProperties && !isLocalType(typeNode) && LombokOptionsFactory.getDelombokOptions(typeNode.getContext()).getFormatPreferences().generateConstructorProperties()) {
 			addConstructorProperties(mods, typeNode, fieldsToParam);
@@ -369,7 +369,7 @@ public class HandleConstructor {
 			null, List.<JCTypeParameter>nil(), params.toList(), List.<JCExpression>nil(),
 			maker.Block(0L, nullChecks.appendList(assigns).toList()), null), source);
 	}
-	
+
 	/**
 	 * For each field which is not final and has no initializer that gets 'removed' by {@code @Builder.Default} there is no need to
 	 * write an explicit 'this.x = foo' in the constructor, so strip them away here.
@@ -386,7 +386,7 @@ public class HandleConstructor {
 		}
 		return out.toList();
 	}
-	
+
 	/**
 	 * Return each field which is final and has no initializer, and which is not already a parameter.
 	 */
@@ -405,7 +405,7 @@ public class HandleConstructor {
 		}
 		return out.toList();
 	}
-	
+
 	private static JCExpression getDefaultExpr(JavacTreeMaker maker, JCExpression type) {
 		if (type instanceof JCPrimitiveTypeTree) {
 			switch (((JCPrimitiveTypeTree) type).getPrimitiveTypeKind()) {
@@ -426,30 +426,30 @@ public class HandleConstructor {
 				return maker.Literal(CTC_DOUBLE, 0D);
 			}
 		}
-		
+
 		return maker.Literal(CTC_BOT, null);
-		
+
 	}
-	
+
 	public static boolean isLocalType(JavacNode type) {
 		Kind kind = type.up().getKind();
 		if (kind == Kind.COMPILATION_UNIT) return false;
 		if (kind == Kind.TYPE) return isLocalType(type.up());
 		return true;
 	}
-	
+
 	public JCMethodDecl createStaticConstructor(String name, AccessLevel level, JavacNode typeNode, List<JavacNode> fields, JavacNode source) {
 		JavacTreeMaker maker = typeNode.getTreeMaker();
 		JCClassDecl type = (JCClassDecl) typeNode.get();
-		
+
 		JCModifiers mods = maker.Modifiers(Flags.STATIC | toJavacModifier(level));
-		
+
 		JCExpression returnType, constructorType;
-		
+
 		ListBuffer<JCTypeParameter> typeParams = new ListBuffer<JCTypeParameter>();
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
 		ListBuffer<JCExpression> args = new ListBuffer<JCExpression>();
-		
+
 		if (!type.typarams.isEmpty()) {
 			for (JCTypeParameter param : type.typarams) {
 				typeParams.append(maker.TypeParameter(param.name, cloneTypes(maker, param.bounds, source)));
@@ -459,7 +459,7 @@ public class HandleConstructor {
 		if (getCheckerFrameworkVersion(typeNode).generateUnique()) annsOnReturnType = List.of(maker.Annotation(genTypeRef(typeNode, CheckerFrameworkVersion.NAME__UNIQUE), List.<JCExpression>nil()));
 		returnType = namePlusTypeParamsToTypeReference(maker, typeNode, type.typarams, annsOnReturnType);
 		constructorType = namePlusTypeParamsToTypeReference(maker, typeNode, type.typarams);
-		
+
 		for (JavacNode fieldNode : fields) {
 			JCVariableDecl field = (JCVariableDecl) fieldNode.get();
 			Name fieldName = removePrefixFromField(fieldNode);
@@ -472,15 +472,15 @@ public class HandleConstructor {
 		}
 		JCReturn returnStatement = maker.Return(maker.NewClass(null, List.<JCExpression>nil(), constructorType, args.toList(), null));
 		JCBlock body = maker.Block(0, List.<JCStatement>of(returnStatement));
-		
+
 		JCMethodDecl methodDef = maker.MethodDef(mods, typeNode.toName(name), returnType, typeParams.toList(), params.toList(), List.<JCExpression>nil(), body, null);
 		createRelevantNonNullAnnotation(typeNode, methodDef);
 		return recursiveSetGeneratedBy(methodDef, source);
 	}
-	
+
 	private void generateConstructorJavadoc(JCMethodDecl constructor, JavacNode typeNode, List<JavacNode> fields) {
 		if (fields.isEmpty()) return;
-		
+
 		JCCompilationUnit cu = ((JCCompilationUnit) typeNode.top().get());
 		String constructorJavadoc = getConstructorJavadocHeader(typeNode.getName());
 		boolean fieldDescriptionAdded = false;
@@ -488,13 +488,13 @@ public class HandleConstructor {
 			String paramName = removePrefixFromField(fieldNode).toString();
 			String fieldJavadoc = getDocComment(cu, fieldNode.get());
 			String paramJavadoc = getConstructorParameterJavadoc(paramName, fieldJavadoc);
-			
+
 			if (paramJavadoc == null) {
 				paramJavadoc = "@param " + paramName;
 			} else {
 				fieldDescriptionAdded = true;
 			}
-			
+
 			constructorJavadoc = addJavadocLine(constructorJavadoc, paramJavadoc);
 		}
 		if (fieldDescriptionAdded) {

--- a/src/core/lombok/javac/handlers/HandleConstructor.java
+++ b/src/core/lombok/javac/handlers/HandleConstructor.java
@@ -324,6 +324,8 @@ public class HandleConstructor {
 		ListBuffer<JCStatement> assigns = new ListBuffer<JCStatement>();
 		ListBuffer<JCVariableDecl> params = new ListBuffer<JCVariableDecl>();
 
+		boolean isNullMarked = isNullMarked(typeNode);
+
 		for (JavacNode fieldNode : fieldsToParam) {
 			JCVariableDecl field = (JCVariableDecl) fieldNode.get();
 			Name fieldName = removePrefixFromField(fieldNode);
@@ -333,7 +335,7 @@ public class HandleConstructor {
 			JCExpression pType = cloneType(fieldNode.getTreeMaker(), field.vartype, source);
 			JCVariableDecl param = maker.VarDef(maker.Modifiers(flags, copyableAnnotations), fieldName, pType, null);
 			params.append(param);
-			if (hasNonNullAnnotations(fieldNode)) {
+			if (hasNonNullAnnotations(fieldNode) || isJSpecifyNonNull(isNullMarked, fieldNode)) {
 				JCStatement nullCheck = generateNullCheck(maker, param, source);
 				if (nullCheck != null) nullChecks.append(nullCheck);
 			}

--- a/src/core/lombok/javac/handlers/HandleSetter.java
+++ b/src/core/lombok/javac/handlers/HandleSetter.java
@@ -246,7 +246,7 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 		long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, field.getContext());
 		JCExpression pType = cloneType(treeMaker, fieldDecl.vartype, source);
 		JCVariableDecl param = treeMaker.VarDef(treeMaker.Modifiers(flags, annsOnParam), paramName, pType, null);
-		if (!hasNonNullAnnotations(field) && !hasNonNullAnnotations(field, onParam)) {
+		if (!hasNonNullAnnotations(field) && !hasNonNullAnnotations(field, onParam) && (!isJSpecifyNonNull(isNullMarked(getParentTypeNode(field)), field))) {
 
 			statements.append(treeMaker.Exec(assign));
 		} else {

--- a/src/core/lombok/javac/handlers/HandleSetter.java
+++ b/src/core/lombok/javac/handlers/HandleSetter.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2009-2025 The Project Lombok Authors.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -59,7 +59,7 @@ import com.sun.tools.javac.util.Name;
 @Provides
 public class HandleSetter extends JavacAnnotationHandler<Setter> {
 	private static final String SETTER_NODE_NOT_SUPPORTED_ERR = "@Setter is only supported on a class or a field.";
-	
+
 	public void generateSetterForType(JavacNode typeNode, JavacNode errorNode, AccessLevel level, boolean checkForTypeLevelSetter, List<JCAnnotation> onMethod, List<JCAnnotation> onParam) {
 		if (checkForTypeLevelSetter) {
 			if (hasAnnotation(Setter.class, typeNode)) {
@@ -67,12 +67,12 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 				return;
 			}
 		}
-		
+
 		if (!isClass(typeNode)) {
 			errorNode.addError(SETTER_NODE_NOT_SUPPORTED_ERR);
 			return;
 		}
-		
+
 		for (JavacNode field : typeNode.down()) {
 			if (field.getKind() != Kind.FIELD) continue;
 			JCVariableDecl fieldDecl = (JCVariableDecl) field.get();
@@ -82,23 +82,23 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 			if ((fieldDecl.mods.flags & Flags.STATIC) != 0) continue;
 			//Skip final fields.
 			if ((fieldDecl.mods.flags & Flags.FINAL) != 0) continue;
-			
+
 			generateSetterForField(field, errorNode, level, onMethod, onParam);
 		}
 	}
-	
+
 	/**
 	 * Generates a setter on the stated field.
-	 * 
+	 *
 	 * Used by {@link HandleData}.
-	 * 
+	 *
 	 * The difference between this call and the handle method is as follows:
-	 * 
+	 *
 	 * If there is a {@code lombok.Setter} annotation on the field, it is used and the
 	 * same rules apply (e.g. warning if the method already exists, stated access level applies).
 	 * If not, the setter is still generated if it isn't already there, though there will not
 	 * be a warning if its already there. The default access level is used.
-	 * 
+	 *
 	 * @param fieldNode The node representing the field you want a setter for.
 	 * @param pos The node responsible for generating the setter (the {@code @Data} or {@code @Setter} annotation).
 	 */
@@ -107,21 +107,21 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 			//The annotation will make it happen, so we can skip it.
 			return;
 		}
-		
+
 		createSetterForField(level, fieldNode, sourceNode, false, onMethod, onParam);
 	}
-	
+
 	@Override public void handle(AnnotationValues<Setter> annotation, JCAnnotation ast, JavacNode annotationNode) {
 		handleFlagUsage(annotationNode, ConfigurationKeys.SETTER_FLAG_USAGE, "@Setter");
-		
+
 		Collection<JavacNode> fields = annotationNode.upFromAnnotationToFields();
 		deleteAnnotationIfNeccessary(annotationNode, Setter.class);
 		deleteImportFromCompilationUnit(annotationNode, "lombok.AccessLevel");
 		JavacNode node = annotationNode.up();
 		AccessLevel level = annotation.getInstance().value();
-		
+
 		if (level == AccessLevel.NONE || node == null) return;
-		
+
 		List<JCAnnotation> onMethod = unboxAndRemoveAnnotationParameter(ast, "onMethod", "@Setter(onMethod", annotationNode);
 		if (!onMethod.isEmpty()) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.ON_X_FLAG_USAGE, "@Setter(onMethod=...)");
@@ -130,7 +130,7 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 		if (!onParam.isEmpty()) {
 			handleFlagUsage(annotationNode, ConfigurationKeys.ON_X_FLAG_USAGE, "@Setter(onParam=...)");
 		}
-		
+
 		switch (node.getKind()) {
 		case FIELD:
 			createSetterForFields(level, fields, annotationNode, true, onMethod, onParam);
@@ -140,33 +140,33 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 			break;
 		}
 	}
-	
+
 	public void createSetterForFields(AccessLevel level, Collection<JavacNode> fieldNodes, JavacNode errorNode, boolean whineIfExists, List<JCAnnotation> onMethod, List<JCAnnotation> onParam) {
 		for (JavacNode fieldNode : fieldNodes) {
 			createSetterForField(level, fieldNode, errorNode, whineIfExists, onMethod, onParam);
 		}
 	}
-	
+
 	public void createSetterForField(AccessLevel level, JavacNode fieldNode, JavacNode sourceNode, boolean whineIfExists, List<JCAnnotation> onMethod, List<JCAnnotation> onParam) {
 		if (fieldNode.getKind() != Kind.FIELD) {
 			fieldNode.addError(SETTER_NODE_NOT_SUPPORTED_ERR);
 			return;
 		}
-		
+
 		AnnotationValues<Accessors> accessors = JavacHandlerUtil.getAccessorsForField(fieldNode);
 		JCVariableDecl fieldDecl = (JCVariableDecl) fieldNode.get();
 		String methodName = toSetterName(fieldNode, accessors);
-		
+
 		if (methodName == null) {
 			fieldNode.addWarning("Not generating setter for this field: It does not fit your @Accessors prefix list.");
 			return;
 		}
-		
+
 		if ((fieldDecl.mods.flags & Flags.FINAL) != 0) {
 			fieldNode.addWarning("Not generating setter for this field: Setters cannot be generated for final fields.");
 			return;
 		}
-		
+
 		for (String altName : toAllSetterNames(fieldNode, accessors)) {
 			switch (methodExists(altName, fieldNode, false, 1)) {
 			case EXISTS_BY_LOMBOK:
@@ -184,13 +184,13 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 				//continue scanning the other alt names.
 			}
 		}
-		
+
 		long access = toJavacModifier(level) | (fieldDecl.mods.flags & Flags.STATIC);
-		
+
 		JCMethodDecl createdSetter = createSetter(access, fieldNode, fieldNode.getTreeMaker(), sourceNode, onMethod, onParam);
 		injectMethod(fieldNode.up(), createdSetter);
 	}
-	
+
 	public static JCMethodDecl createSetter(long access, JavacNode field, JavacTreeMaker treeMaker, JavacNode source, List<JCAnnotation> onMethod, List<JCAnnotation> onParam) {
 		AnnotationValues<Accessors> accessors = JavacHandlerUtil.getAccessorsForField(field);
 		String setterName = toSetterName(field, accessors);
@@ -198,7 +198,7 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 		JCMethodDecl setter = createSetter(access, false, field, treeMaker, setterName, null, null, returnThis, source, onMethod, onParam);
 		return setter;
 	}
-	
+
 	public static JCMethodDecl createSetter(long access, boolean deprecate, JavacNode field, JavacTreeMaker treeMaker, String setterName, Name paramName, Name booleanFieldToSet, boolean shouldReturnThis, JavacNode source, List<JCAnnotation> onMethod, List<JCAnnotation> onParam) {
 		JCExpression returnType = null;
 		JCReturn returnStatement = null;
@@ -207,10 +207,10 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 			returnType = addCheckerFrameworkReturnsReceiver(returnType, treeMaker, field, getCheckerFrameworkVersion(source));
 			returnStatement = treeMaker.Return(treeMaker.Ident(field.toName("this")));
 		}
-		
+
 		return createSetter(access, deprecate, field, treeMaker, setterName, paramName, booleanFieldToSet, returnType, returnStatement, source, onMethod, onParam);
 	}
-	
+
 	public static JCMethodDecl createSetterWithRecv(long access, boolean deprecate, JavacNode field, JavacTreeMaker treeMaker, String setterName, Name paramName, Name booleanFieldToSet, boolean shouldReturnThis, JavacNode source, List<JCAnnotation> onMethod, List<JCAnnotation> onParam, JCVariableDecl recv, boolean forceAnnotationCopying) {
 		JCExpression returnType = null;
 		JCReturn returnStatement = null;
@@ -219,72 +219,72 @@ public class HandleSetter extends JavacAnnotationHandler<Setter> {
 			returnType = addCheckerFrameworkReturnsReceiver(returnType, treeMaker, field, getCheckerFrameworkVersion(source));
 			returnStatement = treeMaker.Return(treeMaker.Ident(field.toName("this")));
 		}
-		
+
 		JCMethodDecl d = createSetterWithRecv(access, deprecate, field, treeMaker, setterName, paramName, booleanFieldToSet, returnType, returnStatement, source, onMethod, onParam, recv);
 		return d;
 	}
-	
+
 	public static JCMethodDecl createSetter(long access, boolean deprecate, JavacNode field, JavacTreeMaker treeMaker, String setterName, Name paramName, Name booleanFieldToSet, JCExpression methodType, JCStatement returnStatement, JavacNode source, List<JCAnnotation> onMethod, List<JCAnnotation> onParam) {
 		return createSetterWithRecv(access, deprecate, field, treeMaker, setterName, paramName, booleanFieldToSet, methodType, returnStatement, source, onMethod, onParam, null);
 	}
-	
+
 	public static JCMethodDecl createSetterWithRecv(long access, boolean deprecate, JavacNode field, JavacTreeMaker treeMaker, String setterName, Name paramName, Name booleanFieldToSet, JCExpression methodType, JCStatement returnStatement, JavacNode source, List<JCAnnotation> onMethod, List<JCAnnotation> onParam, JCVariableDecl recv) {
 		if (setterName == null) return null;
-		
+
 		JCVariableDecl fieldDecl = (JCVariableDecl) field.get();
 		if (paramName == null) paramName = fieldDecl.name;
-		
+
 		JCExpression fieldRef = createFieldAccessor(treeMaker, field, FieldAccess.ALWAYS_FIELD);
 		JCAssign assign = treeMaker.Assign(fieldRef, treeMaker.Ident(paramName));
-		
+
 		ListBuffer<JCStatement> statements = new ListBuffer<JCStatement>();
 		List<JCAnnotation> copyableAnnotations = findCopyableAnnotations(field);
-		
+
 		Name methodName = field.toName(setterName);
 		List<JCAnnotation> annsOnParam = copyAnnotations(onParam, treeMaker).appendList(copyableAnnotations);
-		
+
 		long flags = JavacHandlerUtil.addFinalIfNeeded(Flags.PARAMETER, field.getContext());
 		JCExpression pType = cloneType(treeMaker, fieldDecl.vartype, source);
 		JCVariableDecl param = treeMaker.VarDef(treeMaker.Modifiers(flags, annsOnParam), paramName, pType, null);
-		
 		if (!hasNonNullAnnotations(field) && !hasNonNullAnnotations(field, onParam)) {
+
 			statements.append(treeMaker.Exec(assign));
 		} else {
 			JCStatement nullCheck = generateNullCheck(treeMaker, fieldDecl.vartype, paramName, source, null);
 			if (nullCheck != null) statements.append(nullCheck);
 			statements.append(treeMaker.Exec(assign));
 		}
-		
+
 		if (booleanFieldToSet != null) {
 			JCAssign setBool = treeMaker.Assign(treeMaker.Ident(booleanFieldToSet), treeMaker.Literal(CTC_BOOLEAN, 1));
 			statements.append(treeMaker.Exec(setBool));
 		}
-		
+
 		if (methodType == null) {
 			//WARNING: Do not use field.getSymbolTable().voidType - that field has gone through non-backwards compatible API changes within javac1.6.
 			methodType = treeMaker.Type(Javac.createVoidType(field.getSymbolTable(), CTC_VOID));
 			returnStatement = null;
 		}
-		
+
 		if (returnStatement != null) statements.append(returnStatement);
-		
+
 		JCBlock methodBody = treeMaker.Block(0, statements.toList());
 		List<JCTypeParameter> methodGenericParams = List.nil();
 		List<JCVariableDecl> parameters = List.of(param);
 		List<JCExpression> throwsClauses = List.nil();
 		JCExpression annotationMethodDefaultValue = null;
-		
+
 		// Copying Jackson annotations is required for fluent accessors (otherwise Jackson would not find the accessor).
 		AnnotationValues<Accessors> accessors = JavacHandlerUtil.getAccessorsForField(field);
 		boolean fluent = accessors.isExplicit("fluent");
 		Boolean fluentConfig = field.getAst().readConfiguration(ConfigurationKeys.ACCESSORS_FLUENT);
 		if (fluentConfig != null && fluentConfig) fluent = fluentConfig;
-		
+
 		List<JCAnnotation> annsOnMethod = mergeAnnotations(copyAnnotations(onMethod, treeMaker), findCopyableToSetterAnnotations(field, fluent));
 		if (isFieldDeprecated(field) || deprecate) {
 			annsOnMethod = annsOnMethod.prepend(treeMaker.Annotation(genJavaLangTypeRef(field, "Deprecated"), List.<JCExpression>nil()));
 		}
-		
+
 		if (shouldMakeFinal(field, accessors)) access |= Flags.FINAL;
 		JCMethodDecl methodDef;
 		if (recv != null && treeMaker.hasMethodDefWithRecvParam()) {

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -131,7 +131,7 @@ public class JavacHandlerUtil {
 	/**
 	 * Find the parent class or interface
 	 */
-  static JavacNode getParentTypeNode(JavacNode childOfType) {
+	static JavacNode getParentTypeNode(JavacNode childOfType) {
 		JavacNode typeNode = childOfType;
 		while (typeNode != null && typeNode.getKind() != Kind.TYPE) typeNode = typeNode.up();
 		return typeNode;

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -119,8 +119,38 @@ public class JavacHandlerUtil {
 	private JavacHandlerUtil() {
 		//Prevent instantiation
 	}
-	
-  private static class MarkingScanner extends TreeScanner {
+
+	static boolean hasNullableAnnotations(JavacNode fieldNode) {
+		return hasAnnotation("org.jspecify.annotations.Nullable", fieldNode);
+	}
+
+	static boolean isNullMarked(JavacNode typeNode) {
+		return hasAnnotation("org.jspecify.annotations.NullMarked", typeNode);
+	}
+
+	/**
+	 * Find the parent class or interface
+	 */
+  static JavacNode getParentTypeNode(JavacNode childOfType) {
+		JavacNode typeNode = childOfType;
+		while (typeNode != null && typeNode.getKind() != Kind.TYPE) typeNode = typeNode.up();
+		return typeNode;
+	}
+
+	/**
+	 * Return true if the specified field or parameter node is determined as non-null according
+	 * to JSpecify rules.
+	 * Currently supports @NullMarked on class. To support annotations on package-info.java, we
+	 * would need to place each type node under a package node. Supporting NullMarked on the type
+	 * seems adequate for now, and gives the option opt-in to null assertions on a per class basis
+	 * (i.e. have NullMarked be the default but allow a custom annotation to trigger null checks at
+	 * system boundaries only).
+	 */
+	static boolean isJSpecifyNonNull(boolean isNullMarked, JavacNode node) {
+		return isNullMarked && !hasNullableAnnotations(node);
+	}
+
+	private static class MarkingScanner extends TreeScanner {
 		private final JavacNode source;
 
 		MarkingScanner(JavacNode source) {
@@ -796,9 +826,8 @@ public class JavacHandlerUtil {
 	}
 
 	public static JCExpression cloneSelfType(JavacNode childOfType) {
-		JavacNode typeNode = childOfType;
 		JavacTreeMaker maker = childOfType.getTreeMaker();
-		while (typeNode != null && typeNode.getKind() != Kind.TYPE) typeNode = typeNode.up();
+		JavacNode typeNode = getParentTypeNode(childOfType);
 		return JavacHandlerUtil.namePlusTypeParamsToTypeReference(maker, typeNode, ((JCClassDecl) typeNode.get()).typarams);
 	}
 
@@ -1716,17 +1745,17 @@ public class JavacHandlerUtil {
 				for (String nn : NONNULL_ANNOTATIONS) if (typeMatches(nn, node, annotationTypeName)) return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	public static boolean hasNonNullAnnotations(JavacNode node, List<JCAnnotation> anns) {
 		if (anns == null) return false;
 		for (JCAnnotation ann : anns) {
 			String annotationTypeName = getTypeName(ann.annotationType);
 			for (String nn : NONNULL_ANNOTATIONS) if (typeMatches(nn, node, annotationTypeName)) return true;
 		}
-		
+
 		return false;
 	}
 

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2009-2025 The Project Lombok Authors.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -120,13 +120,13 @@ public class JavacHandlerUtil {
 		//Prevent instantiation
 	}
 	
-	private static class MarkingScanner extends TreeScanner {
+  private static class MarkingScanner extends TreeScanner {
 		private final JavacNode source;
-		
+
 		MarkingScanner(JavacNode source) {
 			this.source = source;
 		}
-		
+
 		@Override public void scan(JCTree tree) {
 			if (tree == null) return;
 			if (JCTree_keepPosition.get(tree)) return;
@@ -134,7 +134,7 @@ public class JavacHandlerUtil {
 			super.scan(tree);
 		}
 	}
-	
+
 	/**
 	 * Contributed by Jan Lahoda; many lombok transformations should not be run (or a lite version should be run) when the netbeans editor
 	 * is running javac on the open source file to find inline errors and such. As class files are compiled separately this does not affect
@@ -143,32 +143,32 @@ public class JavacHandlerUtil {
 	public static boolean inNetbeansEditor(JavacNode node) {
 		return inNetbeansEditor(node.getContext());
 	}
-	
+
 	public static boolean inNetbeansEditor(Context context) {
 		Options options = Options.instance(context);
 		return (options.keySet().contains("ide") && !options.keySet().contains("backgroundCompilation"));
 	}
-	
+
 	public static boolean inNetbeansCompileOnSave(Context context) {
 		Options options = Options.instance(context);
 		return (options.keySet().contains("ide") && options.keySet().contains("backgroundCompilation"));
 	}
-	
+
 	public static JCTree getGeneratedBy(JCTree node) {
 		return JCTree_generatedNode.get(node);
 	}
-	
+
 	public static boolean isGenerated(JCTree node) {
 		return getGeneratedBy(node) != null;
 	}
-	
+
 	public static <T extends JCTree> T recursiveSetGeneratedBy(T node, JavacNode source) {
 		if (node == null) return null;
 		setGeneratedBy(node, source);
 		node.accept(new MarkingScanner(source));
 		return node;
 	}
-	
+
 	public static <T extends JCTree> T setGeneratedBy(T node, JavacNode sourceNode) {
 		if (node == null) return null;
 		if (sourceNode == null) {
@@ -176,10 +176,10 @@ public class JavacHandlerUtil {
 			return node;
 		}
 		JCTree_generatedNode.set(node, sourceNode.get());
-		
+
 		if (JCTree_keepPosition.get(node)) return node;
 		if (inNetbeansEditor(sourceNode.getContext()) && !isParameter(node)) return node;
-		
+
 		node.pos = sourceNode.getStartPos();
 		storeEnd(node, sourceNode.getEndPosition(), (JCCompilationUnit) sourceNode.top().get());
 		return node;
@@ -188,19 +188,19 @@ public class JavacHandlerUtil {
 	public static boolean isParameter(JCTree node) {
 		return node instanceof JCVariableDecl && (((JCVariableDecl) node).mods.flags & Flags.PARAMETER) != 0;
 	}
-	
+
 	public static boolean hasAnnotation(String type, JavacNode node) {
 		return hasAnnotation(type, node, false);
 	}
-	
+
 	public static boolean hasAnnotation(Class<? extends Annotation> type, JavacNode node) {
 		return hasAnnotation(type, node, false);
 	}
-	
+
 	public static boolean hasAnnotationAndDeleteIfNeccessary(Class<? extends Annotation> type, JavacNode node) {
 		return hasAnnotation(type, node, true);
 	}
-	
+
 	private static boolean hasAnnotation(Class<? extends Annotation> type, JavacNode node, boolean delete) {
 		if (node == null) return false;
 		if (type == null) return false;
@@ -221,7 +221,7 @@ public class JavacHandlerUtil {
 			return false;
 		}
 	}
-	
+
 	private static boolean hasAnnotation(String type, JavacNode node, boolean delete) {
 		if (node == null) return false;
 		if (type == null) return false;
@@ -242,7 +242,7 @@ public class JavacHandlerUtil {
 			return false;
 		}
 	}
-	
+
 	public static JavacNode findInnerClass(JavacNode parent, String name) {
 		for (JavacNode child : parent.down()) {
 			if (child.getKind() != Kind.TYPE) continue;
@@ -251,11 +251,11 @@ public class JavacHandlerUtil {
 		}
 		return null;
 	}
-	
+
 	public static JavacNode findAnnotation(Class<? extends Annotation> type, JavacNode node) {
 		return findAnnotation(type, node, false);
 	}
-	
+
 	public static JavacNode findAnnotation(Class<? extends Annotation> type, JavacNode node, boolean delete) {
 		if (node == null) return null;
 		if (type == null) return null;
@@ -276,10 +276,10 @@ public class JavacHandlerUtil {
 			return null;
 		}
 	}
-	
+
 	/**
 	 * Checks if the Annotation AST Node provided is likely to be an instance of the provided annotation type.
-	 * 
+	 *
 	 * @param type An actual annotation type, such as {@code lombok.Getter.class}.
 	 * @param node A Lombok AST node representing an annotation in source code.
 	 */
@@ -287,10 +287,10 @@ public class JavacHandlerUtil {
 		if (node.getKind() != Kind.ANNOTATION) return false;
 		return typeMatches(type, node, ((JCAnnotation) node.get()).annotationType);
 	}
-	
+
 	/**
 	 * Checks if the Annotation AST Node provided is likely to be an instance of the provided annotation type.
-	 * 
+	 *
 	 * @param type An actual annotation type, such as {@code lombok.Getter.class}.
 	 * @param node A Lombok AST node representing an annotation in source code.
 	 */
@@ -298,10 +298,10 @@ public class JavacHandlerUtil {
 		if (node.getKind() != Kind.ANNOTATION) return false;
 		return typeMatches(type, node, ((JCAnnotation) node.get()).annotationType);
 	}
-	
+
 	/**
 	 * Checks if the given TypeReference node is likely to be a reference to the provided class.
-	 * 
+	 *
 	 * @param type An actual type. This method checks if {@code typeNode} is likely to be a reference to this type.
 	 * @param node A Lombok AST node. Any node in the appropriate compilation unit will do (used to get access to import statements).
 	 * @param typeNode A type reference to check.
@@ -309,10 +309,10 @@ public class JavacHandlerUtil {
 	public static boolean typeMatches(Class<?> type, JavacNode node, JCTree typeNode) {
 		return typeMatches(type.getName(), node, typeNode);
 	}
-	
+
 	/**
 	 * Checks if the given TypeReference node is likely to be a reference to the provided class.
-	 * 
+	 *
 	 * @param type An actual type. This method checks if {@code typeNode} is likely to be a reference to this type.
 	 * @param node A Lombok AST node. Any node in the appropriate compilation unit will do (used to get access to import statements).
 	 * @param typeNode A type reference to check.
@@ -355,12 +355,12 @@ public class JavacHandlerUtil {
 		}
 		return false;
 	}
-	
+
 	public static CheckerFrameworkVersion getCheckerFrameworkVersion(JavacNode node) {
 		CheckerFrameworkVersion cfv = node.getAst().readConfiguration(ConfigurationKeys.CHECKER_FRAMEWORK);
 		return cfv == null ? CheckerFrameworkVersion.NONE : cfv;
 	}
-	
+
 	/**
 	 * Returns if a node is marked deprecated (as picked up on by the parser).
 	 * @param node the node to check (type, method, or field decl).
@@ -371,17 +371,17 @@ public class JavacHandlerUtil {
 		if (node instanceof JCClassDecl) return (((JCClassDecl) node).mods.flags & Flags.DEPRECATED) != 0;
 		return false;
 	}
-	
+
 	/**
 	 * Creates an instance of {@code AnnotationValues} for the provided AST Node.
-	 * 
+	 *
 	 * @param type An annotation class type, such as {@code lombok.Getter.class}.
 	 * @param node A Lombok AST node representing an annotation in source code.
 	 */
 	public static <A extends Annotation> AnnotationValues<A> createAnnotation(Class<A> type, final JavacNode node) {
 		return createAnnotation(type, (JCAnnotation) node.get(), node);
 	}
-	
+
 	/**
 	 * Creates an instance of {@code AnnotationValues} for the provided AST Node
 	 * and Annotation expression.
@@ -393,7 +393,7 @@ public class JavacHandlerUtil {
 	public static <A extends Annotation> AnnotationValues<A> createAnnotation(Class<A> type, JCAnnotation anno, final JavacNode node) {
 		Map<String, AnnotationValue> values = new HashMap<String, AnnotationValue>();
 		List<JCExpression> arguments = anno.getArguments();
-		
+
 		for (JCExpression arg : arguments) {
 			String mName;
 			JCExpression rhs;
@@ -401,7 +401,7 @@ public class JavacHandlerUtil {
 			java.util.List<Object> guesses = new ArrayList<Object>();
 			java.util.List<Object> expressions = new ArrayList<Object>();
 			final java.util.List<DiagnosticPosition> positions = new ArrayList<DiagnosticPosition>();
-			
+
 			if (arg instanceof JCAssign) {
 				JCAssign assign = (JCAssign) arg;
 				mName = assign.lhs.toString();
@@ -410,7 +410,7 @@ public class JavacHandlerUtil {
 				rhs = arg;
 				mName = "value";
 			}
-			
+
 			if (rhs instanceof JCNewArray) {
 				List<JCExpression> elems = ((JCNewArray) rhs).elems;
 				for (JCExpression inner : elems) {
@@ -420,7 +420,7 @@ public class JavacHandlerUtil {
 						try {
 							@SuppressWarnings("unchecked")
 							Class<A> innerClass = (Class<A>) Class.forName(inner.type.toString());
-							
+
 							guesses.add(createAnnotation(innerClass, (JCAnnotation) inner, node));
 						} catch (ClassNotFoundException ex) {
 							guesses.add(calculateGuess(inner));
@@ -437,7 +437,7 @@ public class JavacHandlerUtil {
 					try {
 						@SuppressWarnings("unchecked")
 						Class<A> innerClass = (Class<A>) Class.forName(rhs.type.toString());
-						
+
 						guesses.add(createAnnotation(innerClass, (JCAnnotation) rhs, node));
 					} catch (ClassNotFoundException ex) {
 						guesses.add(calculateGuess(rhs));
@@ -447,20 +447,20 @@ public class JavacHandlerUtil {
 				}
 				positions.add(rhs.pos());
 			}
-			
+
 			values.put(mName, new AnnotationValue(node, raws, expressions, guesses, true) {
 				@Override public void setError(String message, int valueIdx) {
 					if (valueIdx < 0) node.addError(message);
 					else node.addError(message, positions.get(valueIdx));
 				}
-				
+
 				@Override public void setWarning(String message, int valueIdx) {
 					if (valueIdx < 0) node.addWarning(message);
 					else node.addWarning(message, positions.get(valueIdx));
 				}
 			});
 		}
-		
+
 		for (Method m : type.getDeclaredMethods()) {
 			if (!Modifier.isPublic(m.getModifiers())) continue;
 			String name = m.getName();
@@ -475,10 +475,10 @@ public class JavacHandlerUtil {
 				});
 			}
 		}
-		
+
 		return new AnnotationValues<A>(type, values, node);
 	}
-	
+
 	/**
 	 * Removes the annotation from javac's AST (it remains in lombok's AST),
 	 * then removes any import statement that imports this exact annotation (not star imports).
@@ -487,7 +487,7 @@ public class JavacHandlerUtil {
 	public static void deleteAnnotationIfNeccessary(JavacNode annotation, String annotationType) {
 		deleteAnnotationIfNeccessary0(annotation, annotationType);
 	}
-	
+
 	/**
 	 * Removes the annotation from javac's AST (it remains in lombok's AST),
 	 * then removes any import statement that imports this exact annotation (not star imports).
@@ -496,7 +496,7 @@ public class JavacHandlerUtil {
 	public static void deleteAnnotationIfNeccessary(JavacNode annotation, Class<? extends Annotation> annotationType) {
 		deleteAnnotationIfNeccessary0(annotation, annotationType.getName());
 	}
-	
+
 	/**
 	 * Removes the annotation from javac's AST (it remains in lombok's AST),
 	 * then removes any import statement that imports this exact annotation (not star imports).
@@ -505,7 +505,7 @@ public class JavacHandlerUtil {
 	public static void deleteAnnotationIfNeccessary(JavacNode annotation, Class<? extends Annotation> annotationType1, Class<? extends Annotation> annotationType2) {
 		deleteAnnotationIfNeccessary0(annotation, annotationType1.getName(), annotationType2.getName());
 	}
-	
+
 	/**
 	 * Removes the annotation from javac's AST (it remains in lombok's AST),
 	 * then removes any import statement that imports this exact annotation (not star imports).
@@ -514,7 +514,7 @@ public class JavacHandlerUtil {
 	public static void deleteAnnotationIfNeccessary(JavacNode annotation, Class<? extends Annotation> annotationType1, String annotationType2) {
 		deleteAnnotationIfNeccessary0(annotation, annotationType1.getName(), annotationType2);
 	}
-	
+
 	private static void deleteAnnotationIfNeccessary0(JavacNode annotation, String... annotationTypes) {
 		if (inNetbeansEditor(annotation)) return;
 		if (!annotation.shouldDeleteLombokAnnotations()) return;
@@ -525,7 +525,7 @@ public class JavacHandlerUtil {
 		case LOCAL:
 			JCVariableDecl variable = (JCVariableDecl) parentNode.get();
 			variable.mods.annotations = filterList(variable.mods.annotations, annotation.get());
-			
+
 			if ((variable.mods.flags & GENERATED_MEMBER) != 0) {
 				JavacNode typeNode = upToTypeNode(annotation);
 				if (isRecord(typeNode)) {
@@ -549,19 +549,19 @@ public class JavacHandlerUtil {
 			//This really shouldn't happen, but if it does, better just break delombok instead of breaking everything.
 			return;
 		}
-		
+
 		parentNode.getAst().setChanged();
 		for (String annotationType : annotationTypes) {
 			deleteImportFromCompilationUnit(annotation, annotationType);
 		}
 	}
-	
+
 	public static void deleteImportFromCompilationUnit(JavacNode node, String name) {
 		if (inNetbeansEditor(node)) return;
 		if (!node.shouldDeleteLombokAnnotations()) return;
-		
+
 		JCCompilationUnit unit = (JCCompilationUnit) node.top().get();
-		
+
 		for (JCTree def : unit.defs) {
 			if (!(def instanceof JCImport)) continue;
 			JCImport imp0rt = (JCImport) def;
@@ -570,7 +570,7 @@ public class JavacHandlerUtil {
 			JavacAugments.JCImport_deletable.set(imp0rt, true);
 		}
 	}
-	
+
 	private static List<JCAnnotation> filterList(List<JCAnnotation> annotations, JCTree jcTree) {
 		ListBuffer<JCAnnotation> newAnnotations = new ListBuffer<JCAnnotation>();
 		for (JCAnnotation ann : annotations) {
@@ -578,7 +578,7 @@ public class JavacHandlerUtil {
 		}
 		return newAnnotations.toList();
 	}
-	
+
 	private static List<JCAnnotation> filterListByPos(List<JCAnnotation> annotations, JCTree jcTree) {
 		ListBuffer<JCAnnotation> newAnnotations = new ListBuffer<JCAnnotation>();
 		for (JCAnnotation ann : annotations) {
@@ -586,14 +586,14 @@ public class JavacHandlerUtil {
 		}
 		return newAnnotations.toList();
 	}
-	
-	
+
+
 	static class RecordComponentReflect {
-		
+
 		private static final Field astField;
 		private static final Field originalAnnos;
 		private static final Method getRecordComponents = Permit.permissiveGetMethod(ClassSymbol.class, "getRecordComponents");
-		
+
 		static {
 			Field a = null;
 			Field o = null;
@@ -607,17 +607,17 @@ public class JavacHandlerUtil {
 			astField = a;
 			originalAnnos = o;
 		}
-		
+
 		static void deleteAnnotation(JCClassDecl record, JCVariableDecl component, JCTree annotation) {
 			if ((astField == null && originalAnnos == null) || getRecordComponents == null) return;
-			
+
 			try {
 				List<?> recordComponents = (List<?>) Permit.invokeSneaky(getRecordComponents, record.sym);
-				
+
 				for (Object recordComponent : recordComponents) {
 					Name recordComponentName = ((Symbol) recordComponent).name;
 					if (!recordComponentName.equals(component.name)) continue;
-					
+
 					if (astField != null) {
 						// OpenJDK
 						JCVariableDecl variable = Permit.get(astField, recordComponent);
@@ -634,12 +634,12 @@ public class JavacHandlerUtil {
 			}
 		}
 	}
-	
+
 	/** Serves as return value for the methods that check for the existence of fields and methods. */
 	public enum MemberExistsResult {
 		NOT_EXISTS, EXISTS_BY_LOMBOK, EXISTS_BY_USER;
 	}
-	
+
 	/**
 	 * Translates the given field into all possible getter names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllGetterNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -647,7 +647,7 @@ public class JavacHandlerUtil {
 	public static java.util.List<String> toAllGetterNames(JavacNode field) {
 		return HandlerUtil.toAllGetterNames(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * Translates the given field into all possible getter names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllGetterNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -655,25 +655,25 @@ public class JavacHandlerUtil {
 	public static java.util.List<String> toAllGetterNames(JavacNode field, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toAllGetterNames(field.getAst(), accessors, field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * @return the likely getter name for the stated field. (e.g. private boolean foo; to isFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toGetterName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toGetterName(JavacNode field) {
 		return HandlerUtil.toGetterName(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * @return the likely getter name for the stated field. (e.g. private boolean foo; to isFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toGetterName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toGetterName(JavacNode field, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toGetterName(field.getAst(), accessors, field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * Translates the given field into all possible setter names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllSetterNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -681,7 +681,7 @@ public class JavacHandlerUtil {
 	public static java.util.List<String> toAllSetterNames(JavacNode field) {
 		return HandlerUtil.toAllSetterNames(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * Translates the given field into all possible setter names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllSetterNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -689,25 +689,25 @@ public class JavacHandlerUtil {
 	public static java.util.List<String> toAllSetterNames(JavacNode field, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toAllSetterNames(field.getAst(), accessors, field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * @return the likely setter name for the stated field. (e.g. private boolean foo; to setFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toSetterName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toSetterName(JavacNode field) {
 		return HandlerUtil.toSetterName(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * @return the likely setter name for the stated field. (e.g. private boolean foo; to setFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toSetterName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toSetterName(JavacNode field, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toSetterName(field.getAst(), accessors, field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * Translates the given field into all possible with names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllWithNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -715,7 +715,7 @@ public class JavacHandlerUtil {
 	public static java.util.List<String> toAllWithNames(JavacNode field) {
 		return HandlerUtil.toAllWithNames(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * Translates the given field into all possible with names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllWithNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -723,7 +723,7 @@ public class JavacHandlerUtil {
 	public static java.util.List<String> toAllWithNames(JavacNode field, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toAllWithNames(field.getAst(), accessors, field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * Translates the given field into all possible withBy names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllWithByNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -731,7 +731,7 @@ public class JavacHandlerUtil {
 	public static java.util.List<String> toAllWithByNames(JavacNode field) {
 		return HandlerUtil.toAllWithByNames(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * Translates the given field into all possible withBy names.
 	 * Convenient wrapper around {@link HandlerUtil#toAllWithByNames(lombok.core.AnnotationValues, CharSequence, boolean)}.
@@ -739,78 +739,78 @@ public class JavacHandlerUtil {
 	public static java.util.List<String> toAllWithByNames(JavacNode field, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toAllWithByNames(field.getAst(), accessors, field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * @return the likely with name for the stated field. (e.g. private boolean foo; to withFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toWithName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toWithName(JavacNode field) {
 		return HandlerUtil.toWithName(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * @return the likely with name for the stated field. (e.g. private boolean foo; to withFoo).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toWithName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toWithName(JavacNode field, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toWithName(field.getAst(), accessors, field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * @return the likely withBy name for the stated field. (e.g. private boolean foo; to withFooBy).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toWithByName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toWithByName(JavacNode field) {
 		return HandlerUtil.toWithByName(field.getAst(), getAccessorsForField(field), field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * @return the likely withBy name for the stated field. (e.g. private boolean foo; to withFooBy).
-	 * 
+	 *
 	 * Convenient wrapper around {@link HandlerUtil#toWithByName(lombok.core.AnnotationValues, CharSequence, boolean)}.
 	 */
 	public static String toWithByName(JavacNode field, AnnotationValues<Accessors> accessors) {
 		return HandlerUtil.toWithByName(field.getAst(), accessors, field.getName(), isBoolean(field));
 	}
-	
+
 	/**
 	 * When generating a setter, the setter either returns void (beanspec) or Self (fluent).
 	 * This method scans for the {@code Accessors} annotation to figure that out.
 	 */
 	public static boolean shouldReturnThis(JavacNode field, AnnotationValues<Accessors> accessors) {
 		if ((((JCVariableDecl) field.get()).mods.flags & Flags.STATIC) != 0) return false;
-		
+
 		return HandlerUtil.shouldReturnThis0(accessors, field.getAst());
 	}
-	
+
 	/**
 	 * When generating a setter/getter/wither, should it be made final?
 	 */
 	public static boolean shouldMakeFinal(JavacNode field, AnnotationValues<Accessors> accessors) {
 		if ((((JCVariableDecl) field.get()).mods.flags & Flags.STATIC) != 0) return false;
-		
+
 		return HandlerUtil.shouldMakeFinal0(accessors, field.getAst());
 	}
-	
+
 	public static JCExpression cloneSelfType(JavacNode childOfType) {
 		JavacNode typeNode = childOfType;
 		JavacTreeMaker maker = childOfType.getTreeMaker();
 		while (typeNode != null && typeNode.getKind() != Kind.TYPE) typeNode = typeNode.up();
 		return JavacHandlerUtil.namePlusTypeParamsToTypeReference(maker, typeNode, ((JCClassDecl) typeNode.get()).typarams);
 	}
-	
-	public static boolean isBoolean(JavacNode field) {
+
+  public static boolean isBoolean(JavacNode field) {
 		JCExpression varType = ((JCVariableDecl) field.get()).vartype;
 		return isBoolean(varType);
 	}
-	
+
 	public static boolean isBoolean(JCExpression varType) {
 		return varType != null && varType.toString().equals("boolean");
 	}
-	
+
 	public static Name removePrefixFromField(JavacNode field) {
 		java.util.List<String> prefixes = null;
 		for (JavacNode node : field.down()) {
@@ -820,7 +820,7 @@ public class JavacHandlerUtil {
 				break;
 			}
 		}
-		
+
 		if (prefixes == null) {
 			JavacNode current = field.up();
 			outer:
@@ -835,27 +835,27 @@ public class JavacHandlerUtil {
 				current = current.up();
 			}
 		}
-		
+
 		if (prefixes == null) prefixes = field.getAst().readConfiguration(ConfigurationKeys.ACCESSORS_PREFIX);
-		
+
 		if (!prefixes.isEmpty()) {
 			CharSequence newName = removePrefix(field.getName(), prefixes);
 			if (newName != null) return field.toName(newName.toString());
 		}
-		
+
 		return ((JCVariableDecl) field.get()).name;
 	}
-	
+
 	public static AnnotationValues<Accessors> getAccessorsForField(JavacNode field) {
 		AnnotationValues<Accessors> values = null;
-		
+
 		for (JavacNode node : field.down()) {
 			if (annotationTypeMatches(Accessors.class, node)) {
 				values = createAnnotation(Accessors.class, node);
 				break;
 			}
 		}
-		
+
 		JavacNode current = field.up();
 		while (current != null) {
 			for (JavacNode node : current.down()) {
@@ -867,19 +867,19 @@ public class JavacHandlerUtil {
 			}
 			current = current.up();
 		}
-		
+
 		return values == null ? AnnotationValues.of(Accessors.class, field) : values;
 	}
-	
+
 	/**
 	 * Checks if there is a field with the provided name.
-	 * 
+	 *
 	 * @param fieldName the field name to check for.
 	 * @param node Any node that represents the Type (JCClassDecl) to look in, or any child node thereof.
 	 */
 	public static MemberExistsResult fieldExists(String fieldName, JavacNode node) {
 		node = upToTypeNode(node);
-		
+
 		if (node != null && node.get() instanceof JCClassDecl) {
 			for (JCTree def : ((JCClassDecl)node.get()).defs) {
 				if (def instanceof JCVariableDecl) {
@@ -889,18 +889,18 @@ public class JavacHandlerUtil {
 				}
 			}
 		}
-		
+
 		return MemberExistsResult.NOT_EXISTS;
 	}
-	
+
 	public static MemberExistsResult methodExists(String methodName, JavacNode node, int params) {
 		return methodExists(methodName, node, true, params);
 	}
-	
+
 	/**
 	 * Checks if there is a method with the provided name. In case of multiple methods (overloading), only
 	 * the first method decides if EXISTS_BY_USER or EXISTS_BY_LOMBOK is returned.
-	 * 
+	 *
 	 * @param methodName the method name to check for.
 	 * @param node Any node that represents the Type (JCClassDecl) to look in, or any child node thereof.
 	 * @param caseSensitive If the search should be case sensitive.
@@ -908,7 +908,7 @@ public class JavacHandlerUtil {
 	 */
 	public static MemberExistsResult methodExists(String methodName, JavacNode node, boolean caseSensitive, int params) {
 		node = upToTypeNode(node);
-		
+
 		if (node != null && node.get() instanceof JCClassDecl) {
 			top: for (JCTree def : ((JCClassDecl)node.get()).defs) {
 				if (def instanceof JCMethodDecl) {
@@ -929,21 +929,21 @@ public class JavacHandlerUtil {
 									maxArgs = minArgs;
 								}
 							}
-							
+
 							if (params < minArgs || params > maxArgs) continue;
 						}
-						
+
 						if (isTolerate(node, md)) continue top;
-						
+
 						return getGeneratedBy(def) == null ? MemberExistsResult.EXISTS_BY_USER : MemberExistsResult.EXISTS_BY_LOMBOK;
 					}
 				}
 			}
 		}
-		
+
 		return MemberExistsResult.NOT_EXISTS;
 	}
-	
+
 	public static boolean isTolerate(JavacNode node, JCTree.JCMethodDecl md) {
 		List<JCAnnotation> annotations = md.getModifiers().getAnnotations();
 		if (annotations != null) for (JCTree.JCAnnotation anno : annotations) {
@@ -951,16 +951,16 @@ public class JavacHandlerUtil {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Checks if there is a (non-default) constructor. In case of multiple constructors (overloading), only
 	 * the first constructor decides if EXISTS_BY_USER or EXISTS_BY_LOMBOK is returned.
-	 * 
+	 *
 	 * @param node Any node that represents the Type (JCClassDecl) to look in, or any child node thereof.
 	 */
 	public static MemberExistsResult constructorExists(JavacNode node) {
 		node = upToTypeNode(node);
-		
+
 		if (node != null && node.get() instanceof JCClassDecl) {
 			for (JCTree def : ((JCClassDecl) node.get()).defs) {
 				if (def instanceof JCMethodDecl) {
@@ -973,10 +973,10 @@ public class JavacHandlerUtil {
 				}
 			}
 		}
-		
+
 		return MemberExistsResult.NOT_EXISTS;
 	}
-	
+
 	public static boolean isConstructorCall(final JCStatement statement) {
 		if (!(statement instanceof JCExpressionStatement)) return false;
 		JCExpression expr = ((JCExpressionStatement) statement).expr;
@@ -990,10 +990,10 @@ public class JavacHandlerUtil {
 		} else {
 			name = "";
 		}
-		
+
 		return "super".equals(name) || "this".equals(name);
 	}
-	
+
 	/**
 	 * Turns an {@code AccessLevel} instance into the flag bit used by javac.
 	 */
@@ -1013,17 +1013,17 @@ public class JavacHandlerUtil {
 			return Flags.PROTECTED;
 		}
 	}
-	
+
 	private static class GetterMethod {
 		private final Name name;
 		private final JCExpression type;
-		
+
 		GetterMethod(Name name, JCExpression type) {
 			this.name = name;
 			this.type = type;
 		}
 	}
-	
+
 	private static GetterMethod findGetter(JavacNode field) {
 		JCVariableDecl decl = (JCVariableDecl)field.get();
 		JavacNode typeNode = field.up();
@@ -1039,11 +1039,11 @@ public class JavacHandlerUtil {
 				return new GetterMethod(method.name, method.restype);
 			}
 		}
-		
+
 		// Check if the field has a @Getter annotation.
-		
+
 		boolean hasGetterAnnotation = false;
-		
+
 		for (JavacNode child : field.down()) {
 			if (child.getKind() == Kind.ANNOTATION && annotationTypeMatches(Getter.class, child)) {
 				AnnotationValues<Getter> ann = createAnnotation(Getter.class, child);
@@ -1051,12 +1051,12 @@ public class JavacHandlerUtil {
 				hasGetterAnnotation = true;
 			}
 		}
-		
+
 		// Check if the class has a @Getter annotation.
-		
+
 		if (!hasGetterAnnotation && HandleGetter.fieldQualifiesForGetterGeneration(field)) {
 			//Check if the class has @Getter or @Data annotation.
-			
+
 			JavacNode containingType = field.up();
 			if (containingType != null) for (JavacNode child : containingType.down()) {
 				if (child.getKind() == Kind.ANNOTATION && annotationTypeMatches(Data.class, child)) hasGetterAnnotation = true;
@@ -1067,20 +1067,20 @@ public class JavacHandlerUtil {
 				}
 			}
 		}
-		
+
 		if (hasGetterAnnotation) {
 			String getterName = toGetterName(field);
 			if (getterName == null) return null;
 			return new GetterMethod(field.toName(getterName), decl.vartype);
 		}
-		
+
 		return null;
 	}
-	
+
 	static boolean lookForGetter(JavacNode field, FieldAccess fieldAccess) {
 		if (fieldAccess == FieldAccess.GETTER) return true;
 		if (fieldAccess == FieldAccess.ALWAYS_FIELD) return false;
-		
+
 		// If @Getter(lazy = true) is used, then using it is mandatory.
 		for (JavacNode child : field.down()) {
 			if (child.getKind() != Kind.ANNOTATION) continue;
@@ -1091,39 +1091,39 @@ public class JavacHandlerUtil {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Returns the type of the field, unless a getter exists for this field, in which case the return type of the getter is returned.
-	 * 
+	 *
 	 * @see #createFieldAccessor(TreeMaker, JavacNode, FieldAccess)
 	 */
 	static JCExpression getFieldType(JavacNode field, FieldAccess fieldAccess) {
 		if (field.getKind() == Kind.METHOD) return ((JCMethodDecl) field.get()).restype;
-		
+
 		boolean lookForGetter = lookForGetter(field, fieldAccess);
-		
+
 		GetterMethod getter = lookForGetter ? findGetter(field) : null;
-		
+
 		if (getter == null) {
 			return ((JCVariableDecl) field.get()).vartype;
 		}
-		
+
 		return getter.type;
 	}
-	
+
 	/**
 	 * Creates an expression that reads the field. Will either be {@code this.field} or {@code this.getField()} depending on whether or not there's a getter.
 	 */
 	static JCExpression createFieldAccessor(JavacTreeMaker maker, JavacNode field, FieldAccess fieldAccess) {
 		return createFieldAccessor(maker, field, fieldAccess, null);
 	}
-	
+
 	static JCExpression createFieldAccessor(JavacTreeMaker maker, JavacNode field, FieldAccess fieldAccess, JCExpression receiver) {
 		boolean lookForGetter = lookForGetter(field, fieldAccess);
-		
+
 		GetterMethod getter = lookForGetter ? findGetter(field) : null;
 		JCVariableDecl fieldDecl = (JCVariableDecl) field.get();
-		
+
 		if (getter == null) {
 			if (receiver == null) {
 				if ((fieldDecl.mods.flags & Flags.STATIC) == 0) {
@@ -1136,23 +1136,23 @@ public class JavacHandlerUtil {
 					}
 				}
 			}
-			
+
 			return receiver == null ? maker.Ident(fieldDecl.name) : maker.Select(receiver, fieldDecl.name);
 		}
-		
+
 		if (receiver == null) receiver = maker.Ident(field.toName("this"));
 		JCMethodInvocation call = maker.Apply(List.<JCExpression>nil(),
 			maker.Select(receiver, getter.name), List.<JCExpression>nil());
 		return call;
 	}
-	
+
 	static JCExpression createMethodAccessor(JavacTreeMaker maker, JavacNode method) {
 		return createMethodAccessor(maker, method, null);
 	}
-	
+
 	static JCExpression createMethodAccessor(JavacTreeMaker maker, JavacNode method, JCExpression receiver) {
 		JCMethodDecl methodDecl = (JCMethodDecl) method.get();
-		
+
 		if (receiver == null && (methodDecl.mods.flags & Flags.STATIC) == 0) {
 			receiver = maker.Ident(method.toName("this"));
 		} else if (receiver == null) {
@@ -1162,12 +1162,12 @@ public class JavacHandlerUtil {
 				receiver = maker.Ident(container.name);
 			}
 		}
-		
+
 		JCMethodInvocation call = maker.Apply(List.<JCExpression>nil(),
 			receiver == null ? maker.Ident(methodDecl.name) : maker.Select(receiver, methodDecl.name), List.<JCExpression>nil());
 		return call;
 	}
-	
+
 	/**
 	 * Adds the given new field declaration to the provided type AST Node.
 	 * The field carries the &#64;{@link SuppressWarnings}("all") annotation.
@@ -1176,28 +1176,28 @@ public class JavacHandlerUtil {
 	public static JavacNode injectFieldAndMarkGenerated(JavacNode typeNode, JCVariableDecl field) {
 		return injectField(typeNode, field, true);
 	}
-	
+
 	/**
 	 * Adds the given new field declaration to the provided type AST Node.
-	 * 
+	 *
 	 * Also takes care of updating the JavacAST.
 	 */
 	public static JavacNode injectField(JavacNode typeNode, JCVariableDecl field) {
 		return injectField(typeNode, field, false);
 	}
-	
+
 	public static JavacNode injectField(JavacNode typeNode, JCVariableDecl field, boolean addGenerated) {
 		return injectField(typeNode, field, addGenerated, false);
 	}
-	
+
 	public static JavacNode injectField(JavacNode typeNode, JCVariableDecl field, boolean addGenerated, boolean specialEnumHandling) {
 		JCClassDecl type = (JCClassDecl) typeNode.get();
-		
+
 		if (addGenerated) {
 			addSuppressWarningsAll(field.mods, typeNode, typeNode.getNodeFor(getGeneratedBy(field)), typeNode.getContext());
 			addGenerated(field.mods, typeNode, typeNode.getNodeFor(getGeneratedBy(field)), typeNode.getContext());
 		}
-		
+
 		List<JCTree> insertAfter = null;
 		List<JCTree> insertBefore = type.defs;
 		while (true) {
@@ -1222,27 +1222,27 @@ public class JavacHandlerUtil {
 		} else {
 			insertAfter.tail = fieldEntry;
 		}
-		
+
 		EnterReflect.memberEnter(field, typeNode);
-		
+
 		return typeNode.add(field, Kind.FIELD);
 	}
-	
+
 	public static boolean isEnumConstant(final JCVariableDecl field) {
 		return (field.mods.flags & Flags.ENUM) != 0;
 	}
-	
+
 	static class JCAnnotatedTypeReflect {
 		private static final Class<?> TYPE;
 		private static final Constructor<?> CONSTRUCTOR;
 		private static final Field ANNOTATIONS, UNDERLYING_TYPE;
-		
+
 		static {
 			Class<?> t = null;
 			Constructor<?> c = null;
 			Field a = null;
 			Field u = null;
-			
+
 			try {
 				t = Class.forName("com.sun.tools.javac.tree.JCTree$JCAnnotatedType");
 				c = Permit.getConstructor(t, List.class, JCExpression.class);
@@ -1251,18 +1251,18 @@ public class JavacHandlerUtil {
 			} catch (Exception e) {
 				// Ignore
 			}
-			
+
 			TYPE = t;
 			CONSTRUCTOR = c;
 			ANNOTATIONS = a;
 			UNDERLYING_TYPE = u;
 		}
-		
+
 		static boolean is(JCTree obj) {
 			if (obj == null) return false;
 			return obj.getClass() == TYPE;
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		static List<JCAnnotation> getAnnotations(JCTree obj) {
 			if (ANNOTATIONS == null) return List.nil();
@@ -1272,7 +1272,7 @@ public class JavacHandlerUtil {
 				return List.nil();
 			}
 		}
-		
+
 		static void setAnnotations(JCTree obj, List<JCAnnotation> anns) {
 			if (ANNOTATIONS == null) return;
 			try {
@@ -1281,7 +1281,7 @@ public class JavacHandlerUtil {
 				// Ignore
 			}
 		}
-		
+
 		static JCExpression getUnderlyingType(JCTree obj) {
 			if (UNDERLYING_TYPE == null) return null;
 			try {
@@ -1290,7 +1290,7 @@ public class JavacHandlerUtil {
 				return null;
 			}
 		}
-		
+
 		static JCExpression create(List<JCAnnotation> annotations, JCExpression underlyingType) {
 			if (CONSTRUCTOR == null) return underlyingType;
 			try {
@@ -1300,7 +1300,7 @@ public class JavacHandlerUtil {
 			}
 		}
 	}
-	
+
 	static class JCAnnotationReflect {
 		private static final Field ATTRIBUTE;
 
@@ -1318,7 +1318,7 @@ public class JavacHandlerUtil {
 			}
 			return null;
 		}
-		
+
 		static void setAttribute(JCAnnotation jcAnnotation, Attribute.Compound attribute) {
 			if (ATTRIBUTE != null) {
 				try {
@@ -1335,7 +1335,7 @@ public class JavacHandlerUtil {
 		private static final Field membersField;
 		private static final Method removeMethod;
 		private static final Method enterMethod;
-		
+
 		static {
 			Field f = null;
 			Method r = null;
@@ -1349,7 +1349,7 @@ public class JavacHandlerUtil {
 			removeMethod = r;
 			enterMethod = e;
 		}
-		
+
 		static void remove(ClassSymbol from, Symbol toRemove) {
 			if (from == null) return;
 			try {
@@ -1358,7 +1358,7 @@ public class JavacHandlerUtil {
 				Permit.invoke(removeMethod, scope, toRemove);
 			} catch (Exception e) {}
 		}
-		
+
 		static void enter(ClassSymbol from, Symbol toEnter) {
 			if (from == null) return;
 			try {
@@ -1368,31 +1368,31 @@ public class JavacHandlerUtil {
 			} catch (Exception e) {}
 		}
 	}
-	
+
 	/**
 	 * Adds the given new method declaration to the provided type AST Node.
 	 * Can also inject constructors.
-	 * 
+	 *
 	 * Also takes care of updating the JavacAST.
 	 */
 	public static void injectMethod(JavacNode typeNode, JCMethodDecl method) {
 		JavacNode source = typeNode.getNodeFor(getGeneratedBy(method));
 		injectMethod(typeNode, source, method);
 	}
-	
+
 	/**
 	 * Adds the given new method declaration to the provided type AST Node.
 	 * Can also inject constructors.
-	 * 
+	 *
 	 * Also takes care of updating the JavacAST.
-	 * 
+	 *
 	 * Ordinarily the 'source' is determined automatically. In rare cases generally involving combinations between
 	 * annotations, some of which require re-attribution such as {@code @Delegate}, that doesn't work. This method
 	 * exists if you explicitly have the source.
 	 */
 	public static void injectMethod(JavacNode typeNode, JavacNode source, JCMethodDecl method) {
 		JCClassDecl type = (JCClassDecl) typeNode.get();
-		
+
 		if (method.getName().contentEquals("<init>")) {
 			//Scan for default constructor, and remove it.
 			int idx = 0;
@@ -1409,53 +1409,53 @@ public class JavacHandlerUtil {
 				idx++;
 			}
 		}
-		
+
 		addSuppressWarningsAll(method.mods, typeNode, typeNode.getNodeFor(getGeneratedBy(method)), typeNode.getContext());
 		addGenerated(method.mods, typeNode, source, typeNode.getContext());
 		type.defs = type.defs.append(method);
-		
+
 		EnterReflect.memberEnter(method, typeNode);
-		
+
 		typeNode.add(method, Kind.METHOD);
 	}
 
 	/**
 	 * Adds an inner type (class, interface, enum) to the given type. Cannot inject top-level types.
-	 * 
+	 *
 	 * @param typeNode parent type to inject new type into
 	 * @param type New type (class, interface, etc) to inject.
-	 * @return 
+	 * @return
 	 */
 	public static JavacNode injectType(JavacNode typeNode, final JCClassDecl type) {
 		JCClassDecl typeDecl = (JCClassDecl) typeNode.get();
 		addSuppressWarningsAll(type.mods, typeNode, typeNode.getNodeFor(getGeneratedBy(type)), typeNode.getContext());
 		addGenerated(type.mods, typeNode, typeNode.getNodeFor(getGeneratedBy(type)), typeNode.getContext());
 		typeDecl.defs = typeDecl.defs.append(type);
-		
+
 		EnterReflect.classEnter(type, typeNode);
-		
+
 		return typeNode.add(type, Kind.TYPE);
 	}
-	
+
 	static class EnterReflect {
 		private static final Method classEnter;
 		private static final Method memberEnter;
 		private static final Method blockAnnotations;
 		private static final Method unblockAnnotations;
-		
+
 		static {
 			classEnter = Permit.permissiveGetMethod(Enter.class, "classEnter", JCTree.class, Env.class);
 			memberEnter = Permit.permissiveGetMethod(MemberEnter.class, "memberEnter", JCTree.class, Env.class);
-			
+
 			Method block = Permit.permissiveGetMethod(Annotate.class, "blockAnnotations");
 			if (block == null) block = Permit.permissiveGetMethod(Annotate.class, "enterStart");
 			blockAnnotations = block;
-			
+
 			Method unblock = Permit.permissiveGetMethod(Annotate.class, "unblockAnnotations");
 			if (unblock == null) unblock = Permit.permissiveGetMethod(Annotate.class, "enterDone");
 			unblockAnnotations = unblock;
 		}
-		
+
 		static Type classEnter(JCTree tree, JavacNode parent) {
 			Enter enter = Enter.instance(parent.getContext());
 			Env<AttrContext> classEnv = enter.getEnv((TypeSymbol) parent.getElement());
@@ -1465,29 +1465,29 @@ public class JavacHandlerUtil {
 			type.complete();
 			return type;
 		}
-		
+
 		static void memberEnter(JCTree tree, JavacNode parent) {
 			Context context = parent.getContext();
 			MemberEnter me = MemberEnter.instance(context);
 			Annotate annotate = Annotate.instance(context);
 			Enter enter = Enter.instance(context);
-			
+
 			Env<AttrContext> classEnv = enter.getEnv((TypeSymbol) parent.getElement());
 			if (classEnv == null) return;
-			
+
 			Permit.invokeSneaky(blockAnnotations, annotate);
 			Permit.invokeSneaky(memberEnter, me, tree, classEnv);
 			Permit.invokeSneaky(unblockAnnotations, annotate);
 		}
 	}
-	
+
 	public static long addFinalIfNeeded(long flags, Context context) {
 		boolean addFinal = LombokOptionsFactory.getDelombokOptions(context).getFormatPreferences().generateFinalParams();
-		
+
 		if (addFinal) flags |= Flags.FINAL;
 		return flags;
 	}
-	
+
 	public static JCExpression genTypeRef(JavacNode node, String complexName) {
 		String[] parts = complexName.split("\\.");
 		if (parts.length > 2 && parts[0].equals("java") && parts[1].equals("lang")) {
@@ -1495,10 +1495,10 @@ public class JavacHandlerUtil {
 			System.arraycopy(parts, 2, subParts, 0, subParts.length);
 			return genJavaLangTypeRef(node, subParts);
 		}
-		
+
 		return chainDots(node, parts);
 	}
-	
+
 	public static JCExpression genJavaLangTypeRef(JavacNode node, String... simpleNames) {
 		if (LombokOptionsFactory.getDelombokOptions(node.getContext()).getFormatPreferences().javaLangAsFqn()) {
 			return chainDots(node, "java", "lang", simpleNames);
@@ -1506,7 +1506,7 @@ public class JavacHandlerUtil {
 			return chainDots(node, null, null, simpleNames);
 		}
 	}
-	
+
 	public static JCExpression genJavaLangTypeRef(JavacNode node, int pos, String... simpleNames) {
 		if (LombokOptionsFactory.getDelombokOptions(node.getContext()).getFormatPreferences().javaLangAsFqn()) {
 			return chainDots(node, pos, "java", "lang", simpleNames);
@@ -1514,12 +1514,12 @@ public class JavacHandlerUtil {
 			return chainDots(node, pos, null, null, simpleNames);
 		}
 	}
-	
+
 	public static void addSuppressWarningsAll(JCModifiers mods, JavacNode node, JavacNode source, Context context) {
 		if (!LombokOptionsFactory.getDelombokOptions(context).getFormatPreferences().generateSuppressWarnings()) return;
-		
+
 		boolean addJLSuppress = !Boolean.FALSE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_SUPPRESSWARNINGS_ANNOTATIONS));
-		
+
 		if (addJLSuppress) {
 			for (JCAnnotation ann : mods.annotations) {
 				JCTree type = ann.getAnnotationType();
@@ -1532,17 +1532,17 @@ public class JavacHandlerUtil {
 			}
 		}
 		if (addJLSuppress) addAnnotation(mods, node, source, "java.lang.SuppressWarnings", node.getTreeMaker().Literal("all"));
-		
+
 		if (Boolean.TRUE.equals(node.getAst().readConfiguration(ConfigurationKeys.ADD_FINDBUGS_SUPPRESSWARNINGS_ANNOTATIONS))) {
 			JavacTreeMaker maker = node.getTreeMaker();
 			JCExpression arg = maker.Assign(maker.Ident(node.toName("justification")), maker.Literal("generated code"));
 			addAnnotation(mods, node, source, "edu.umd.cs.findbugs.annotations.SuppressFBWarnings", arg);
 		}
 	}
-	
+
 	public static void addGenerated(JCModifiers mods, JavacNode node, JavacNode source, Context context) {
 		if (!LombokOptionsFactory.getDelombokOptions(context).getFormatPreferences().generateGenerated()) return;
-		
+
 		if (HandlerUtil.shouldAddGenerated(node)) {
 			addAnnotation(mods, node, source, "javax.annotation.Generated", node.getTreeMaker().Literal("lombok"));
 		}
@@ -1553,35 +1553,35 @@ public class JavacHandlerUtil {
 			addAnnotation(mods, node, source, "lombok.Generated", null);
 		}
 	}
-	
+
 	public static void addAnnotation(JCModifiers mods, JavacNode node, JavacNode source, String annotationTypeFqn, JCExpression arg) {
 		boolean isJavaLangBased;
 		String simpleName; {
 			int idx = annotationTypeFqn.lastIndexOf('.');
 			simpleName = idx == -1 ? annotationTypeFqn : annotationTypeFqn.substring(idx + 1);
-			
+
 			isJavaLangBased = idx == 9 && annotationTypeFqn.regionMatches(0, "java.lang.", 0, 10);
 		}
-		
+
 		for (JCAnnotation ann : mods.annotations) {
 			JCTree annType = ann.getAnnotationType();
 			if (annType instanceof JCIdent) {
 				Name lastPart = ((JCIdent) annType).name;
 				if (lastPart.contentEquals(simpleName)) return;
 			}
-			
+
 			if (annType instanceof JCFieldAccess) {
 				if (annType.toString().equals(annotationTypeFqn)) return;
 			}
 		}
-		
+
 		JavacTreeMaker maker = node.getTreeMaker();
 		JCExpression annType = isJavaLangBased ? genJavaLangTypeRef(node, simpleName) : chainDotsString(node, annotationTypeFqn);
 		List<JCExpression> argList = arg != null ? List.of(arg) : List.<JCExpression>nil();
 		JCAnnotation annotation = recursiveSetGeneratedBy(maker.Annotation(annType, argList), source);
 		mods.annotations = mods.annotations.append(annotation);
 	}
-	
+
 	static JCExpression addCheckerFrameworkReturnsReceiver(JCExpression returnType, JavacTreeMaker maker, JavacNode typeNode, CheckerFrameworkVersion cfv) {
 		if (cfv.generateReturnsReceiver()) {
 			JCAnnotation rrAnnotation = maker.Annotation(genTypeRef(typeNode, CheckerFrameworkVersion.NAME__RETURNS_RECEIVER), List.<JCExpression>nil());
@@ -1589,7 +1589,7 @@ public class JavacHandlerUtil {
 		}
 		return returnType;
 	}
-	
+
 	private static List<JCTree> addAllButOne(List<JCTree> defs, int idx) {
 		ListBuffer<JCTree> out = new ListBuffer<JCTree>();
 		int i = 0;
@@ -1598,30 +1598,30 @@ public class JavacHandlerUtil {
 		}
 		return out.toList();
 	}
-	
+
 	/**
 	 * In javac, dotted access of any kind, from {@code java.lang.String} to {@code var.methodName}
 	 * is represented by a fold-left of {@code Select} nodes with the leftmost string represented by
 	 * a {@code Ident} node. This method generates such an expression.
 	 * <p>
 	 * The position of the generated node(s) will be unpositioned (-1).
-	 * 
+	 *
 	 * For example, maker.Select(maker.Select(maker.Ident(NAME[java]), NAME[lang]), NAME[String]).
-	 * 
+	 *
 	 * @see com.sun.tools.javac.tree.JCTree.JCIdent
 	 * @see com.sun.tools.javac.tree.JCTree.JCFieldAccess
 	 */
 	public static JCExpression chainDots(JavacNode node, String elem1, String elem2, String... elems) {
 		return chainDots(node, -1, elem1, elem2, elems);
 	}
-	
+
 	public static JCExpression chainDots(JavacNode node, String[] elems) {
 		return chainDots(node, -1, null, null, elems);
 	}
-	
+
 	public static JCExpression chainDots(JavacNode node, LombokImmutableList<String> elems) {
 		assert elems != null;
-		
+
 		JavacTreeMaker maker = node.getTreeMaker();
 		JCExpression e = null;
 		for (String elem : elems) {
@@ -1630,7 +1630,7 @@ public class JavacHandlerUtil {
 		}
 		return e;
 	}
-	
+
 	/**
 	 * In javac, dotted access of any kind, from {@code java.lang.String} to {@code var.methodName}
 	 * is represented by a fold-left of {@code Select} nodes with the leftmost string represented by
@@ -1639,13 +1639,13 @@ public class JavacHandlerUtil {
 	 * The position of the generated node(s) will be equal to the {@code pos} parameter.
 	 *
 	 * For example, maker.Select(maker.Select(maker.Ident(NAME[java]), NAME[lang]), NAME[String]).
-	 * 
+	 *
 	 * @see com.sun.tools.javac.tree.JCTree.JCIdent
 	 * @see com.sun.tools.javac.tree.JCTree.JCFieldAccess
 	 */
 	public static JCExpression chainDots(JavacNode node, int pos, String elem1, String elem2, String... elems) {
 		assert elems != null;
-		
+
 		JavacTreeMaker maker = node.getTreeMaker();
 		if (pos != -1) maker = maker.at(pos);
 		JCExpression e = null;
@@ -1654,29 +1654,29 @@ public class JavacHandlerUtil {
 		for (int i = 0 ; i < elems.length ; i++) {
 			e = e == null ? maker.Ident(node.toName(elems[i])) : maker.Select(e, node.toName(elems[i]));
 		}
-		
+
 		assert e != null;
-		
+
 		return e;
 	}
-	
+
 	/**
 	 * In javac, dotted access of any kind, from {@code java.lang.String} to {@code var.methodName}
 	 * is represented by a fold-left of {@code Select} nodes with the leftmost string represented by
 	 * a {@code Ident} node. This method generates such an expression.
-	 * 
+	 *
 	 * For example, maker.Select(maker.Select(maker.Ident(NAME[java]), NAME[lang]), NAME[String]).
-	 * 
+	 *
 	 * @see com.sun.tools.javac.tree.JCTree.JCIdent
 	 * @see com.sun.tools.javac.tree.JCTree.JCFieldAccess
 	 */
 	public static JCExpression chainDotsString(JavacNode node, String elems) {
 		return chainDots(node, null, null, elems.split("\\."));
 	}
-	
+
 	/**
 	 * Searches the given field node for annotations and returns each one that matches the provided regular expression pattern.
-	 * 
+	 *
 	 * Only the simple name is checked - the package and any containing class are ignored.
 	 */
 	public static List<JCAnnotation> findAnnotations(JavacNode fieldNode, Pattern namePattern) {
@@ -1691,10 +1691,10 @@ public class JavacHandlerUtil {
 					result.append(annotation);
 				}
 			}
-		}	
+		}
 		return result.toList();
 	}
-	
+
 	public static String scanForNearestAnnotation(JavacNode node, String... anns) {
 		while (node != null) {
 			for (JavacNode ann : node.down()) {
@@ -1704,10 +1704,10 @@ public class JavacHandlerUtil {
 			}
 			node = node.up();
 		}
-		
+
 		return null;
 	}
-	
+
 	public static boolean hasNonNullAnnotations(JavacNode node) {
 		for (JavacNode child : node.down()) {
 			if (child.getKind() == Kind.ANNOTATION) {
@@ -1729,13 +1729,13 @@ public class JavacHandlerUtil {
 		
 		return false;
 	}
-	
+
 	/**
 	 * Searches the given field node for annotations and returns each one that is 'copyable' (either via configuration or from the base list).
 	 */
 	public static List<JCAnnotation> findCopyableAnnotations(JavacNode node) {
 		java.util.List<TypeName> configuredCopyable = node.getAst().readConfiguration(ConfigurationKeys.COPYABLE_ANNOTATIONS);
-		
+
 		ListBuffer<JCAnnotation> result = new ListBuffer<JCAnnotation>();
 		for (JavacNode child : node.down()) {
 			if (child.getKind() == Kind.ANNOTATION) {
@@ -1756,10 +1756,10 @@ public class JavacHandlerUtil {
 
 		return copyAnnotations(result.toList(), node.getTreeMaker());
 	}
-	
+
 	/**
 	 * Searches the given field node for annotations that are specifically intended to be copied to the getter.
-	 * 
+	 *
 	 * @param forceCopyJacksonAnnotations If {@code true}, always copy the annotations regardless of lombok configuration key {@code lombok.copyJacksonAnnotationsToAccessors}.
 	 */
 	public static List<JCAnnotation> findCopyableToGetterAnnotations(JavacNode node, boolean forceCopyJacksonAnnotations) {
@@ -1772,7 +1772,7 @@ public class JavacHandlerUtil {
 
 	/**
 	 * Searches the given field node for annotations that are specifically intended to be copied to the setter.
-	 * 
+	 *
 	 * @param forceCopyJacksonAnnotations If {@code true}, always copy the annotations regardless of lombok configuration key {@code lombok.copyJacksonAnnotationsToAccessors}.
 	 */
 	public static List<JCAnnotation> findCopyableToSetterAnnotations(JavacNode node, boolean forceCopyJacksonAnnotations) {
@@ -1789,7 +1789,7 @@ public class JavacHandlerUtil {
 	public static List<JCAnnotation> findCopyableToBuilderSingularSetterAnnotations(JavacNode node) {
 		return findAnnotationsInList(node, JACKSON_COPY_TO_BUILDER_SINGULAR_SETTER_ANNOTATIONS);
 	}
-	
+
 	/**
 	 * Searches the given field node for annotations that are in the given list, and returns those.
 	 */
@@ -1807,13 +1807,13 @@ public class JavacHandlerUtil {
 				anno = annotation;
 			}
 		}
-		
+
 		if (annoName == null) return List.nil();
-		
+
 		if (!annoName.isEmpty()) {
 			for (String bn : annotationsToFind) if (typeMatches(bn, node, annoName)) return copyAnnotations(List.of(anno), node.getTreeMaker());
 		}
-		
+
 		ListBuffer<JCAnnotation> result = new ListBuffer<JCAnnotation>();
 		for (JavacNode child : node.down()) {
 			if (child.getKind() == Kind.ANNOTATION) {
@@ -1828,7 +1828,7 @@ public class JavacHandlerUtil {
 		}
 		return copyAnnotations(result.toList(), node.getTreeMaker());
 	}
-	
+
 	/**
 	 * Generates a new statement that checks if the given variable is null, and if so, throws a configured exception with the
 	 * variable name as message.
@@ -1836,38 +1836,38 @@ public class JavacHandlerUtil {
 	public static JCStatement generateNullCheck(JavacTreeMaker maker, JavacNode variable, JavacNode source) {
 		return generateNullCheck(maker, (JCVariableDecl) variable.get(), source);
 	}
-	
+
 	/**
 	 * Generates a new statement that checks if the given local is null, and if so, throws a configured exception with the
-	 * local variable name as message. 
+	 * local variable name as message.
 	 */
 	public static JCStatement generateNullCheck(JavacTreeMaker maker, JCExpression typeNode, Name varName, JavacNode source, String customMessage) {
 		NullCheckExceptionType exceptionType = source.getAst().readConfiguration(ConfigurationKeys.NON_NULL_EXCEPTION_TYPE);
 		if (exceptionType == null) exceptionType = NullCheckExceptionType.NULL_POINTER_EXCEPTION;
-		
+
 		if (typeNode != null && isPrimitive(typeNode)) return null;
 		JCLiteral message = maker.Literal(exceptionType.toExceptionMessage(varName.toString(), customMessage));
-		
+
 		LombokImmutableList<String> method = exceptionType.getMethod();
 		if (method != null) {
 			return maker.Exec(maker.Apply(List.<JCExpression>nil(), chainDots(source, method), List.of(maker.Ident(varName), message)));
 		}
-		
+
 		if (exceptionType == NullCheckExceptionType.ASSERTION) {
 			return maker.Assert(maker.Binary(CTC_NOT_EQUAL, maker.Ident(varName), maker.Literal(CTC_BOT, null)), message);
 		}
-		
+
 		JCExpression exType = genTypeRef(source, exceptionType.getExceptionType());
 		JCExpression exception = maker.NewClass(null, List.<JCExpression>nil(), exType, List.<JCExpression>of(message), null);
 		JCStatement throwStatement = maker.Throw(exception);
 		JCBlock throwBlock = maker.Block(0, List.of(throwStatement));
 		return maker.If(maker.Binary(CTC_EQUAL, maker.Ident(varName), maker.Literal(CTC_BOT, null)), throwBlock, null);
 	}
-	
+
 	/**
 	 * Generates a new statement that checks if the given variable is null, and if so, throws a configured exception with the
-	 * variable name as message. 
-	 * 
+	 * variable name as message.
+	 *
 	 * This is a special case method reserved for use when the provided declaration differs from the
 	 * variable's declaration, i.e. in a constructor or setter where the local parameter is named the same but with the prefix
 	 * stripped as a result of @Accessors.prefix.
@@ -1875,13 +1875,13 @@ public class JavacHandlerUtil {
 	public static JCStatement generateNullCheck(JavacTreeMaker maker, JCVariableDecl varDecl, JavacNode source) {
 		return generateNullCheck(maker, varDecl.vartype, varDecl.name, source, null);
 	}
-	
+
 	/**
 	 * Given a list of field names and a node referring to a type, finds each name in the list that does not match a field within the type.
 	 */
 	public static List<Integer> createListOfNonExistentFields(List<String> list, JavacNode type, boolean excludeStandard, boolean excludeTransient) {
 		boolean[] matched = new boolean[list.size()];
-		
+
 		for (JavacNode child : type.down()) {
 			if (list.isEmpty()) break;
 			if (child.getKind() != Kind.FIELD) continue;
@@ -1891,23 +1891,23 @@ public class JavacHandlerUtil {
 				if (field.name.toString().startsWith("$")) continue;
 			}
 			if (excludeTransient && (field.mods.flags & Flags.TRANSIENT) != 0) continue;
-			
+
 			int idx = list.indexOf(child.getName());
 			if (idx > -1) matched[idx] = true;
 		}
-		
+
 		ListBuffer<Integer> problematic = new ListBuffer<Integer>();
 		for (int i = 0 ; i < list.size() ; i++) {
 			if (!matched[i]) problematic.append(i);
 		}
-		
+
 		return problematic.toList();
 	}
-	
+
 	static List<JCAnnotation> unboxAndRemoveAnnotationParameter(JCAnnotation ast, String parameterName, String errorName, JavacNode annotationNode) {
 		ListBuffer<JCExpression> params = new ListBuffer<JCExpression>();
 		ListBuffer<JCAnnotation> result = new ListBuffer<JCAnnotation>();
-		
+
 		outer:
 		for (JCExpression param : ast.args) {
 			boolean allowRaw;
@@ -1921,7 +1921,7 @@ public class JavacHandlerUtil {
 				}
 				valueOfParam = assign.rhs;
 			}
-			
+
 			/* strip trailing underscores */ {
 				int lastIdx;
 				for (lastIdx = nameOfParam.length() ; lastIdx > 0; lastIdx--) {
@@ -1930,15 +1930,15 @@ public class JavacHandlerUtil {
 				allowRaw = lastIdx < nameOfParam.length();
 				nameOfParam = nameOfParam.substring(0, lastIdx);
 			}
-			
+
 			if (!parameterName.equals(nameOfParam)) {
 				params.append(param);
 				continue outer;
 			}
-			
+
 			int endPos = Javac.getEndPosition(param.pos(), (JCCompilationUnit) annotationNode.top().get());
 			annotationNode.getAst().removeFromDeferredDiagnostics(param.pos, endPos);
-			
+
 			if (valueOfParam instanceof JCAnnotation) {
 				String dummyAnnotationName = ((JCAnnotation) valueOfParam).annotationType.toString();
 				dummyAnnotationName = dummyAnnotationName.replace("_", "").replace("$", "").replace("x", "").replace("X", "");
@@ -1959,7 +1959,7 @@ public class JavacHandlerUtil {
 								addError(errorName, annotationNode);
 							}
 						}
-						
+
 						if (expr instanceof JCAnnotation) {
 							result.append((JCAnnotation) expr);
 						} else if (expr instanceof JCNewArray) {
@@ -1999,7 +1999,7 @@ public class JavacHandlerUtil {
 		ast.args = params.toList();
 		return result.toList();
 	}
-	
+
 	/**
 	 * Removes all type information from the provided tree.
 	 */
@@ -2036,7 +2036,7 @@ public class JavacHandlerUtil {
 			}
 		});
 	}
-	
+
 	private static void addError(String errorName, JavacNode node) {
 		if (node.getLatestJavaSpecSupported() < 8) {
 			node.addError("The correct format up to JDK7 is " + errorName + "=@__({@SomeAnnotation, @SomeOtherAnnotation}))");
@@ -2044,7 +2044,7 @@ public class JavacHandlerUtil {
 			node.addError("The correct format for JDK8+ is " + errorName + "_={@SomeAnnotation, @SomeOtherAnnotation})");
 		}
 	}
-	
+
 	public static List<JCTypeParameter> copyTypeParams(JavacNode source, List<JCTypeParameter> params) {
 		if (params == null || params.isEmpty()) return params;
 		ListBuffer<JCTypeParameter> out = new ListBuffer<JCTypeParameter>();
@@ -2062,33 +2062,33 @@ public class JavacHandlerUtil {
 		}
 		return out.toList();
 	}
-	
+
 	public static List<JCAnnotation> getTypeUseAnnotations(JCExpression from) {
 		if (!JCAnnotatedTypeReflect.is(from)) return List.nil();
 		return JCAnnotatedTypeReflect.getAnnotations(from);
 	}
-	
+
 	public static JCExpression removeTypeUseAnnotations(JCExpression from) {
 		if (!JCAnnotatedTypeReflect.is(from)) return from;
 		return JCAnnotatedTypeReflect.getUnderlyingType(from);
 	}
-	
+
 	public static JCExpression namePlusTypeParamsToTypeReference(JavacTreeMaker maker, JavacNode type, List<JCTypeParameter> params) {
 		JCClassDecl td = (JCClassDecl) type.get();
 		boolean instance = !type.isStatic();
 		return namePlusTypeParamsToTypeReference(maker, type.up(), td.name, instance, params, List.<JCAnnotation>nil());
 	}
-	
+
 	public static JCExpression namePlusTypeParamsToTypeReference(JavacTreeMaker maker, JavacNode type, List<JCTypeParameter> params, List<JCAnnotation> annotations) {
 		JCClassDecl td = (JCClassDecl) type.get();
 		boolean instance = !type.isStatic();
 		return namePlusTypeParamsToTypeReference(maker, type.up(), td.name, instance, params, annotations);
 	}
-	
+
 	public static JCExpression namePlusTypeParamsToTypeReference(JavacTreeMaker maker, JavacNode parentType, Name typeName, boolean instance, List<JCTypeParameter> params) {
 		return namePlusTypeParamsToTypeReference(maker, parentType, typeName, instance, params, List.<JCAnnotation>nil());
 	}
-	
+
 	public static JCExpression namePlusTypeParamsToTypeReference(JavacTreeMaker maker, JavacNode parentType, Name typeName, boolean instance, List<JCTypeParameter> params, List<JCAnnotation> annotations) {
 		JCExpression r = null;
 		if (parentType != null && parentType.getKind() == Kind.TYPE && !parentType.getName().isEmpty()) {
@@ -2097,13 +2097,13 @@ public class JavacHandlerUtil {
 			List<JCTypeParameter> outerParams = instance ? td.typarams : List.<JCTypeParameter>nil();
 			r = namePlusTypeParamsToTypeReference(maker, parentType.up(), td.name, outerInstance, outerParams, List.<JCAnnotation>nil());
 		}
-		
+
 		r = r == null ? maker.Ident(typeName) : maker.Select(r, typeName);
 		if (!annotations.isEmpty()) r = JCAnnotatedTypeReflect.create(annotations, r);
 		if (!params.isEmpty()) r = maker.TypeApply(r, typeParameterNames(maker, params));
 		return r;
 	}
-	
+
 	public static List<JCExpression> typeParameterNames(JavacTreeMaker maker, List<JCTypeParameter> params) {
 		ListBuffer<JCExpression> typeArgs = new ListBuffer<JCExpression>();
 		for (JCTypeParameter param : params) {
@@ -2111,7 +2111,7 @@ public class JavacHandlerUtil {
 		}
 		return typeArgs.toList();
 	}
-	
+
 	public static void sanityCheckForMethodGeneratingAnnotationsOnBuilderClass(JavacNode typeNode, JavacNode errorNode) {
 		List<String> disallowed = List.nil();
 		for (JavacNode child : typeNode.down()) {
@@ -2122,7 +2122,7 @@ public class JavacHandlerUtil {
 				}
 			}
 		}
-		
+
 		int size = disallowed.size();
 		if (size == 0) return;
 		if (size == 1) {
@@ -2134,7 +2134,7 @@ public class JavacHandlerUtil {
 		out.setLength(out.length() - 2);
 		errorNode.addError(out.append(" are not allowed on builder classes.").toString());
 	}
-	
+
 	static List<JCAnnotation> copyAnnotations(List<? extends JCExpression> in, JavacTreeMaker maker) {
 		ListBuffer<JCAnnotation> out = new ListBuffer<JCAnnotation>();
 		for (JCExpression expr : in) {
@@ -2143,13 +2143,13 @@ public class JavacHandlerUtil {
 		}
 		return out.toList();
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	static <T extends JCExpression> T copyExpression(T expression, JavacTreeMaker maker) {
 		TreeVisitor<JCTree, Void> visitor = new TreeCopier<Void>(maker.getUnderlyingTreeMaker());
 		return (T) expression.accept(visitor, null);
 	}
-	
+
 	static List<JCAnnotation> mergeAnnotations(List<JCAnnotation> a, List<JCAnnotation> b) {
 		if (a == null || a.isEmpty()) return b;
 		if (b == null || b.isEmpty()) return a;
@@ -2158,72 +2158,72 @@ public class JavacHandlerUtil {
 		for (JCAnnotation ann : b) out.append(ann);
 		return out.toList();
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node is an actual class and not some other type declaration (so, not an annotation definition, interface, enum, or record).
 	 */
 	public static boolean isClass(JavacNode typeNode) {
 		return isClassAndDoesNotHaveFlags(typeNode, Flags.INTERFACE | Flags.ENUM | Flags.ANNOTATION | RECORD);
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node is an actual class or enum and not some other type declaration (so, not an annotation definition, interface, or record).
 	 */
 	public static boolean isClassOrEnum(JavacNode typeNode) {
 		return isClassAndDoesNotHaveFlags(typeNode, Flags.INTERFACE | Flags.ANNOTATION | RECORD);
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node is an actual class an enum or an interface and not some other type declaration (so, not an annotation definition, or record).
 	 */
 	public static boolean isClassEnumOrInterface(JavacNode typeNode) {
 		return isClassAndDoesNotHaveFlags(typeNode, Flags.ANNOTATION | RECORD);
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node is an actual class, an enum, an interface or a record and not some other type declaration (so, not an annotation definition).
 	 */
 	public static boolean isClassEnumInterfaceOrRecord(JavacNode typeNode) {
 		return isClassAndDoesNotHaveFlags(typeNode, Flags.ANNOTATION);
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node is an actual class, an enum or a record and not some other type declaration (so, not an annotation definition or interface).
 	 */
 	public static boolean isClassEnumOrRecord(JavacNode typeNode) {
 		return isClassAndDoesNotHaveFlags(typeNode, Flags.INTERFACE | Flags.ANNOTATION);
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node is a record declaration (so, not an annotation definition, interface, enum, or plain class).
 	 */
 	public static boolean isRecord(JavacNode typeNode) {
 		return typeNode.getKind() == Kind.TYPE && (((JCClassDecl) typeNode.get()).mods.flags & RECORD) != 0;
 	}
-	
+
 	public static boolean isClassAndDoesNotHaveFlags(JavacNode typeNode, long flags) {
 		JCClassDecl typeDecl = null;
 		if (typeNode.get() instanceof JCClassDecl) typeDecl = (JCClassDecl) typeNode.get();
 		else return false;
-		
+
 		long typeDeclflags = typeDecl == null ? 0 : typeDecl.mods.flags;
 		return (typeDeclflags & flags) == 0;
 	}
-	
+
 	/**
 	 * Returns {@code true} if the provided node supports static methods and types (top level or static class)
 	 */
 	public static boolean isStaticAllowed(JavacNode typeNode) {
 		return typeNode.isStatic() || typeNode.up() == null || typeNode.up().getKind() == Kind.COMPILATION_UNIT || isRecord(typeNode);
 	}
-	
+
 	public static JavacNode upToTypeNode(JavacNode node) {
 		if (node == null) throw new NullPointerException("node");
 		while ((node != null) && !(node.get() instanceof JCClassDecl)) node = node.up();
-		
+
 		return node;
 	}
-	
+
 	public static List<JCExpression> cloneTypes(JavacTreeMaker maker, List<JCExpression> in, JavacNode source) {
 		if (in.isEmpty()) return List.nil();
 		if (in.size() == 1) return List.of(cloneType(maker, in.get(0), source));
@@ -2231,13 +2231,13 @@ public class JavacHandlerUtil {
 		for (JCExpression expr : in) lb.append(cloneType(maker, expr, source));
 		return lb.toList();
 	}
-	
+
 	/**
 	 * Creates a full clone of a given javac AST type node. Every part is cloned (every identifier, every select, every wildcard, every type apply, every type_use annotation).
-	 * 
+	 *
 	 * If there's any node in the tree that we don't know how to clone, that part isn't cloned. However, we wouldn't know what could possibly show up that we
 	 * can't currently clone; that's just a safeguard.
-	 * 
+	 *
 	 * This should be used if the type looks the same in the code, but resolves differently. For example, a static method that has some generics in it named after
 	 * the class's own parameter, but as its a static method, the static method's notion of {@code T} is different from the class notion of {@code T}. If you're duplicating
 	 * a type used in the class context, you need to use this method.
@@ -2247,28 +2247,28 @@ public class JavacHandlerUtil {
 		if (out != null) recursiveSetGeneratedBy(out, source);
 		return out;
 	}
-	
+
 	private static JCExpression cloneType0(JavacTreeMaker maker, JCTree in) {
 		if (in == null) return null;
-		
+
 		if (in instanceof JCPrimitiveTypeTree) {
 			return maker.TypeIdent(TypeTag.typeTag(in));
 		}
-		
+
 		if (in instanceof JCIdent) {
 			return maker.Ident(((JCIdent) in).name);
 		}
-		
+
 		if (in instanceof JCFieldAccess) {
 			JCFieldAccess fa = (JCFieldAccess) in;
 			return maker.Select(cloneType0(maker, fa.selected), fa.name);
 		}
-		
+
 		if (in instanceof JCArrayTypeTree) {
 			JCArrayTypeTree att = (JCArrayTypeTree) in;
 			return maker.TypeArray(cloneType0(maker, att.elemtype));
 		}
-		
+
 		if (in instanceof JCTypeApply) {
 			JCTypeApply ta = (JCTypeApply) in;
 			ListBuffer<JCExpression> lb = new ListBuffer<JCExpression>();
@@ -2277,7 +2277,7 @@ public class JavacHandlerUtil {
 			}
 			return maker.TypeApply(cloneType0(maker, ta.clazz), lb.toList());
 		}
-		
+
 		if (in instanceof JCWildcard) {
 			JCWildcard w = (JCWildcard) in;
 			JCExpression newInner = cloneType0(maker, w.inner);
@@ -2296,17 +2296,17 @@ public class JavacHandlerUtil {
 			}
 			return maker.Wildcard(newKind, newInner);
 		}
-		
+
 		if (JCAnnotatedTypeReflect.is(in)) {
 			JCExpression underlyingType = cloneType0(maker, JCAnnotatedTypeReflect.getUnderlyingType(in));
 			List<JCAnnotation> anns = copyAnnotations(JCAnnotatedTypeReflect.getAnnotations(in), maker);
 			return JCAnnotatedTypeReflect.create(anns, underlyingType);
 		}
-		
+
 		// This is somewhat unsafe, but it's better than outright throwing an exception here. Returning null will just cause an exception down the pipeline.
 		return (JCExpression) in;
 	}
-	
+
 	public static enum CopyJavadoc {
 		VERBATIM {
 			@Override public String apply(final JCCompilationUnit cu, final JavacNode node) {
@@ -2352,9 +2352,9 @@ public class JavacHandlerUtil {
 				return applySetter(cu, node, "WITHBY|WITH_BY");
 			}
 		};
-		
+
 		public abstract String apply(final JCCompilationUnit cu, final JavacNode node);
-		
+
 		private static String applySetter(final JCCompilationUnit cu, JavacNode node, String sectionName) {
 			final JCTree n = node.get();
 			String javadoc = Javac.getDocComment(cu, n);
@@ -2378,18 +2378,18 @@ public class JavacHandlerUtil {
 			return shouldReturnThis(node, JavacHandlerUtil.getAccessorsForField(node)) ? addReturnsThisIfNeeded(out) : out;
 		}
 	}
-	
+
 	public static void copyJavadoc(JavacNode from, JCTree to, CopyJavadoc copyMode) {
 		copyJavadoc(from, to, copyMode, false);
 	}
-	
+
 	/**
 	 * Copies javadoc on one node to the other.
-	 * 
+	 *
 	 * in 'GETTER' copyMode, first a 'GETTER' segment is searched for. If it exists, that will become the javadoc for the 'to' node, and this section is
 	 * stripped out of the 'from' node. If no 'GETTER' segment is found, then the entire javadoc is taken minus any {@code @param} lines and other sections.
 	 * any {@code @return} lines are stripped from 'from'.
-	 * 
+	 *
 	 * in 'SETTER' mode, stripping works similarly to 'GETTER' mode, except {@code param} are copied and stripped from the original and {@code @return} are skipped.
 	 */
 	public static void copyJavadoc(JavacNode from, JCTree to, CopyJavadoc copyMode, boolean forceAddReturn) {
@@ -2403,7 +2403,7 @@ public class JavacHandlerUtil {
 			Javac.setDocComment(cu, to, newJavadoc);
 		} catch (Exception ignore) {}
 	}
-	
+
 	public static void copyJavadocFromParam(JavacNode from, JCMethodDecl to, String paramName) {
 		try {
 			JCCompilationUnit cu = ((JCCompilationUnit) from.top().get());
@@ -2412,7 +2412,7 @@ public class JavacHandlerUtil {
 			Javac.setDocComment(cu, to, newJavadoc);
 		} catch (Exception ignore) {}
 	}
-	
+
 	public static boolean isDirectDescendantOfObject(JavacNode typeNode) {
 		if (!(typeNode.get() instanceof JCClassDecl)) throw new IllegalArgumentException("not a type node");
 		JCTree extending = Javac.getExtendsClause((JCClassDecl) typeNode.get());
@@ -2420,37 +2420,37 @@ public class JavacHandlerUtil {
 		String p = extending.toString();
 		return p.equals("Object") || p.equals("java.lang.Object");
 	}
-	
+
 	public static void createRelevantNullableAnnotation(JavacNode typeNode, JCMethodDecl mth) {
 		NullAnnotationLibrary lib = typeNode.getAst().readConfiguration(ConfigurationKeys.ADD_NULL_ANNOTATIONS);
 		if (lib == null) return;
 		applyAnnotationToMethodDecl(typeNode, mth, lib.getNullableAnnotation(), lib.isTypeUse());
 	}
-	
+
 	public static void createRelevantNonNullAnnotation(JavacNode typeNode, JCMethodDecl mth) {
 		NullAnnotationLibrary lib = typeNode.getAst().readConfiguration(ConfigurationKeys.ADD_NULL_ANNOTATIONS);
 		if (lib == null) return;
 		applyAnnotationToMethodDecl(typeNode, mth, lib.getNonNullAnnotation(), lib.isTypeUse());
 	}
-	
+
 	public static void createRelevantNonNullAnnotation(JavacNode typeNode, JCVariableDecl arg) {
 		NullAnnotationLibrary lib = typeNode.getAst().readConfiguration(ConfigurationKeys.ADD_NULL_ANNOTATIONS);
 		if (lib == null) return;
-		
+
 		applyAnnotationToVarDecl(typeNode, arg, lib.getNonNullAnnotation(), lib.isTypeUse());
 	}
-	
+
 	public static void createRelevantNullableAnnotation(JavacNode typeNode, JCVariableDecl arg) {
 		NullAnnotationLibrary lib = typeNode.getAst().readConfiguration(ConfigurationKeys.ADD_NULL_ANNOTATIONS);
 		if (lib == null) return;
-		
+
 		applyAnnotationToVarDecl(typeNode, arg, lib.getNullableAnnotation(), lib.isTypeUse());
 	}
-	
+
 	private static void applyAnnotationToMethodDecl(JavacNode typeNode, JCMethodDecl mth, String annType, boolean typeUse) {
 		if (annType == null) return;
 		JavacTreeMaker maker = typeNode.getTreeMaker();
-		
+
 		JCAnnotation m = maker.Annotation(genTypeRef(typeNode, annType), List.<JCExpression>nil());
 		if (typeUse) {
 			JCExpression resType = mth.restype;
@@ -2462,18 +2462,18 @@ public class JavacHandlerUtil {
 				}
 				resType = ta.clazz;
 			}
-			
+
 			if (resType instanceof JCFieldAccess || resType instanceof JCArrayTypeTree) {
 				mth.restype = maker.AnnotatedType(List.of(m), resType);
 				return;
 			}
-			
+
 			if (JCAnnotatedTypeReflect.is(resType)) {
 				List<JCAnnotation> annotations = JCAnnotatedTypeReflect.getAnnotations(resType);
 				JCAnnotatedTypeReflect.setAnnotations(resType, annotations.prepend(m));
 				return;
 			}
-			
+
 			if (resType instanceof JCPrimitiveTypeTree || resType instanceof JCIdent) {
 				mth.mods.annotations = mth.mods.annotations == null ? List.of(m) : mth.mods.annotations.prepend(m);
 			}
@@ -2481,11 +2481,11 @@ public class JavacHandlerUtil {
 			mth.mods.annotations = mth.mods.annotations == null ? List.of(m) : mth.mods.annotations.prepend(m);
 		}
 	}
-	
+
 	private static void applyAnnotationToVarDecl(JavacNode typeNode, JCVariableDecl arg, String annType, boolean typeUse) {
 		if (annType == null) return;
 		JavacTreeMaker maker = typeNode.getTreeMaker();
-		
+
 		JCAnnotation m = maker.Annotation(genTypeRef(typeNode, annType), List.<JCExpression>nil());
 		if (typeUse) {
 			JCExpression varType = arg.vartype;
@@ -2494,20 +2494,20 @@ public class JavacHandlerUtil {
 				ta = (JCTypeApply) varType;
 				varType = ta.clazz;
 			}
-			
+
 			if (varType instanceof JCFieldAccess || varType instanceof JCArrayTypeTree) {
 				varType = maker.AnnotatedType(List.of(m), varType);
 				if (ta != null) ta.clazz = varType;
 				else arg.vartype = varType;
 				return;
 			}
-			
+
 			if (JCAnnotatedTypeReflect.is(varType)) {
 				List<JCAnnotation> annotations = JCAnnotatedTypeReflect.getAnnotations(varType);
 				JCAnnotatedTypeReflect.setAnnotations(varType, annotations.prepend(m));
 				return;
 			}
-			
+
 			if (varType instanceof JCPrimitiveTypeTree || varType instanceof JCIdent) {
 				arg.mods.annotations = arg.mods.annotations == null ? List.of(m) : arg.mods.annotations.prepend(m);
 			}

--- a/test/stubs/org/jspecify/annotations/NonNull.java
+++ b/test/stubs/org/jspecify/annotations/NonNull.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jspecify.annotations;
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Target(TYPE_USE)
+@Retention(RUNTIME)
+public @interface NonNull {}

--- a/test/stubs/org/jspecify/annotations/NullMarked.java
+++ b/test/stubs/org/jspecify/annotations/NullMarked.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018-2020 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jspecify.annotations;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.MODULE;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+
+@Documented
+@Target({MODULE, PACKAGE, TYPE, METHOD, CONSTRUCTOR})
+@Retention(RUNTIME)
+public @interface NullMarked {}

--- a/test/stubs/org/jspecify/annotations/NullUnmarked.java
+++ b/test/stubs/org/jspecify/annotations/NullUnmarked.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jspecify.annotations;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({PACKAGE, TYPE, METHOD, CONSTRUCTOR})
+public @interface NullUnmarked {}

--- a/test/stubs/org/jspecify/annotations/Nullable.java
+++ b/test/stubs/org/jspecify/annotations/Nullable.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018-2020 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jspecify.annotations;
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Target(TYPE_USE)
+@Retention(RUNTIME)
+public @interface Nullable {}

--- a/test/transform/resource/after-delombok/NullMarkedPlain.java
+++ b/test/transform/resource/after-delombok/NullMarkedPlain.java
@@ -1,0 +1,47 @@
+//version 9:
+import java.lang.annotation.*;
+@org.jspecify.annotations.NullMarked
+class NullMarkedPlain {
+	int i;
+	String s;
+	@org.jspecify.annotations.Nullable
+	Object o;
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public NullMarkedPlain() {
+	}
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public int getI() {
+		return this.i;
+	}
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public String getS() {
+		return this.s;
+	}
+	@org.jspecify.annotations.Nullable
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public Object getO() {
+		return this.o;
+	}
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public void setI(final int i) {
+		this.i = i;
+	}
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public void setS(final String s) {
+		if (s == null) {
+			throw new java.lang.NullPointerException("s is marked non-null but is null");
+		}
+		this.s = s;
+	}
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public void setO(@org.jspecify.annotations.Nullable final Object o) {
+		this.o = o;
+	}
+}

--- a/test/transform/resource/after-ecj/NullMarkedPlain.java
+++ b/test/transform/resource/after-ecj/NullMarkedPlain.java
@@ -1,0 +1,32 @@
+//version 9:
+import java.lang.annotation.*;
+@lombok.RequiredArgsConstructor @lombok.Getter @lombok.Setter @org.jspecify.annotations.NullMarked class NullMarkedPlain {
+  int i;
+  String s;
+  @org.jspecify.annotations.Nullable Object o;
+  public @java.lang.SuppressWarnings("all") @lombok.Generated NullMarkedPlain() {
+    super();
+  }
+  public @java.lang.SuppressWarnings("all") @lombok.Generated int getI() {
+    return this.i;
+  }
+  public @java.lang.SuppressWarnings("all") @lombok.Generated String getS() {
+    return this.s;
+  }
+  public @org.jspecify.annotations.Nullable @java.lang.SuppressWarnings("all") @lombok.Generated Object getO() {
+    return this.o;
+  }
+  public @java.lang.SuppressWarnings("all") @lombok.Generated void setI(final int i) {
+    this.i = i;
+  }
+  public @java.lang.SuppressWarnings("all") @lombok.Generated void setS(final String s) {
+    if ((s == null))
+        {
+          throw new java.lang.NullPointerException("s is marked non-null but is null");
+        }
+    this.s = s;
+  }
+  public @java.lang.SuppressWarnings("all") @lombok.Generated void setO(final @org.jspecify.annotations.Nullable Object o) {
+    this.o = o;
+  }
+}

--- a/test/transform/resource/before/NullMarkedPlain.java
+++ b/test/transform/resource/before/NullMarkedPlain.java
@@ -1,0 +1,14 @@
+//version 9:
+import java.lang.annotation.*;
+
+@lombok.RequiredArgsConstructor
+@lombok.Getter
+@lombok.Setter
+@org.jspecify.annotations.NullMarked
+class NullMarkedPlain {
+	int i;
+	String s;
+	@org.jspecify.annotations.Nullable
+	Object o;
+
+}


### PR DESCRIPTION
This adds support for JSpecify @NullMarked when applied to a class.

As demonstrated in the after-delombok and after-ecj snapshots, the constructor and setter will generate null-check code for anything not marked `@Nullable` where the class has `@NullMarked`.

I'd appreciate some review input on this.  I had considered making the `@NullMarked` annotation configurable so that it could potentially support an internal Lombok class too, and with the ability to choose to only apply that annotation on classes where null checks are wanted. So it could be called `@NullCheck`, for example.

TODO:
- [ ] Make `@RequiredArgsConstructor` support an opt-in so that we can get a release out for IDE plugins that use their own bundled Lombok, and then users can opt in.
  [This](https://github.com/JetBrains/intellij-community/blob/master/plugins/lombok/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/constructor/AbstractConstructorClassProcessor.java#L276) is what would need to change in Jetbrains plugin for this to work. They duplicate Lombok's annotation processor.  
- [ ] Additional test scenarios
- [ ] Documentation: Once we have maintainer buy in
- [ ] Later: Support `@NullMarked` on package-info.java (I think I can see the path but that's a separate PR)