### PR TITLE
Fix SuperBuilder for non-ASCII superclass simple names

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ Amine Touzani <ttzn.dev@gmail.com>
 Andre Brait <andrebrait@gmail.com>
 Anshuman Mishra <a.mishra@uber.com>
 Bulgakov Alexander <buls@yandex.ru>
+Burak KALAYCI <kalayciburak1996@gmail.com>
 Caleb Brinkman <floralvikings@gmail.com>
 Christian Nüssgens <christian@nuessgens.com>
 Christian Schlichtherle <christian-schlichtherle@users.noreply.github.com>

--- a/src/core/lombok/javac/handlers/HandleSuperBuilder.java
+++ b/src/core/lombok/javac/handlers/HandleSuperBuilder.java
@@ -261,6 +261,13 @@ public class HandleSuperBuilder extends JavacAnnotationHandler<SuperBuilder> {
 			String builderClassNameTemplate = BuilderJob.getBuilderClassNameTemplate(annotationNode, null);
 			String superclassBuilderClassName = job.replaceBuilderClassName(superclassName.toString(), builderClassNameTemplate);
 			superclassBuilderClass = parent.getTreeMaker().Select(cloneType(maker, (JCFieldAccess) extendsClause, annotationNode), parent.toName(superclassBuilderClassName));
+		} else if (extendsClause instanceof JCIdent) {
+			// Use the identifier Name, not Tree.toString(): javac pretty-prints non-ASCII
+			// names as \\uXXXX escapes, which then become the builder type's simple name.
+			Name superclassName = ((JCIdent) extendsClause).getName();
+			String builderClassNameTemplate = BuilderJob.getBuilderClassNameTemplate(annotationNode, null);
+			String superclassBuilderClassName = job.replaceBuilderClassName(superclassName.toString(), builderClassNameTemplate);
+			superclassBuilderClass = chainDots(parent, superclassName.toString(), superclassBuilderClassName);
 		} else if (extendsClause != null) {
 			String builderClassNameTemplate = BuilderJob.getBuilderClassNameTemplate(annotationNode, null);
 			String superclassBuilderClassName = job.replaceBuilderClassName(extendsClause.toString(), builderClassNameTemplate);

--- a/test/transform/resource/after-delombok/SuperBuilderNonAscii.java
+++ b/test/transform/resource/after-delombok/SuperBuilderNonAscii.java
@@ -1,0 +1,130 @@
+public class SuperBuilderNonAscii {
+	public static class 부모 {
+		Long a;
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public static abstract class 부모Builder<C extends SuperBuilderNonAscii.부모, B extends SuperBuilderNonAscii.부모.부모Builder<C, B>> {
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			private Long a;
+			/**
+			 * @return {@code this}.
+			 */
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			public B a(final Long a) {
+				this.a = a;
+				return self();
+			}
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			protected abstract B self();
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			public abstract C build();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			public java.lang.String toString() {
+				return "SuperBuilderNonAscii.부모.부모Builder(a=" + this.a + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		private static final class 부모BuilderImpl extends SuperBuilderNonAscii.부모.부모Builder<SuperBuilderNonAscii.부모, SuperBuilderNonAscii.부모.부모BuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			private 부모BuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			protected SuperBuilderNonAscii.부모.부모BuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			public SuperBuilderNonAscii.부모 build() {
+				return new SuperBuilderNonAscii.부모(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		protected 부모(final SuperBuilderNonAscii.부모.부모Builder<?, ?> b) {
+			this.a = b.a;
+		}
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public static SuperBuilderNonAscii.부모.부모Builder<?, ?> builder() {
+			return new SuperBuilderNonAscii.부모.부모BuilderImpl();
+		}
+	}
+	public static class 자식 extends 부모 {
+		String b;
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public static abstract class 자식Builder<C extends SuperBuilderNonAscii.자식, B extends SuperBuilderNonAscii.자식.자식Builder<C, B>> extends 부모.부모Builder<C, B> {
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			private String b;
+			/**
+			 * @return {@code this}.
+			 */
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			public B b(final String b) {
+				this.b = b;
+				return self();
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			protected abstract B self();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			public abstract C build();
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			public java.lang.String toString() {
+				return "SuperBuilderNonAscii.자식.자식Builder(super=" + super.toString() + ", b=" + this.b + ")";
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		private static final class 자식BuilderImpl extends SuperBuilderNonAscii.자식.자식Builder<SuperBuilderNonAscii.자식, SuperBuilderNonAscii.자식.자식BuilderImpl> {
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			private 자식BuilderImpl() {
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			protected SuperBuilderNonAscii.자식.자식BuilderImpl self() {
+				return this;
+			}
+			@java.lang.Override
+			@java.lang.SuppressWarnings("all")
+			@lombok.Generated
+			public SuperBuilderNonAscii.자식 build() {
+				return new SuperBuilderNonAscii.자식(this);
+			}
+		}
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		protected 자식(final SuperBuilderNonAscii.자식.자식Builder<?, ?> b) {
+			super(b);
+			this.b = b.b;
+		}
+		@java.lang.SuppressWarnings("all")
+		@lombok.Generated
+		public static SuperBuilderNonAscii.자식.자식Builder<?, ?> builder() {
+			return new SuperBuilderNonAscii.자식.자식BuilderImpl();
+		}
+	}
+	public static void test() {
+		자식 x = 자식.builder().b("").a(5L).build();
+	}
+}

--- a/test/transform/resource/after-ecj/SuperBuilderNonAscii.java
+++ b/test/transform/resource/after-ecj/SuperBuilderNonAscii.java
@@ -1,0 +1,86 @@
+public class SuperBuilderNonAscii {
+  public static @lombok.SuperBuilder class 부모 {
+    public static abstract @java.lang.SuppressWarnings("all") @lombok.Generated class 부모Builder<C extends SuperBuilderNonAscii.부모, B extends SuperBuilderNonAscii.부모.부모Builder<C, B>> {
+      private @java.lang.SuppressWarnings("all") @lombok.Generated Long a;
+      public 부모Builder() {
+        super();
+      }
+      /**
+       * @return {@code this}.
+       */
+      public @java.lang.SuppressWarnings("all") @lombok.Generated B a(final Long a) {
+        this.a = a;
+        return self();
+      }
+      protected abstract @java.lang.SuppressWarnings("all") @lombok.Generated B self();
+      public abstract @java.lang.SuppressWarnings("all") @lombok.Generated C build();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+        return (("SuperBuilderNonAscii.부모.부모Builder(a=" + this.a) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated class 부모BuilderImpl extends SuperBuilderNonAscii.부모.부모Builder<SuperBuilderNonAscii.부모, SuperBuilderNonAscii.부모.부모BuilderImpl> {
+      private 부모BuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated SuperBuilderNonAscii.부모.부모BuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated SuperBuilderNonAscii.부모 build() {
+        return new SuperBuilderNonAscii.부모(this);
+      }
+    }
+    Long a;
+    protected @java.lang.SuppressWarnings("all") @lombok.Generated 부모(final SuperBuilderNonAscii.부모.부모Builder<?, ?> b) {
+      super();
+      this.a = b.a;
+    }
+    public static @java.lang.SuppressWarnings("all") @lombok.Generated SuperBuilderNonAscii.부모.부모Builder<?, ?> builder() {
+      return new SuperBuilderNonAscii.부모.부모BuilderImpl();
+    }
+  }
+  public static @lombok.SuperBuilder class 자식 extends 부모 {
+    public static abstract @java.lang.SuppressWarnings("all") @lombok.Generated class 자식Builder<C extends SuperBuilderNonAscii.자식, B extends SuperBuilderNonAscii.자식.자식Builder<C, B>> extends 부모.부모Builder<C, B> {
+      private @java.lang.SuppressWarnings("all") @lombok.Generated String b;
+      public 자식Builder() {
+        super();
+      }
+      /**
+       * @return {@code this}.
+       */
+      public @java.lang.SuppressWarnings("all") @lombok.Generated B b(final String b) {
+        this.b = b;
+        return self();
+      }
+      protected abstract @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated B self();
+      public abstract @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated C build();
+      public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+        return (((("SuperBuilderNonAscii.자식.자식Builder(super=" + super.toString()) + ", b=") + this.b) + ")");
+      }
+    }
+    private static final @java.lang.SuppressWarnings("all") @lombok.Generated class 자식BuilderImpl extends SuperBuilderNonAscii.자식.자식Builder<SuperBuilderNonAscii.자식, SuperBuilderNonAscii.자식.자식BuilderImpl> {
+      private 자식BuilderImpl() {
+        super();
+      }
+      protected @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated SuperBuilderNonAscii.자식.자식BuilderImpl self() {
+        return this;
+      }
+      public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated SuperBuilderNonAscii.자식 build() {
+        return new SuperBuilderNonAscii.자식(this);
+      }
+    }
+    String b;
+    protected @java.lang.SuppressWarnings("all") @lombok.Generated 자식(final SuperBuilderNonAscii.자식.자식Builder<?, ?> b) {
+      super(b);
+      this.b = b.b;
+    }
+    public static @java.lang.SuppressWarnings("all") @lombok.Generated SuperBuilderNonAscii.자식.자식Builder<?, ?> builder() {
+      return new SuperBuilderNonAscii.자식.자식BuilderImpl();
+    }
+  }
+  public SuperBuilderNonAscii() {
+    super();
+  }
+  public static void test() {
+    자식 x = 자식.builder().b("").a(5L).build();
+  }
+}

--- a/test/transform/resource/before/SuperBuilderNonAscii.java
+++ b/test/transform/resource/before/SuperBuilderNonAscii.java
@@ -1,0 +1,15 @@
+public class SuperBuilderNonAscii {
+	@lombok.SuperBuilder
+	public static class 부모 {
+		Long a;
+	}
+	
+	@lombok.SuperBuilder
+	public static class 자식 extends 부모 {
+		String b;
+	}
+	
+	public static void test() {
+		자식 x = 자식.builder().b("").a(5L).build();
+	}
+}


### PR DESCRIPTION
## Summary
- `@SuperBuilder` on a subclass whose superclass is referenced by a non-ASCII simple name (for example Hangul) failed during javac compilation.
- The javac handler built the superclass builder type from `extendsClause.toString()`. javac pretty-prints non-ASCII identifiers as unicode escapes, so the generated builder type used those escape characters as the name.
- The qualified-name path already used `JCFieldAccess.getIdentifier()`. The simple-name path now uses `JCIdent.getName()` the same way.

Fixes #4070

## Tests
- `ant test.javacCurrent` (JDK 17): `javac-SuperBuilderNonAscii.java` PASS
- same run: `javac-SuperBuilderAbstract.java` and `javac-SuperBuilderWithNonNull.java` PASS (ASCII simple-name / existing SuperBuilder regression)