### PR TITLE
Fix ExtensionMethod target typing for poly expressions in Eclipse

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
@@ -47,7 +47,6 @@ import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
 import org.eclipse.jdt.internal.compiler.ast.ClassLiteralAccess;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
-import org.eclipse.jdt.internal.compiler.ast.ConditionalExpression;
 import org.eclipse.jdt.internal.compiler.ast.Expression;
 import org.eclipse.jdt.internal.compiler.ast.MessageSend;
 import org.eclipse.jdt.internal.compiler.ast.NameReference;
@@ -298,9 +297,11 @@ public class PatchExtensionMethod {
 				
 				List<TypeBinding> argumentTypes = new ArrayList<TypeBinding>();
 				for (Expression argument : arguments) {
-					TypeBinding argumentType = argument.resolvedType;
-					if (argumentType == null && requiresPolyBinding(argument)) {
-						argumentType = Reflection.getPolyTypeBinding(argument);
+					TypeBinding argumentType = requiresPolyBinding(argument)
+						? Reflection.getPolyTypeBinding(argument)
+						: argument.resolvedType;
+					if (argumentType == null) {
+						argumentType = argument.resolvedType;
 					}
 					if (argumentType == null) {
 						argumentType = TypeBinding.NULL;
@@ -387,7 +388,7 @@ public class PatchExtensionMethod {
 	}
 
 	private static boolean requiresPolyBinding(Expression argument) {
-		return Reflection.isFunctionalExpression(argument) || argument instanceof ConditionalExpression && Reflection.isPolyExpression(argument);
+		return Reflection.isFunctionalExpression(argument) || Reflection.isPolyExpression(argument);
 	}
 	
 	private static NameReference createNameRef(TypeBinding typeBinding, ASTNode source) {

--- a/test/transform/resource/after-delombok/ExtensionMethodTargetTyping.java
+++ b/test/transform/resource/after-delombok/ExtensionMethodTargetTyping.java
@@ -1,0 +1,20 @@
+import java.util.Collections;
+import java.util.List;
+
+class ExtensionMethodTargetTyping {
+	boolean test(OrderDto order) {
+		return ExtensionMethodTargetTyping.Extensions.canRefund(order, Collections.emptyList());
+	}
+
+	static class Extensions {
+		public static boolean canRefund(OrderDto order, List<RefundOrderDto> refundOrders) {
+			return order != null && refundOrders != null;
+		}
+	}
+
+	static class OrderDto {
+	}
+
+	static class RefundOrderDto {
+	}
+}

--- a/test/transform/resource/after-ecj/ExtensionMethodTargetTyping.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodTargetTyping.java
@@ -1,0 +1,29 @@
+import java.util.Collections;
+import java.util.List;
+import lombok.experimental.ExtensionMethod;
+@ExtensionMethod(ExtensionMethodTargetTyping.Extensions.class) class ExtensionMethodTargetTyping {
+  static class Extensions {
+    Extensions() {
+      super();
+    }
+    public static boolean canRefund(OrderDto order, List<RefundOrderDto> refundOrders) {
+      return ((order != null) && (refundOrders != null));
+    }
+  }
+  static class OrderDto {
+    OrderDto() {
+      super();
+    }
+  }
+  static class RefundOrderDto {
+    RefundOrderDto() {
+      super();
+    }
+  }
+  ExtensionMethodTargetTyping() {
+    super();
+  }
+  boolean test(OrderDto order) {
+    return ExtensionMethodTargetTyping.Extensions.canRefund(order, Collections.emptyList());
+  }
+}

--- a/test/transform/resource/before/ExtensionMethodTargetTyping.java
+++ b/test/transform/resource/before/ExtensionMethodTargetTyping.java
@@ -1,0 +1,23 @@
+import java.util.Collections;
+import java.util.List;
+
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod(ExtensionMethodTargetTyping.Extensions.class)
+class ExtensionMethodTargetTyping {
+	boolean test(OrderDto order) {
+		return order.canRefund(Collections.emptyList());
+	}
+
+	static class Extensions {
+		public static boolean canRefund(OrderDto order, List<RefundOrderDto> refundOrders) {
+			return order != null && refundOrders != null;
+		}
+	}
+
+	static class OrderDto {
+	}
+
+	static class RefundOrderDto {
+	}
+}


### PR DESCRIPTION
## Summary

This change fixes Eclipse `@ExtensionMethod` resolution when an argument is a poly expression that already carries an overly broad resolved type.

In the failing case, a call like:

    order.canRefund(Collections.emptyList())

could be treated as passing `List<Object>` instead of `List<RefundOrderDto>`. That caused extension method resolution to fail before the call could be rewritten to the static extension method form.

## What Changed

- Prefer `PolyTypeBinding` for poly-expression arguments in the Eclipse extension-method resolution path, instead of only doing so when `resolvedType` is `null`.
- Add a regression test covering extension-method target typing with an empty generic list argument.
- Use `Collections.emptyList()` in the regression test so the case stays valid on the ECJ test path and isolates the actual inference issue.

## Why This Matters

Without this change, valid extension-method calls can be rejected in Eclipse/JDT because argument typing is finalized too early and loses the target type required by the extension method signature.

## Repro

Given an extension method like:

    public static boolean canRefund(OrderDto order, List<RefundOrderDto> refunds)

a call such as:

    order.canRefund(Collections.emptyList())

could fail in Eclipse/JDT with an error equivalent to:

    The method canRefund(OrderDto, List<RefundOrderDto>) is not applicable for the arguments (OrderDto, List<Object>)

## Validation

- `dist test.eclipse-202503`
- `test.compile`