### PR TITLE
[jdt]: check `decl.methods` for `null` in `PatchDelegate`

### DIFF
--- a/src/eclipseAgent/lombok/eclipse/agent/PatchDelegate.java
+++ b/src/eclipseAgent/lombok/eclipse/agent/PatchDelegate.java
@@ -983,7 +983,7 @@ public class PatchDelegate {
 	
 	private static Set<String> findAlreadyImplementedMethods(TypeDeclaration decl) {
 		Set<String> sigs = new HashSet<String>();
-		for (AbstractMethodDeclaration md : decl.methods) {
+		if (decl.methods != null) for (AbstractMethodDeclaration md : decl.methods) {
 			if (md.isStatic()) continue;
 			if ((md.modifiers & ClassFileConstants.AccBridge) != 0) continue;
 			if (md.isConstructor()) continue;


### PR DESCRIPTION
Fixes #4076.

### What changed

Looks like a null check is missing here. Other calls to this field in the file have one.

### Testing
- `ant test`
- `ant dist`

All passed.