### PR TITLE
[#2983] Warn when @NonNull is applied to a type

### DIFF
--- a/doc/changelog.markdown
+++ b/doc/changelog.markdown
@@ -3,6 +3,7 @@ Lombok Changelog
 
 ### v1.18.49 "Edgy Guinea Pig"
 * BUGFIX: `@SuperBuilder` now works properly when your class names contain non-ASCII characters. [#3857](https://github.com/projectlombok/lombok/issues/4070)
+* BUGFIX: `@NonNull` on a type declaration now produces a warning; it has no effect. [#2983](https://github.com/projectlombok/lombok/issues/2983)
 
 ### v1.18.48 (September 1st, 2026)
 * BREAKING CHANGE/BUGFIX: `@Builder(builderClassName = "Builder")` now generates an error, because the type names collide. [#3857](https://github.com/projectlombok/lombok/issues/3857)  (found after release)

--- a/src/core/lombok/eclipse/handlers/HandleNonNull.java
+++ b/src/core/lombok/eclipse/handlers/HandleNonNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2025 The Project Lombok Authors.
+ * Copyright (C) 2013-2026 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -262,6 +262,12 @@ public class HandleNonNull extends EclipseAnnotationHandler<NonNull> {
 	
 	private void handle0(Annotation ast, EclipseNode annotationNode, boolean force) {
 		handleFlagUsage(annotationNode, ConfigurationKeys.NON_NULL_FLAG_USAGE, "@NonNull");
+		
+		if (annotationNode.up().getKind() == Kind.TYPE) {
+			// @NonNull on a class/interface/enum/record declaration is legal via TYPE_USE, but lombok does nothing with it.
+			annotationNode.addWarning("@NonNull is meaningless on a type.");
+			return;
+		}
 		
 		final EclipseNode node;
 		if (annotationNode.up().getKind() == Kind.TYPE_USE) {

--- a/src/core/lombok/javac/handlers/HandleNonNull.java
+++ b/src/core/lombok/javac/handlers/HandleNonNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2025 The Project Lombok Authors.
+ * Copyright (C) 2013-2026 The Project Lombok Authors.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -217,6 +217,12 @@ public class HandleNonNull extends JavacAnnotationHandler<NonNull> {
 	
 	@Override public void handle(AnnotationValues<NonNull> annotation, JCAnnotation ast, JavacNode annotationNode) {
 		handleFlagUsage(annotationNode, ConfigurationKeys.NON_NULL_FLAG_USAGE, "@NonNull");
+		
+		if (annotationNode.up().getKind() == Kind.TYPE) {
+			// @NonNull on a class/interface/enum/record declaration is legal via TYPE_USE, but lombok does nothing with it.
+			annotationNode.addWarning("@NonNull is meaningless on a type.");
+			return;
+		}
 		
 		final JavacNode node;
 		if (annotationNode.up().getKind() == Kind.TYPE_USE) {

--- a/test/transform/resource/before/NonNullOnType.java
+++ b/test/transform/resource/before/NonNullOnType.java
@@ -1,0 +1,14 @@
+//version 8:
+// skip-compare-content
+@lombok.NonNull
+class NonNullOnType {
+}
+
+@lombok.NonNull
+interface NonNullOnInterface {
+}
+
+@lombok.NonNull
+enum NonNullOnEnum {
+	A;
+}

--- a/test/transform/resource/messages-delombok/NonNullOnType.java.messages
+++ b/test/transform/resource/messages-delombok/NonNullOnType.java.messages
@@ -1,0 +1,3 @@
+3 @NonNull is meaningless on a type.
+7 @NonNull is meaningless on a type.
+11 @NonNull is meaningless on a type.

--- a/test/transform/resource/messages-ecj/NonNullOnType.java.messages
+++ b/test/transform/resource/messages-ecj/NonNullOnType.java.messages
@@ -1,0 +1,3 @@
+3 @NonNull is meaningless on a type.
+7 @NonNull is meaningless on a type.
+11 @NonNull is meaningless on a type.


### PR DESCRIPTION
Fixes #2983

`@NonNull` is legal on type declarations because of `TYPE_USE`, but lombok does not treat that as a defaulting hint. Warn in both javac and eclipse handlers, matching the existing `@NonNull is meaningless on a primitive.` diagnostic.

TYPE_USE on fields, parameters, and other type uses is unchanged.

### Test plan
- `ant test.javacCurrent` (JVM 17): 862 pass, 0 fail, including `javac-NonNullOnType.java` and existing NonNull fixtures
- `ant dist test.eclipse-oxygen`: `ecj-NonNullOnType.java` pass