### PR TITLE
Fix required-args detection for type-use @NonNull on qualified types

### DIFF
--- a/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
+++ b/src/core/lombok/eclipse/handlers/EclipseHandlerUtil.java
@@ -777,6 +777,11 @@ public class EclipseHandlerUtil {
 			Annotation annotation = (Annotation) child.get();
 			for (String bn : NONNULL_ANNOTATIONS) if (typeMatches(bn, node, annotation.type)) return true;
 		}
+		if (node.get() instanceof AbstractVariableDeclaration) {
+			AbstractVariableDeclaration variable = (AbstractVariableDeclaration) node.get();
+			Annotation[] typeUseAnns = getTypeUseAnnotations(variable.type);
+			if (typeUseAnns != null && hasNonNullAnnotations(node, Arrays.asList(typeUseAnns))) return true;
+		}
 		return false;
 	}
 	

--- a/src/core/lombok/javac/handlers/JavacHandlerUtil.java
+++ b/src/core/lombok/javac/handlers/JavacHandlerUtil.java
@@ -1725,6 +1725,11 @@ public class JavacHandlerUtil {
 			}
 		}
 		
+		if (node.get() instanceof JCVariableDecl) {
+			JCVariableDecl variableDecl = (JCVariableDecl) node.get();
+			if (hasNonNullAnnotations(node, getTypeUseAnnotations(variableDecl.vartype))) return true;
+		}
+		
 		return false;
 	}
 	

--- a/test/stubs/org/jspecify/annotations/NonNull.java
+++ b/test/stubs/org/jspecify/annotations/NonNull.java
@@ -1,0 +1,12 @@
+package org.jspecify.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Documented
+public @interface NonNull {}

