### PR TITLE
Fix Eclipse classloader lookup after Equinox API removal

### DIFF
--- a/doc/changelog.markdown
+++ b/doc/changelog.markdown
@@ -3,6 +3,7 @@ Lombok Changelog
 
 ### v1.18.47 "Edgy Guinea Pig"
 * BUGFIX: `@SneakyThrows` usage on JDK26 no longer results in class files that require `lombok.jar` to be on the runtime classpath (which should not be neccessary). [#4040](https://github.com/projectlombok/lombok/issues/4022).
+* BUGFIX: `lombok.config` is no longer intermittently ignored in Eclipse and JDT LS after an Equinox class loader API change. [#4058](https://github.com/projectlombok/lombok/issues/4058).
 
 ### v1.18.46 (April 22nd, 2026)
 * PLATFORM: JDK26 support added [#4019](https://github.com/projectlombok/lombok/issues/4019).

--- a/doc/changelog.markdown
+++ b/doc/changelog.markdown
@@ -3,7 +3,6 @@ Lombok Changelog
 
 ### v1.18.47 "Edgy Guinea Pig"
 * BUGFIX: `@SneakyThrows` usage on JDK26 no longer results in class files that require `lombok.jar` to be on the runtime classpath (which should not be neccessary). [#4040](https://github.com/projectlombok/lombok/issues/4022).
-* BUGFIX: `lombok.config` is no longer intermittently ignored in Eclipse and JDT LS after an Equinox class loader API change. [#4058](https://github.com/projectlombok/lombok/issues/4058).
 
 ### v1.18.46 (April 22nd, 2026)
 * PLATFORM: JDK26 support added [#4019](https://github.com/projectlombok/lombok/issues/4019).

--- a/src/eclipseAgent/lombok/launch/PatchFixesHider.java
+++ b/src/eclipseAgent/lombok/launch/PatchFixesHider.java
@@ -196,14 +196,34 @@ final class PatchFixesHider {
 				
 				for (Object searchBundle : bundles) {
 					if (searchBundle.toString().startsWith("org.eclipse.jdt.core_")) {
-						Method getModuleClassLoaderMethod = Permit.getMethod(searchBundle.getClass(), "getModuleClassLoader", boolean.class);
-						return (ClassLoader) Permit.invoke(getModuleClassLoaderMethod, searchBundle, false);
+						return getBundleClassLoader(searchBundle);
 					}
 				}
 			} catch (Throwable t) {
 				// Ignore
 			}
 			return null;
+		}
+
+		private static ClassLoader getBundleClassLoader(Object bundle) {
+			try {
+				Class<?> bundleWiringClass = Class.forName("org.osgi.framework.wiring.BundleWiring", false, bundle.getClass().getClassLoader());
+				Method adaptMethod = Permit.getMethod(bundle.getClass(), "adapt", Class.class);
+				Object bundleWiring = Permit.invoke(adaptMethod, bundle, bundleWiringClass);
+				if (bundleWiring != null) {
+					Method getClassLoaderMethod = Permit.getMethod(bundleWiringClass, "getClassLoader");
+					return (ClassLoader) Permit.invoke(getClassLoaderMethod, bundleWiring);
+				}
+			} catch (Throwable t) {
+				// Fall back to the old Equinox API.
+			}
+
+			try {
+				Method getModuleClassLoaderMethod = Permit.getMethod(bundle.getClass(), "getModuleClassLoader", boolean.class);
+				return (ClassLoader) Permit.invoke(getModuleClassLoaderMethod, bundle, false);
+			} catch (Throwable t) {
+				return null;
+			}
 		}
 	}
 	

--- a/test/core/src/lombok/TestEclipse.java
+++ b/test/core/src/lombok/TestEclipse.java
@@ -26,6 +26,6 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({lombok.transform.TestWithEcj.class})
+@SuiteClasses({lombok.transform.TestWithEcj.class, lombok.launch.PatchFixesHiderTest.class})
 public class TestEclipse {
 }

--- a/test/core/src/lombok/launch/PatchFixesHiderTest.java
+++ b/test/core/src/lombok/launch/PatchFixesHiderTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2026 The Project Lombok Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package lombok.launch;
+
+import static org.junit.Assert.assertSame;
+
+import java.io.File;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.Test;
+
+public class PatchFixesHiderTest {
+	@Test
+	public void findsClassLoaderViaBundleWiring() throws Exception {
+		final ClassLoader expected = new ClassLoader() {};
+		Object bundle = new BundleWithWiring(expected);
+		assertSame(expected, findJdtCoreClassLoader(bundle));
+	}
+
+	@Test
+	public void fallsBackToLegacyEquinoxApi() throws Exception {
+		final ClassLoader expected = new ClassLoader() {};
+		Object bundle = new LegacyBundle(expected);
+		assertSame(expected, findJdtCoreClassLoader(bundle));
+	}
+
+	private static ClassLoader findJdtCoreClassLoader(Object jdtCoreBundle) throws Exception {
+		ClassLoader loader = new BundleClassLoader(new SourceBundle(new BundleContext(jdtCoreBundle)));
+		URL classes = new File("build/lombok-main/Class50").toURI().toURL();
+		Class<?> util = Class.forName("lombok.launch.PatchFixesHider$Util", true, new URLClassLoader(new URL[] {classes}, PatchFixesHiderTest.class.getClassLoader()));
+		Method method = util.getDeclaredMethod("findJdtCoreClassLoader", ClassLoader.class);
+		method.setAccessible(true);
+		return (ClassLoader) method.invoke(null, loader);
+	}
+
+	private static class BundleClassLoader extends ClassLoader {
+		private final Object bundle;
+
+		BundleClassLoader(Object bundle) {
+			this.bundle = bundle;
+		}
+
+		public Object getBundle() {
+			return bundle;
+		}
+	}
+
+	private static class SourceBundle {
+		private final Object context;
+
+		SourceBundle(Object context) {
+			this.context = context;
+		}
+
+		public Object getBundleContext() {
+			return context;
+		}
+	}
+
+	private static class BundleContext {
+		private final Object bundle;
+
+		BundleContext(Object bundle) {
+			this.bundle = bundle;
+		}
+
+		public Object[] getBundles() {
+			return new Object[] {bundle};
+		}
+	}
+
+	private static class BundleWithWiring {
+		private final ClassLoader classLoader;
+
+		BundleWithWiring(ClassLoader classLoader) {
+			this.classLoader = classLoader;
+		}
+
+		public Object adapt(final Class<?> type) {
+			return Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] {type}, new InvocationHandler() {
+				@Override public Object invoke(Object proxy, Method method, Object[] args) {
+					if ("getClassLoader".equals(method.getName())) return classLoader;
+					return null;
+				}
+			});
+		}
+
+		@Override public String toString() {
+			return "org.eclipse.jdt.core_1.0.0";
+		}
+	}
+
+	private static class LegacyBundle {
+		private final ClassLoader classLoader;
+
+		LegacyBundle(ClassLoader classLoader) {
+			this.classLoader = classLoader;
+		}
+
+		public ClassLoader getModuleClassLoader(boolean ignored) {
+			return classLoader;
+		}
+
+		@Override public String toString() {
+			return "org.eclipse.jdt.core_1.0.0";
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Restore Lombok's jdt.core classloader lookup after Equinox removed the private `EquinoxBundle.getModuleClassLoader(boolean)` method.

The existing cross-bundle repair added in #3347 and #3563 depends on that private method. Current Equinox throws `NoSuchMethodException`, causing `findJdtCoreClassLoader()` to return `null`. The later parser-based fallback is timing-dependent, so `EclipseAST` intermittently cannot load `org.eclipse.core.runtime.IPath` and silently ignores `lombok.config`.

## Change

Use the standard OSGi API:

```java
Bundle.adapt(BundleWiring.class).getClassLoader()
```

The lookup is performed reflectively to preserve Lombok's classloader boundary and avoid a direct OSGi dependency. The removed private Equinox method remains as a fallback for older runtimes.

Added focused tests covering:

- the standard `BundleWiring` lookup;
- the legacy Equinox fallback.

## Validation

- `ant compile`
- `ant dist`
- focused `PatchFixesHiderTest`: 2 tests passed
- rebuilt agent against current JDT LS: `lombok.config` applied in 5 of 5 clean workspaces

Fixes #4058.
