### PR TITLE
Fix parameterized return type inference for @ExtensionMethod in Eclipse

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
@@ -319,6 +319,7 @@ public class PatchExtensionMethod {
 				}
 				
 				MethodBinding fixedBinding = scope.getMethod(extensionMethod.declaringClass, methodCall.selector, argumentTypes.toArray(new TypeBinding[0]), methodCall);
+				boolean polyExpression = false;
 				if (fixedBinding instanceof ProblemMethodBinding) {
 					methodCall.arguments = originalArgs;
 					// Sometimes the declaring class is null, in that case we have to create a new ProblemMethodBinding using the extension method's declaring class
@@ -327,11 +328,12 @@ public class PatchExtensionMethod {
 					}
 					PostponedInvalidMethodError.invoke(scope.problemReporter(), methodCall, fixedBinding, scope);
 				} else {
+					polyExpression = fixedBinding.returnType.isParameterizedType() && methodCall.isPolyExpression(fixedBinding);
 					// If the extension method uses varargs, the last fixed binding parameter is an array but 
 					// the method arguments are not. Even thought we already know that the method is fine we still
 					// have to compare each parameter with the type of the array to support autoboxing/unboxing.
 					boolean isVarargs = fixedBinding.isVarargs();
-					for (int i = 0, iend = arguments.size(); i < iend; i++) {
+					for (int i = 0, iend = polyExpression ? 0 : arguments.size(); i < iend; i++) {
 						Expression arg = arguments.get(i);
 						TypeBinding[] parameters = fixedBinding.parameters;
 						TypeBinding param;
@@ -353,6 +355,13 @@ public class PatchExtensionMethod {
 					
 					methodCall.receiver = createNameRef(extensionMethod.declaringClass, methodCall);
 					methodCall.actualReceiverType = extensionMethod.declaringClass;
+					if (Reflection.receiverIsType != null) {
+						try {
+							Permit.set(Reflection.receiverIsType, methodCall, true);
+						} catch (IllegalAccessException ignore) {
+							// ignore
+						}
+					}
 					methodCall.binding = fixedBinding;
 					methodCall.resolvedType = methodCall.binding.returnType;
 					methodCall.statementEnd = methodCall.sourceEnd;
@@ -363,6 +372,10 @@ public class PatchExtensionMethod {
 							// ignore
 						}
 					}
+				}
+				if (polyExpression) {
+					TypeBinding polyType = Reflection.getPolyTypeBinding(methodCall);
+					if (polyType != null) return polyType;
 				}
 				return methodCall.resolvedType;
 			}
@@ -419,6 +432,7 @@ public class PatchExtensionMethod {
 		public static final Field argumentTypes = Permit.permissiveGetField(MessageSend.class, "argumentTypes");
 		public static final Field argumentsHaveErrors = Permit.permissiveGetField(MessageSend.class, "argumentsHaveErrors");
 		public static final Field inferenceContexts = Permit.permissiveGetField(MessageSend.class, "inferenceContexts");
+		public static final Field receiverIsType = Permit.permissiveGetField(MessageSend.class, "receiverIsType");
 		private static final Method isPolyExpression = Permit.permissiveGetMethod(Expression.class, "isPolyExpression");
 		private static final Class<?> functionalExpression;
 		private static final Constructor<?> polyTypeBindingConstructor;

--- a/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchExtensionMethod.java
@@ -328,28 +328,30 @@ public class PatchExtensionMethod {
 					}
 					PostponedInvalidMethodError.invoke(scope.problemReporter(), methodCall, fixedBinding, scope);
 				} else {
-					polyExpression = fixedBinding.returnType.isParameterizedType() && methodCall.isPolyExpression(fixedBinding);
-					// If the extension method uses varargs, the last fixed binding parameter is an array but 
-					// the method arguments are not. Even thought we already know that the method is fine we still
-					// have to compare each parameter with the type of the array to support autoboxing/unboxing.
-					boolean isVarargs = fixedBinding.isVarargs();
-					for (int i = 0, iend = polyExpression ? 0 : arguments.size(); i < iend; i++) {
-						Expression arg = arguments.get(i);
-						TypeBinding[] parameters = fixedBinding.parameters;
-						TypeBinding param;
-						if (isVarargs && i >= parameters.length - 1) {
-							// Extract the array element type for all vararg arguments
-							param = parameters[parameters.length - 1].leafComponentType();
-						} else {
-							param = parameters[i];
-						}
-						// Resolve types for polys
-						if (requiresPolyBinding(arg)) {
-							arg.setExpectedType(param);
-							arg.resolveType(scope);
-						}
-						if (arg.resolvedType != null) {
-							arg.computeConversion(scope, param, arg.resolvedType);
+					polyExpression = fixedBinding.returnType.isParameterizedType() && Reflection.isPolyExpression(methodCall, fixedBinding);
+					if (!polyExpression) {
+						// If the extension method uses varargs, the last fixed binding parameter is an array but
+						// the method arguments are not. Even thought we already know that the method is fine we still
+						// have to compare each parameter with the type of the array to support autoboxing/unboxing.
+						boolean isVarargs = fixedBinding.isVarargs();
+						for (int i = 0, iend = arguments.size(); i < iend; i++) {
+							Expression arg = arguments.get(i);
+							TypeBinding[] parameters = fixedBinding.parameters;
+							TypeBinding param;
+							if (isVarargs && i >= parameters.length - 1) {
+								// Extract the array element type for all vararg arguments
+								param = parameters[parameters.length - 1].leafComponentType();
+							} else {
+								param = parameters[i];
+							}
+							// Resolve types for polys
+							if (requiresPolyBinding(arg)) {
+								arg.setExpectedType(param);
+								arg.resolveType(scope);
+							}
+							if (arg.resolvedType != null) {
+								arg.computeConversion(scope, param, arg.resolvedType);
+							}
 						}
 					}
 					
@@ -434,6 +436,7 @@ public class PatchExtensionMethod {
 		public static final Field inferenceContexts = Permit.permissiveGetField(MessageSend.class, "inferenceContexts");
 		public static final Field receiverIsType = Permit.permissiveGetField(MessageSend.class, "receiverIsType");
 		private static final Method isPolyExpression = Permit.permissiveGetMethod(Expression.class, "isPolyExpression");
+		private static final Method isPolyExpressionWithBinding = Permit.permissiveGetMethod(MessageSend.class, "isPolyExpression", MethodBinding.class);
 		private static final Class<?> functionalExpression;
 		private static final Constructor<?> polyTypeBindingConstructor;
 		
@@ -469,6 +472,16 @@ public class PatchExtensionMethod {
 			return false;
 		}
 		
+		public static boolean isPolyExpression(MessageSend methodCall, MethodBinding binding) {
+			if (isPolyExpressionWithBinding == null) return false;
+			try {
+				return (Boolean) isPolyExpressionWithBinding.invoke(methodCall, binding);
+			} catch (Exception e) {
+				// Ignore
+			}
+			return false;
+		}
+
 		public static TypeBinding getPolyTypeBinding(Expression expression) {
 			if (polyTypeBindingConstructor == null) return null;
 			try {

--- a/test/transform/resource/after-delombok/ExtensionMethodParameterizedReturn.java
+++ b/test/transform/resource/after-delombok/ExtensionMethodParameterizedReturn.java
@@ -1,0 +1,19 @@
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+class ExtensionMethodParameterizedReturn {
+	void test() {
+		List<String> values = null;
+		process(ExtensionMethodParameterizedReturn.Extensions.mapAllToList(values, s -> s + ";"));
+	}
+
+	void process(List<String> values) {
+	}
+
+	static class Extensions {
+		public static <V, R> List<R> mapAllToList(Collection<? extends V> values, Function<V, R> mapper) {
+			return null;
+		}
+	}
+}

--- a/test/transform/resource/after-ecj/ExtensionMethodParameterizedReturn.java
+++ b/test/transform/resource/after-ecj/ExtensionMethodParameterizedReturn.java
@@ -1,0 +1,23 @@
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import lombok.experimental.ExtensionMethod;
+@ExtensionMethod(ExtensionMethodParameterizedReturn.Extensions.class) class ExtensionMethodParameterizedReturn {
+  static class Extensions {
+    Extensions() {
+      super();
+    }
+    public static <V, R>List<R> mapAllToList(Collection<? extends V> values, Function<V, R> mapper) {
+      return null;
+    }
+  }
+  ExtensionMethodParameterizedReturn() {
+    super();
+  }
+  void test() {
+    List<String> values = null;
+    process(ExtensionMethodParameterizedReturn.Extensions.mapAllToList(values, (<no type> s) -> (s + ";")));
+  }
+  void process(List<String> values) {
+  }
+}

--- a/test/transform/resource/before/ExtensionMethodParameterizedReturn.java
+++ b/test/transform/resource/before/ExtensionMethodParameterizedReturn.java
@@ -1,0 +1,23 @@
+// version 8:
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod(ExtensionMethodParameterizedReturn.Extensions.class)
+class ExtensionMethodParameterizedReturn {
+	void test() {
+		List<String> values = null;
+		process(values.mapAllToList(s -> s + ";"));
+	}
+
+	void process(List<String> values) {
+	}
+
+	static class Extensions {
+		public static <V, R> List<R> mapAllToList(Collection<? extends V> values, Function<V, R> mapper) {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #4060

### What changed

Fix parameterized return type inference for `@ExtensionMethod` calls in Eclipse.

When an extension method has a parameterized generic return type, such as `List<R>`, ECJ may resolve the provisional return type as `List<Object>` before the surrounding target type can participate in type inference.

This change preserves the invocation as a poly expression so ECJ can continue inference using the outer target type.

A regression test based on the reproduction from #4060 is included.

### Testing

- `ant test.eclipse-202503`
- `ant test`
- `ant dist`

All passed.

The relevant `@ExtensionMethod` tests also pass against the latest Eclipse integration build. The full integration-build test suite still reports unrelated existing expected-output differences.