--- a/test/transform/resource/after-delombok/DataWithJspecifyTypeUseNonNull.java
+++ b/test/transform/resource/after-delombok/DataWithJspecifyTypeUseNonNull.java
@@ -1,0 +1,95 @@
+//version 8:
+import org.jspecify.annotations.NonNull;
+
+class DataWithJspecifyTypeUseNonNull {
+	@NonNull
+	private String prop1;
+	private java.lang.@NonNull String prop2;
+
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public DataWithJspecifyTypeUseNonNull(@NonNull final String prop1, final java.lang.@NonNull String prop2) {
+		if (prop1 == null) {
+			throw new java.lang.NullPointerException("prop1 is marked non-null but is null");
+		}
+		if (prop2 == null) {
+			throw new java.lang.NullPointerException("prop2 is marked non-null but is null");
+		}
+		this.prop1 = prop1;
+		this.prop2 = prop2;
+	}
+
+	@NonNull
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public String getProp1() {
+		return this.prop1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public java.lang.@NonNull String getProp2() {
+		return this.prop2;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public void setProp1(@NonNull final String prop1) {
+		if (prop1 == null) {
+			throw new java.lang.NullPointerException("prop1 is marked non-null but is null");
+		}
+		this.prop1 = prop1;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public void setProp2(final java.lang.@NonNull String prop2) {
+		if (prop2 == null) {
+			throw new java.lang.NullPointerException("prop2 is marked non-null but is null");
+		}
+		this.prop2 = prop2;
+	}
+
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public boolean equals(final java.lang.Object o) {
+		if (o == this) return true;
+		if (!(o instanceof DataWithJspecifyTypeUseNonNull)) return false;
+		final DataWithJspecifyTypeUseNonNull other = (DataWithJspecifyTypeUseNonNull) o;
+		if (!other.canEqual((java.lang.Object) this)) return false;
+		final java.lang.Object this$prop1 = this.getProp1();
+		final java.lang.Object other$prop1 = other.getProp1();
+		if (this$prop1 == null ? other$prop1 != null : !this$prop1.equals(other$prop1)) return false;
+		final java.lang.Object this$prop2 = this.getProp2();
+		final java.lang.Object other$prop2 = other.getProp2();
+		if (this$prop2 == null ? other$prop2 != null : !this$prop2.equals(other$prop2)) return false;
+		return true;
+	}
+
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	protected boolean canEqual(final java.lang.Object other) {
+		return other instanceof DataWithJspecifyTypeUseNonNull;
+	}
+
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public int hashCode() {
+		final int PRIME = 59;
+		int result = 1;
+		final java.lang.Object $prop1 = this.getProp1();
+		result = result * PRIME + ($prop1 == null ? 43 : $prop1.hashCode());
+		final java.lang.Object $prop2 = this.getProp2();
+		result = result * PRIME + ($prop2 == null ? 43 : $prop2.hashCode());
+		return result;
+	}
+
+	@java.lang.Override
+	@java.lang.SuppressWarnings("all")
+	@lombok.Generated
+	public java.lang.String toString() {
+		return "DataWithJspecifyTypeUseNonNull(prop1=" + this.getProp1() + ", prop2=" + this.getProp2() + ")";
+	}
+}

--- a/test/transform/resource/after-ecj/DataWithJspecifyTypeUseNonNull.java
+++ b/test/transform/resource/after-ecj/DataWithJspecifyTypeUseNonNull.java
@@ -1,0 +1,72 @@
+import lombok.Data;
+import org.jspecify.annotations.NonNull;
+@Data class DataWithJspecifyTypeUseNonNull {
+  private @NonNull String prop1;
+  private java.lang.@NonNull String prop2;
+  public @java.lang.SuppressWarnings("all") @lombok.Generated @NonNull String getProp1() {
+    return this.prop1;
+  }
+  public @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.@NonNull String getProp2() {
+    return this.prop2;
+  }
+  public @java.lang.SuppressWarnings("all") @lombok.Generated void setProp1(final @NonNull String prop1) {
+    if ((prop1 == null))
+        {
+          throw new java.lang.NullPointerException("prop1 is marked non-null but is null");
+        }
+    this.prop1 = prop1;
+  }
+  public @java.lang.SuppressWarnings("all") @lombok.Generated void setProp2(final java.lang.@NonNull String prop2) {
+    if ((prop2 == null))
+        {
+          throw new java.lang.NullPointerException("prop2 is marked non-null but is null");
+        }
+    this.prop2 = prop2;
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated boolean equals(final java.lang.Object o) {
+    if ((o == this))
+        return true;
+    if ((! (o instanceof DataWithJspecifyTypeUseNonNull)))
+        return false;
+    final DataWithJspecifyTypeUseNonNull other = (DataWithJspecifyTypeUseNonNull) o;
+    if ((! other.canEqual((java.lang.Object) this)))
+        return false;
+    final java.lang.Object this$prop1 = this.getProp1();
+    final java.lang.Object other$prop1 = other.getProp1();
+    if (((this$prop1 == null) ? (other$prop1 != null) : (! this$prop1.equals(other$prop1))))
+        return false;
+    final java.lang.Object this$prop2 = this.getProp2();
+    final java.lang.Object other$prop2 = other.getProp2();
+    if (((this$prop2 == null) ? (other$prop2 != null) : (! this$prop2.equals(other$prop2))))
+        return false;
+    return true;
+  }
+  protected @java.lang.SuppressWarnings("all") @lombok.Generated boolean canEqual(final java.lang.Object other) {
+    return (other instanceof DataWithJspecifyTypeUseNonNull);
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated int hashCode() {
+    final int PRIME = 59;
+    int result = 1;
+    final java.lang.Object $prop1 = this.getProp1();
+    result = ((result * PRIME) + (($prop1 == null) ? 43 : $prop1.hashCode()));
+    final java.lang.Object $prop2 = this.getProp2();
+    result = ((result * PRIME) + (($prop2 == null) ? 43 : $prop2.hashCode()));
+    return result;
+  }
+  public @java.lang.Override @java.lang.SuppressWarnings("all") @lombok.Generated java.lang.String toString() {
+    return (((("DataWithJspecifyTypeUseNonNull(prop1=" + this.getProp1()) + ", prop2=") + this.getProp2()) + ")");
+  }
+  public @java.lang.SuppressWarnings("all") @lombok.Generated DataWithJspecifyTypeUseNonNull(final @NonNull String prop1, final java.lang.@NonNull String prop2) {
+    super();
+    if ((prop1 == null))
+        {
+          throw new java.lang.NullPointerException("prop1 is marked non-null but is null");
+        }
+    if ((prop2 == null))
+        {
+          throw new java.lang.NullPointerException("prop2 is marked non-null but is null");
+        }
+    this.prop1 = prop1;
+    this.prop2 = prop2;
+  }
+}

--- a/test/transform/resource/before/DataWithJspecifyTypeUseNonNull.java
+++ b/test/transform/resource/before/DataWithJspecifyTypeUseNonNull.java
@@ -1,0 +1,9 @@
+//version 8:
+import lombok.Data;
+import org.jspecify.annotations.NonNull;
+
+@Data
+class DataWithJspecifyTypeUseNonNull {
+	private @NonNull String prop1;
+	private java.lang.@NonNull String prop2;
+}


### PR DESCRIPTION
We noticed, that lombok behaves differently, when declaing a field with full qualified class and jspecify @NonNull annotation:

```java
import lombok.Data;
import org.jspecify.annotations.NonNull;

@Data
class DataWithJspecifyTypeUseNonNull {
	private @NonNull String prop1; // works
        
	@NonNull
	private String prop2; // works, too

	// @NonNull
	// private java.lang.String prop3; // would not compile: Annotation is not applicable to this kind of reference
        
	// must be written as
	private java.lang.@NonNull String prop2; // compiles, but not recognized as NonNull by lombok
}
```

Add regression coverage for `@Data` classes using JSpecify `@NonNull` in type-use
position on qualified types (e.g. `java.lang.@NonNull String`).

Before this change, fields annotated via type-use on qualified types were not
always recognized as required fields for constructor generation.

Update non-null detection in both javac and eclipse handler utils to also inspect
type-use annotations on variable types, so required-args constructor generation
correctly includes these fields and emits null checks.

Also add a jspecify NonNull test stub and transform test fixtures.

Note: This PR is AI assisted, but the change makes sense to me.
