### PR TITLE
Fix: Bump EA_JDK to 27 (25 and 26 have been released)

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -41,8 +41,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     env:
-      EA_JDK: 25
-    strategy: 
+      EA_JDK: 27
+    strategy:
       matrix: 
         jdk: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
         goal: [javacCurrent]


### PR DESCRIPTION
Attempt to use EA logic for JDK 25 was failing.

Naturally there is work to be done before 26 and 27 can be added to the list of JDKs, but this at least sorts JDK 25.